### PR TITLE
Move RDS database to a separate CloudFormation stack

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -3,12 +3,11 @@
   "Description": "Digital Marketplace API Environment",
 
   "Parameters": {
-    "DBName": {
+    "RDSSecurityGroup": {
       "Type": "String",
-      "Description": "Database name"
+      "Description": "Name of the RDS instances security group"
     },
     "DBUser": {
-      "NoEcho": "true",
       "Type": "String",
       "Description": "Database admin account name"
     },
@@ -17,13 +16,9 @@
       "Type": "String",
       "Description": "Database admin account password"
     },
-    "DBInstanceType": {
+    "DBPath": {
       "Type": "String",
-      "Description": "Database instance type"
-    },
-    "DBAllocatedStorage": {
-      "Type": "String",
-      "Description": "Database allocated storage"
+      "Description": "Full database URI"
     },
     "KeyName": {
       "Type": "String",
@@ -48,34 +43,19 @@
     "InstanceSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "RDS allows ingress from EC2 instances in this group.",
+        "GroupDescription": "EC2 instances security group.",
         "SecurityGroupIngress": []
       }
     },
 
-    "RDSInstanceSecurityGroup": {
-      "Type": "AWS::EC2::SecurityGroup",
+    "RDSIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
-        "GroupDescription": "Digital Marketplace API RDS Instance security group",
-        "SecurityGroupIngress": [{
-          "IpProtocol": "tcp",
-          "FromPort": "5432",
-          "ToPort": "5432",
-          "SourceSecurityGroupName": {"Ref" : "InstanceSecurityGroup"}
-        }]
-      }
-    },
-
-    "DB": {
-      "Type": "AWS::RDS::DBInstance",
-      "Properties": {
-        "Engine": "postgres",
-        "DBName": {"Ref": "DBName"},
-        "MasterUsername": {"Ref": "DBUser"},
-        "DBInstanceClass": {"Ref": "DBInstanceType"},
-        "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
-        "MasterUserPassword": {"Ref": "DBPassword"},
-        "VPCSecurityGroups": [{"Fn::GetAtt": ["RDSInstanceSecurityGroup", "GroupId"]}]
+        "GroupName": {"Ref": "RDSSecurityGroup"},
+        "IpProtocol": "tcp",
+        "FromPort": "5432",
+        "ToPort": "5432",
+        "SourceSecurityGroupName": {"Ref" : "InstanceSecurityGroup"}
       }
     },
 
@@ -111,6 +91,7 @@
         }]
       }
     },
+
     "InstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
@@ -140,11 +121,7 @@
                   ":",
                   {"Ref": "DBPassword"},
                   "@",
-                  {"Fn::GetAtt": ["DB", "Endpoint.Address"]},
-                  ":",
-                  {"Fn::GetAtt": ["DB", "Endpoint.Port"]},
-                  "/",
-                  {"Ref": "DBName"}
+                  {"Ref": "DBPath"}
                 ]
               ]
             }
@@ -185,10 +162,6 @@
   },
 
   "Outputs": {
-    "RDSSecurityGroup": {
-      "Description": "RDS security group",
-      "Value": {"Ref": "RDSInstanceSecurityGroup"}
-    },
     "Environment": {
       "Description": "Digital Marketplace API environment",
       "Value": {"Ref": "Environment"}

--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -1,0 +1,71 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "RDS database",
+
+  "Parameters": {
+    "DBName": {
+      "Type": "String",
+      "Description": "Database name"
+    },
+    "DBUser": {
+      "NoEcho": "true",
+      "Type": "String",
+      "Description": "Database admin account name"
+    },
+    "DBPassword": {
+      "NoEcho": "true",
+      "Type": "String",
+      "Description": "Database admin account password"
+    },
+    "DBInstanceType": {
+      "Type": "String",
+      "Description": "Database instance type"
+    },
+    "DBAllocatedStorage": {
+      "Type": "String",
+      "Description": "Database allocated storage"
+    }
+  },
+
+  "Resources": {
+    "SecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "RDS Instance security group",
+        "SecurityGroupIngress": []
+      }
+    },
+
+    "DB": {
+      "Type": "AWS::RDS::DBInstance",
+      "Properties": {
+        "Engine": "postgres",
+        "DBName": {"Ref": "DBName"},
+        "MasterUsername": {"Ref": "DBUser"},
+        "DBInstanceClass": {"Ref": "DBInstanceType"},
+        "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
+        "MasterUserPassword": {"Ref": "DBPassword"},
+        "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}]
+      }
+    }
+  },
+
+  "Outputs": {
+    "SecurityGroup": {
+      "Description": "RDS security group",
+      "Value": {"Ref": "SecurityGroup"}
+    },
+    "URL": {
+      "Description": "Address of the RDS instance",
+      "Value": {
+        "Fn::Join": ["", [
+          {"Fn::GetAtt": ["DB", "Endpoint.Address"]},
+          ":",
+          {"Fn::GetAtt": ["DB", "Endpoint.Port"]},
+          "/",
+          {"Ref": "DBName"}
+        ]]
+      }
+    }
+  }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -1,8 +1,23 @@
 ---
 all:
