### PR TITLE
Add Elasticsearch ELB and ELB URLs to stack outputs

### DIFF
--- a/cloudformation_templates/aws_dev_access.json
+++ b/cloudformation_templates/aws_dev_access.json
@@ -9,7 +9,7 @@
     },
     "CidrIp": {
       "Type": "String",
-      "Description": "CIDR or IP to use for security group rules"
+      "Description": "CIDR IP to use for security group rules"
     },
     "FromPort": {
       "Type": "Number",

--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -188,6 +188,19 @@
     "RDSSecurityGroup": {
       "Description": "RDS security group",
       "Value": {"Ref": "RDSInstanceSecurityGroup"}
+    },
+    "Environment": {
+      "Description": "Digital Marketplace API environment",
+      "Value": {"Ref": "Environment"}
+    },
+    "URL": {
+      "Description": "URL of the AWS Elastic Beanstalk Environment",
+      "Value": {
+        "Fn::Join": ["", [
+          "http://",
+          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+        ]]
+      }
     }
   }
 }

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -7,6 +7,10 @@
       "Type": "String",
       "Description": "Group Tag"
     },
+    "LoadBalancerName": {
+      "Type": "String",
+      "Description": "ELB name prefix"
+    },
     "KeyName": {
       "Type": "String",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
@@ -14,6 +18,11 @@
     "SSHCidrIp": {
       "Type": "String",
       "Description": "CIDR or IP to use for SSH access security group rules"
+    },
+    "Port": {
+      "Type": "Number",
+      "Default": "9200",
+      "Description": "Elasticsearch port"
     },
     "InstanceImage" : {
       "Description" : "EC2 instance image",
@@ -36,6 +45,14 @@
         "GroupDescription": "Main instance security group"
       }
     },
+
+    "LoadBalancerSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "ELB security group"
+      }
+    },
+
     "ClusterDiscoveryIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
         "Properties": {
@@ -46,6 +63,18 @@
           "SourceSecurityGroupName": {"Ref": "InstanceSecurityGroup"}
         }
     },
+
+    "LoadBalancerIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupName": {"Ref": "InstanceSecurityGroup"},
+        "IpProtocol": "tcp",
+        "FromPort": {"Ref": "Port"},
+        "ToPort": {"Ref": "Port"},
+        "SourceSecurityGroupName": {"Ref": "LoadBalancerSecurityGroup"}
+      }
+    },
+
     "SSHIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
@@ -56,6 +85,7 @@
         "CidrIp": {"Ref": "SSHCidrIp"}
       }
     },
+
     "IAMRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
@@ -90,6 +120,33 @@
         "Roles": [{"Ref": "IAMRole"}]
       }
     },
+
+    "LoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "Properties": {
+        "LoadBalancerName": {"Ref": "LoadBalancerName"},
+        "AvailabilityZones": {"Fn::GetAZs": ""},
+        "CrossZone": "true",
+        "Listeners": [{
+          "LoadBalancerPort": {"Ref": "Port"},
+          "InstancePort": {"Ref": "Port"},
+          "Protocol": "HTTP"
+        }],
+        "SecurityGroups": [
+          {"Fn::GetAtt": ["LoadBalancerSecurityGroup", "GroupId"]}
+        ],
+        "HealthCheck": {
+          "Target": {"Fn::Join": ["", [
+            "HTTP:", {"Ref": "Port"}, "/"
+          ]]},
+          "HealthyThreshold": "3",
+          "UnhealthyThreshold": "5",
+          "Interval": "30",
+          "Timeout": "5"
+        }
+      }
+    },
+
     "AutoScalingGroup" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       "Properties" : {
@@ -107,11 +164,13 @@
         ],
         "AvailabilityZones" : {"Fn::GetAZs": ""},
         "LaunchConfigurationName" : {"Ref": "LaunchConfiguration"},
+        "LoadBalancerNames": [{"Ref": "LoadBalancer"}],
         "MinSize" : {"Ref": "InstanceCount"},
         "MaxSize" : {"Ref": "InstanceCount"},
         "DesiredCapacity" : {"Ref": "InstanceCount"}
       }
     },
