### PR TITLE
Remove app name prefixes from CloudFormation resource names

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_api_app.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api_app.json
@@ -10,7 +10,7 @@
   },
 
   "Resources": {
-    "DigitalMarketplaceAPIApplication": {
+    "EBApplication": {
       "Type": "AWS::ElasticBeanstalk::Application",
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},

--- a/cloudformation_templates/aws_digitalmarketplace_api_env.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api_env.json
@@ -66,7 +66,7 @@
       }
     },
 
-    "DigitalMarketplaceAPIDB": {
+    "DB": {
       "Type": "AWS::RDS::DBInstance",
       "Properties": {
         "Engine": "postgres",
@@ -79,7 +79,7 @@
       }
     },
 
-    "DigitalMarketplaceAPIIAMRole": {
+    "IAMRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -111,17 +111,17 @@
         }]
       }
     },
-    "DigitalMarketplaceAPIInstanceProfile": {
+    "InstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
         "Path": "/",
         "Roles": [{
-          "Ref": "DigitalMarketplaceAPIIAMRole"
+          "Ref": "IAMRole"
         }]
       }
     },
 
-    "DigitalMarketplaceAPIConfigurationTemplate": {
+    "ConfigurationTemplate": {
       "Type": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
@@ -140,9 +140,9 @@
                   ":",
                   {"Ref": "DBPassword"},
                   "@",
-                  {"Fn::GetAtt": ["DigitalMarketplaceAPIDB", "Endpoint.Address"]},
+                  {"Fn::GetAtt": ["DB", "Endpoint.Address"]},
                   ":",
-                  {"Fn::GetAtt": ["DigitalMarketplaceAPIDB", "Endpoint.Port"]},
+                  {"Fn::GetAtt": ["DB", "Endpoint.Port"]},
                   "/",
                   {"Ref": "DBName"}
                 ]
@@ -162,7 +162,7 @@
           {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "IamInstanceProfile",
-            "Value": {"Ref": "DigitalMarketplaceAPIInstanceProfile"}
+            "Value": {"Ref": "InstanceProfile"}
           },
           {
             "Namespace": "aws:autoscaling:launchconfiguration",
@@ -173,12 +173,12 @@
       }
     },
 
-    "DigitalMarketplaceAPIEnvironment": {
+    "Environment": {
       "Type": "AWS::ElasticBeanstalk::Environment",
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
         "EnvironmentName": {"Ref": "EnvironmentName"},
-        "TemplateName": {"Ref": "DigitalMarketplaceAPIConfigurationTemplate"},
+        "TemplateName": {"Ref": "ConfigurationTemplate"},
         "Description": "Digital Marketplace API Environment"
       }
     }

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -30,33 +30,33 @@
   },
 
   "Resources": {
-    "ElasticsearchSecurityGroup": {
+    "InstanceSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Elasticsearch cluster"
+        "GroupDescription": "Main instance security group"
       }
     },
-    "ElasticsearchClusterDiscoveryIngress": {
+    "ClusterDiscoveryIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
         "Properties": {
-          "GroupName": { "Ref": "ElasticsearchSecurityGroup" },
+          "GroupName": {"Ref": "InstanceSecurityGroup"},
           "IpProtocol": "-1",
           "FromPort": "0",
           "ToPort": "65535",
-          "SourceSecurityGroupName": { "Ref": "ElasticsearchSecurityGroup" }
+          "SourceSecurityGroupName": {"Ref": "InstanceSecurityGroup"}
         }
     },
-    "ElasticsearchSSHIngress": {
+    "SSHIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
-        "GroupName": {"Ref": "ElasticsearchSecurityGroup"},
+        "GroupName": {"Ref": "InstanceSecurityGroup"},
         "IpProtocol": "tcp",
         "FromPort": "22",
         "ToPort": "22",
         "CidrIp": {"Ref": "SSHCidrIp"}
       }
     },
-    "ElasticsearchIAMRole": {
+    "IAMRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -71,7 +71,7 @@
         },
         "Path": "/",
         "Policies": [{
-          "PolicyName": "Elasticsearch-ec2-describe",
+          "PolicyName": "elasticsearch-ec2-describe",
           "PolicyDocument": {
             "Version" : "2012-10-17",
             "Statement": [{
@@ -83,16 +83,14 @@
         }]
       }
     },
-    "ElasticsearchInstanceProfile": {
+    "InstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
         "Path": "/",
-        "Roles": [{
-          "Ref": "ElasticsearchIAMRole"
-        }]
+        "Roles": [{"Ref": "IAMRole"}]
       }
     },
-    "ElasticsearchAutoScalingGroup" : {
+    "AutoScalingGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
         "Tags" : [
@@ -108,28 +106,28 @@
           }
         ],
         "AvailabilityZones" : {"Fn::GetAZs": ""},
-        "LaunchConfigurationName" : {"Ref": "ElasticsearchInstancesLC"},
+        "LaunchConfigurationName" : {"Ref": "LaunchConfiguration"},
         "MinSize" : {"Ref": "InstanceCount"},
         "MaxSize" : {"Ref": "InstanceCount"},
         "DesiredCapacity" : {"Ref": "InstanceCount"}
       }
     },
-    "ElasticsearchInstancesLC": {
+    "LaunchConfiguration": {
       "Type": "AWS::AutoScaling::LaunchConfiguration",
       "Properties": {
-        "SecurityGroups": [{ "Ref": "ElasticsearchSecurityGroup" }],
+        "SecurityGroups": [{"Ref": "InstanceSecurityGroup"}],
         "ImageId": {"Ref": "InstanceImage"},
-        "KeyName": { "Ref": "KeyName" },
-        "IamInstanceProfile": {"Ref": "ElasticsearchInstanceProfile"},
-        "InstanceType": { "Ref": "InstanceType" }
+        "KeyName": {"Ref": "KeyName"},
+        "IamInstanceProfile": {"Ref": "InstanceProfile"},
+        "InstanceType": {"Ref": "InstanceType"}
       }
     }
   },
 
   "Outputs": {
-    "ElasticsearchSecurityGroup": {
+    "InstanceSecurityGroup": {
       "Description": "Elasticsearch security group",
-      "Value": {"Ref": "ElasticsearchSecurityGroup"}
+      "Value": {"Ref": "InstanceSecurityGroup"}
     }
   }
 }

--- a/cloudformation_templates/aws_elasticsearch_dev_access.json
+++ b/cloudformation_templates/aws_elasticsearch_dev_access.json
@@ -14,7 +14,7 @@
   },
 
   "Resources": {
-    "ElasticsearchDeveloperIngress": {
+    "DeveloperIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupName": {"Ref": "ElasticsearchSecurityGroup"},

--- a/playbooks/roles/aws_elasticsearch/tasks/main.yml
+++ b/playbooks/roles/aws_elasticsearch/tasks/main.yml
@@ -26,7 +26,7 @@
     template: ../cloudformation_templates/aws_elasticsearch_dev_access.json
     template_parameters:
       CidrIp: "{{ user_ip }}"
-      ElasticsearchSecurityGroup: "{{ elasticsearch_stack.stack_outputs.ElasticsearchSecurityGroup }}"
+      ElasticsearchSecurityGroup: "{{ elasticsearch_stack.stack_outputs.InstanceSecurityGroup }}"
   register: elasticsearch_dev_access_stack
   tags:
     - elasticsearch


### PR DESCRIPTION
Resource names are internal to CloudFormation stack so they don't need to be globally unique.

Not having app prefixes makes it easier to reuse parts of templates (which we'll have to do with api/search/admin templates) 