### PR TITLE
Add tasks to create/remove dev access rules

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_api_env.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api_env.json
@@ -53,10 +53,10 @@
       }
     },
 
-    "DBEC2SecurityGroup": {
+    "RDSInstanceSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Open database for access",
+        "GroupDescription": "Digital Marketplace API RDS Instance security group",
         "SecurityGroupIngress": [{
           "IpProtocol": "tcp",
           "FromPort": "5432",
@@ -75,7 +75,7 @@
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "VPCSecurityGroups": [{"Fn::GetAtt": ["DBEC2SecurityGroup", "GroupId"]}]
+        "VPCSecurityGroups": [{"Fn::GetAtt": ["RDSInstanceSecurityGroup", "GroupId"]}]
       }
     },
 
@@ -134,6 +134,13 @@
         "TemplateName": {"Ref": "DigitalMarketplaceAPIConfigurationTemplate"},
         "Description": "Digital Marketplace API Environment"
       }
+    }
+  },
+
+  "Outputs": {
+    "RDSSecurityGroup": {
+      "Description": "RDS security group",
+      "Value": {"Ref": "RDSInstanceSecurityGroup"}
     }
   }
 }

--- a/cloudformation_templates/aws_digitalmarketplace_api_rds_dev_access.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api_rds_dev_access.json
@@ -1,0 +1,28 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Developer ingress security group rules",
+
+  "Parameters": {
+    "RDSSecurityGroup": {
+      "Type": "String",
+      "Description": "RDS security group name"
+    },
+    "CidrIp": {
+      "Type": "String",
+      "Description": "CIDR or IP to use for security group rules"
+    }
+  },
+
+  "Resources": {
+    "RDSDeveloperIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupName": {"Ref": "RDSSecurityGroup"},
+        "IpProtocol": "tcp",
+        "FromPort": "5432",
+        "ToPort": "5432",
+        "CidrIp": {"Ref": "CidrIp"}
+      }
+    }
+  }
+}

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -11,6 +11,10 @@
       "Type": "String",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
     },
+    "SSHCidrIp": {
+      "Type": "String",
+      "Description": "CIDR or IP to use for SSH access security group rules"
+    },
     "InstanceImage" : {
       "Description" : "EC2 instance image",
       "Type" : "String"
@@ -29,21 +33,7 @@
     "ElasticsearchSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Elasticsearch cluster",
-        "SecurityGroupIngress": [
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
-            "CidrIp": "80.194.77.0/24"
-          },
-          {
-            "IpProtocol": "tcp",
-            "FromPort": "9200",
-            "ToPort": "9200",
-            "CidrIp": "80.194.77.0/24"
-          }
-        ]
+        "GroupDescription": "Elasticsearch cluster"
       }
     },
     "ElasticsearchClusterDiscoveryIngress": {
@@ -55,6 +45,16 @@
           "ToPort": "65535",
           "SourceSecurityGroupName": { "Ref": "ElasticsearchSecurityGroup" }
         }
+    },
+    "ElasticsearchSSHIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupName": {"Ref": "ElasticsearchSecurityGroup"},
+        "IpProtocol": "tcp",
+        "FromPort": "22",
+        "ToPort": "22",
+        "CidrIp": {"Ref": "SSHCidrIp"}
+      }
     },
     "ElasticsearchIAMRole": {
       "Type": "AWS::IAM::Role",
@@ -127,9 +127,9 @@
   },
 
   "Outputs": {
-    "ElasticsearchInstances": {
-      "Description": "Elasticsearch instances",
-      "Value": {"Ref": "ElasticsearchAutoScalingGroup"}
+    "ElasticsearchSecurityGroup": {
+      "Description": "Elasticsearch security group",
+      "Value": {"Ref": "ElasticsearchSecurityGroup"}
     }
   }
 }

--- a/cloudformation_templates/aws_elasticsearch_dev_access.json
+++ b/cloudformation_templates/aws_elasticsearch_dev_access.json
@@ -1,0 +1,28 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Developer ingress security group rules",
+
+  "Parameters": {
+    "ElasticsearchSecurityGroup": {
+      "Type": "String",
+      "Description": "Elasticsearch security group name"
+    },
+    "CidrIp": {
+      "Type": "String",
+      "Description": "CIDR or IP to use for security group rules"
+    }
+  },
+
+  "Resources": {
+    "ElasticsearchDeveloperIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupName": {"Ref": "ElasticsearchSecurityGroup"},
+        "IpProtocol": "tcp",
+        "FromPort": "9200",
+        "ToPort": "9200",
+        "CidrIp": {"Ref": "CidrIp"}
+      }
+    }
+  }
+}