+
     "LaunchConfiguration": {
       "Type": "AWS::AutoScaling::LaunchConfiguration",
       "Properties": {
@@ -126,8 +185,16 @@
 
   "Outputs": {
     "InstanceSecurityGroup": {
-      "Description": "Elasticsearch security group",
+      "Description": "Elasticsearch instances security group",
       "Value": {"Ref": "InstanceSecurityGroup"}
+    },
+    "LoadBalancerSecurityGroup": {
+      "Description": "ELB security group",
+      "Value": {"Ref": "LoadBalancerSecurityGroup"}
+    },
+    "URL": {
+      "Description": "Load balancer endpoint URL",
+      "Value": {"Fn::GetAtt": ["LoadBalancer", "DNSName"]}
     }
   }
 }

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -17,7 +17,7 @@
     },
     "SSHCidrIp": {
       "Type": "String",
-      "Description": "CIDR or IP to use for SSH access security group rules"
+      "Description": "CIDR IP to use for SSH access security group rules"
     },
     "Port": {
       "Type": "Number",

--- a/playbooks/roles/aws_digitalmarketplace_api/tasks/main.yml
+++ b/playbooks/roles/aws_digitalmarketplace_api/tasks/main.yml
@@ -42,7 +42,7 @@
     disable_rollback: false
     template: ../cloudformation_templates/aws_dev_access.json
     template_parameters:
-      CidrIp: "{{ user_ip }}"
+      CidrIp: "{{ user_cidr_ip }}"
       FromPort: "{{ digitalmarketplace_api_rds_port }}"
       ToPort: "{{ digitalmarketplace_api_rds_port }}"
       SecurityGroup: "{{ digitalmarketplace_api_env_stack.stack_outputs.RDSSecurityGroup }}"

--- a/playbooks/roles/aws_elasticsearch/tasks/main.yml
+++ b/playbooks/roles/aws_elasticsearch/tasks/main.yml
@@ -9,6 +9,7 @@
     template_parameters:
       KeyName: "{{ key_name }}"
       SSHCidrIp: "{{ user_ip }}"
+      LoadBalancerName: "{{ elasticsearch_name }}"
       GroupTag: "{{ elasticsearch_name }}"
       InstanceCount: "{{ elasticsearch_ec2_instance_count }}"
       InstanceType: "{{ elasticsearch_ec2_instance_type }}"
@@ -28,7 +29,7 @@
       CidrIp: "{{ user_ip }}"
       FromPort: "{{ elasticsearch_port }}"
       ToPort: "{{ elasticsearch_port }}"
-      SecurityGroup: "{{ elasticsearch_stack.stack_outputs.InstanceSecurityGroup }}"
+      SecurityGroup: "{{ elasticsearch_stack.stack_outputs.LoadBalancerSecurityGroup }}"
   register: elasticsearch_dev_access_stack
   tags:
     - elasticsearch

--- a/playbooks/roles/aws_elasticsearch/tasks/main.yml
+++ b/playbooks/roles/aws_elasticsearch/tasks/main.yml
@@ -8,7 +8,7 @@
     template: ../cloudformation_templates/aws_elasticsearch.json
     template_parameters:
       KeyName: "{{ key_name }}"
-      SSHCidrIp: "{{ user_ip }}"
+      SSHCidrIp: "{{ user_cidr_ip }}"
       LoadBalancerName: "{{ elasticsearch_name }}"
       GroupTag: "{{ elasticsearch_name }}"
       InstanceCount: "{{ elasticsearch_ec2_instance_count }}"
@@ -26,7 +26,7 @@
     disable_rollback: false
     template: ../cloudformation_templates/aws_dev_access.json
     template_parameters:
-      CidrIp: "{{ user_ip }}"
+      CidrIp: "{{ user_cidr_ip }}"
       FromPort: "{{ elasticsearch_port }}"
       ToPort: "{{ elasticsearch_port }}"
       SecurityGroup: "{{ elasticsearch_stack.stack_outputs.LoadBalancerSecurityGroup }}"

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -16,3 +16,7 @@
     - role: aws_digitalmarketplace_api
       state: present
       dev_access_state: "{{ dev_access_state }}"
+
+  post_tasks:
+    - name: Elasticsearch URL
+      debug: msg={{elasticsearch_stack.stack_outputs.URL}}

--- a/user.yml.sample
+++ b/user.yml.sample
@@ -2,7 +2,7 @@
 key_name: ***
 ansible_ssh_private_key_file: "~/.ssh/{{ key_name }}"
 
-user_ip: ***
+user_cidr_ip: ***
 digitalmarketplace_api_db_password: ***
 digitalmarketplace_api_auth_tokens:
   - ***


### PR DESCRIPTION
Creates an ELB in front of Elasticsearch and adds ELB URL to elasticsearch and digitalmarketplace-api stack outputs so that we can use them to configure apps that require access to elasticsearch/API.