+  - apps
+  - dev_access
+  - data_storage
+
+apps:
   - api
   - search_api
   - admin_frontend
+
+eb_apps:
+  - api_app
+  - search_api_app
+  - admin_frontend_app
+
+data_storage:
+  - database
+  - documents_s3
+  - elasticsearch
 
 dev_access:
   - database_dev_access

--- a/stacks.yml
+++ b/stacks.yml
@@ -5,18 +5,18 @@ all:
   - admin_frontend
 
 dev_access:
-  - api_dev_access
+  - database_dev_access
   - elasticsearch_dev_access
 
 database:
   name: "rds-database-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_rds_database.json
   parameters:
-    DBName: "{{ api.db_name }}"
-    DBUser: "{{ api.db_user }}"
-    DBPassword: "{{ api.db_password }}"
-    DBInstanceType: "{{ api.db_instance_type }}"
-    DBAllocatedStorage: "{{ api.db_allocated_storage }}"
+    DBName: "{{ database.name }}"
+    DBUser: "{{ database.user }}"
+    DBPassword: "{{ database.password }}"
+    DBInstanceType: "{{ database.instance_type }}"
+    DBAllocatedStorage: "{{ database.allocated_storage }}"
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"
@@ -41,21 +41,21 @@ api:
     EnvironmentName: "dmapi-{{ stage[:3] }}-{{ environment }}"
     KeyName: "{{ key_name }}"
     APIAuthTokens: "{{ api.auth_tokens | join(':') }}"
-    DBUser: "{{ api.db_user }}"
-    DBPassword: "{{ api.db_password }}"
+    DBUser: "{{ database.user }}"
+    DBPassword: "{{ database.password }}"
     DBPath: "{{ stacks.database.outputs.URL }}"
     RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
 
-api_dev_access:
+database_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"
   template: cloudformation_templates/aws_dev_access.json
   dependencies:
-    - api
+    - database
   parameters:
     CidrIp: "{{ user_cidr_ip }}"
-    FromPort: "{{ api.rds_port }}"
-    ToPort: "{{ api.rds_port }}"
-    SecurityGroup: "{{ stacks.api.outputs.RDSSecurityGroup }}"
+    FromPort: "{{ database.port }}"
+    ToPort: "{{ database.port }}"
+    SecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
 
 elasticsearch:
   name: "elasticsearch-{{ stage }}-{{ environment }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -8,6 +8,16 @@ dev_access:
   - api_dev_access
   - elasticsearch_dev_access
 
+database:
+  name: "rds-database-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_rds_database.json
+  parameters:
+    DBName: "{{ api.db_name }}"
+    DBUser: "{{ api.db_user }}"
+    DBPassword: "{{ api.db_password }}"
+    DBInstanceType: "{{ api.db_instance_type }}"
+    DBAllocatedStorage: "{{ api.db_allocated_storage }}"
+
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_documents_s3.json
@@ -25,16 +35,16 @@ api:
   template: cloudformation_templates/aws_digitalmarketplace_api.json
   dependencies:
     - api_app
+    - database
   parameters:
     ApplicationName: "{{ stacks.api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmapi-{{ stage[:3] }}-{{ environment }}"
     KeyName: "{{ key_name }}"
     APIAuthTokens: "{{ api.auth_tokens | join(':') }}"
-    DBName: "{{ api.db_name }}"
     DBUser: "{{ api.db_user }}"
     DBPassword: "{{ api.db_password }}"
-    DBInstanceType: "{{ api.db_instance_type }}"
-    DBAllocatedStorage: "{{ api.db_allocated_storage }}"
+    DBPath: "{{ stacks.database.outputs.URL }}"
+    RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
 
 api_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"

--- a/user.yml.sample
+++ b/user.yml.sample
@@ -5,9 +5,11 @@ ansible_ssh_private_key_file: "~/.ssh/{{ key_name }}"
 user_cidr_ip: ***
 
 api:
-  db_password: ***
   auth_tokens:
     - ***
+
+database:
+  password: ***
 
 search_api:
   auth_tokens:

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -2,11 +2,13 @@
 aws_region: eu-west-1
 
 api:
-  rds_port: 5432
-  db_user: "digitalmarketplace"
-  db_name: "digitalmarketplace_api"
-  db_instance_type: db.m1.small
-  db_allocated_storage: 5
+
+database:
+  port: 5432
+  user: "digitalmarketplace"
+  name: "digitalmarketplace_api"
+  instance_type: db.m1.small
+  allocated_storage: 5
 
 elasticsearch:
   port: 9200


### PR DESCRIPTION
Having the DB instance outside the api stacks makes it easier to change Elastic Beanstalk app/env stacks and would allow us to reuse the database for multiple environments later.