--- a/playbooks/roles/aws_digitalmarketplace_api/tasks/main.yml
+++ b/playbooks/roles/aws_digitalmarketplace_api/tasks/main.yml
@@ -33,3 +33,18 @@
   register: digitalmarketplace_api_env_stack
   tags:
     - digitalmarketplace-api
+
+- name: RDS dev access security group rules ({{dev_access_state}})
+  cloudformation:
+    stack_name: "digitalmarketplace-api-{{ name_suffix }}-dev-access"
+    state: "{{ dev_access_state }}"
+    region: "{{ aws_region }}"
+    disable_rollback: false
+    template: ../cloudformation_templates/aws_digitalmarketplace_api_rds_dev_access.json
+    template_parameters:
+      CidrIp: "{{ user_ip }}"
+      RDSSecurityGroup: "{{ digitalmarketplace_api_env_stack.stack_outputs.RDSSecurityGroup }}"
+  register: digitalmarketplace_api_rds_dev_access_stack
+  tags:
+    - digitalmarketplace-api
+    - dev-access

--- a/playbooks/roles/aws_elasticsearch/tasks/main.yml
+++ b/playbooks/roles/aws_elasticsearch/tasks/main.yml
@@ -8,6 +8,7 @@
     template: ../cloudformation_templates/aws_elasticsearch.json
     template_parameters:
       KeyName: "{{ key_name }}"
+      SSHCidrIp: "{{ user_ip }}"
       GroupTag: "{{ elasticsearch_name }}"
       InstanceCount: "{{ elasticsearch_ec2_instance_count }}"
       InstanceType: "{{ elasticsearch_ec2_instance_type }}"
@@ -15,3 +16,18 @@
   register: elasticsearch_stack
   tags:
     - elasticsearch
+
+- name: Elasticsearch dev access security group rules ({{ dev_access_state }})
+  cloudformation:
+    stack_name: "{{ elasticsearch_name }}-dev-access"
+    state: "{{ dev_access_state }}"
+    region: "{{ aws_region }}"
+    disable_rollback: false
+    template: ../cloudformation_templates/aws_elasticsearch_dev_access.json
+    template_parameters:
+      CidrIp: "{{ user_ip }}"
+      ElasticsearchSecurityGroup: "{{ elasticsearch_stack.stack_outputs.ElasticsearchSecurityGroup }}"
+  register: elasticsearch_dev_access_stack
+  tags:
+    - elasticsearch
+    - dev-access

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -11,6 +11,8 @@
   roles:
     - role: aws_elasticsearch
       state: present
+      dev_access_state: "{{ dev_access_state }}"
 
     - role: aws_digitalmarketplace_api
       state: present
+      dev_access_state: "{{ dev_access_state }}"

--- a/playbooks/teardown.yml
+++ b/playbooks/teardown.yml
@@ -10,5 +10,8 @@
   roles:
     - role: aws_elasticsearch
       state: absent
+      dev_access_state: absent
+
     - role: aws_digitalmarketplace_api
       state: absent
+      dev_access_state: absent

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -81,9 +81,16 @@ def main(ctx, stage, environment, tag,
 
 @main.command()
 @click.pass_context
-def setup(ctx):
+@click.option('--enable-dev/--disable-dev', default=False)
+def setup(ctx, enable_dev):
     """Create AWS environment and launch instances"""
-    run_playbook('setup', 'hosts', **ctx.obj)
+    kwargs = ctx.obj.copy()
+    kwargs['variables'] = ctx.obj['variables'].copy()
+    kwargs['variables'].update({
+        'dev_access_state': 'present' if enable_dev else 'absent',
+    })
+
+    run_playbook('setup', 'hosts', **kwargs)
 
 
 @main.command()


### PR DESCRIPTION
Creates AWS security group rules to enable remote access to Elasticsearch and RDS database from given IPs

I haven't moved SSH access out of the Elasticsearch CloudFormation template since it's required for provisioning (and so needs to be in the same state as elasticsearch tasks). 

SSH access for all Elastic Beanstalk instances is always enabled by Amazon.