### PR TITLE
Clone app when releasing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.repos
 *.egg-info
 *.pyc
 user.yml

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 *.pyc
 user.yml
+venv

--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -32,8 +32,11 @@ def clone_or_update(repo_url):
     if not os.path.exists(repository_path):
         run_git_cmd(['clone', repo_url], REPOS_PATH)
     else:
-        run_git_cmd(['reset', '--hard', 'origin'], repository_path)
-        run_git_cmd(['pull'], repository_path)
+        run_git_cmd(['reset', '--hard', 'HEAD'], repository_path)
+        run_git_cmd(['checkout', 'master'], repository_path)
+        run_git_cmd(['clean', '-fdx'], repository_path)
+        run_git_cmd(['fetch'], repository_path)
+        run_git_cmd(['reset', '--hard', 'origin/master'], repository_path)
 
     return repository_path
 

--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -23,14 +23,14 @@ def run_git_cmd(args, cwd, stdout=None):
     )
 
 
-def clone_or_update(app_name):
-    app_git_url = get_application_git_url(app_name)
+def clone_or_update(repo_url):
+    app_name = get_application_name_from_url(repo_url)
     repository_path = os.path.join(REPOS_PATH,
                                    'digitalmarketplace-{}'.format(app_name))
     if not os.path.exists(REPOS_PATH):
         os.mkdir(REPOS_PATH)
     if not os.path.exists(repository_path):
-        run_git_cmd(['clone', app_git_url], REPOS_PATH)
+        run_git_cmd(['clone', repo_url], REPOS_PATH)
     else:
         run_git_cmd(['reset', '--hard', 'origin'], repository_path)
         run_git_cmd(['pull'], repository_path)
@@ -38,12 +38,7 @@ def clone_or_update(app_name):
     return repository_path
 
 
-def get_application_git_url(app_name):
-    return 'git@github.com:alphagov/digitalmarketplace-{}.git'.format(app_name)
-
-
-def get_application_name(cwd):
-    repo_url = get_repo_url(cwd)
+def get_application_name_from_url(repo_url):
     match = SSH_REPO_PATTERN.match(repo_url)
     if not match:
         match = HTTPS_REPO_PATTERN.match(repo_url)
@@ -51,6 +46,10 @@ def get_application_name(cwd):
     if 'digitalmarketplace-' not in name:
         raise ValueError('Application name format not recognized')
     return name.replace('digitalmarketplace-', '')
+
+
+def get_application_name(cwd):
+    return get_application_name_from_url(get_repo_url(cwd))
 
 
 def get_repo_url(cwd):

--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -100,7 +100,7 @@ def get_release_name_for_tag(cwd, tag):
     if len(tags) == 1:
         return tags[0]
     elif len(tags) > 1:
-        raise StandardError(
+        raise ValueError(
             "More than one release tag pointing to the same commit.")
 
 

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -16,7 +16,7 @@ def release_cmd(ctx, app_name, release_name=None, from_account=None):
     If releasing to staging copy the artefact over from the development account.
     If releasing to production just promote the current staging releasee to production.
     """
-    repository_path = build.clone_or_update(app_name)
+    repository_path = build.clone_or_update(ctx.stacks[app_name].repo_url)
     if ctx.stage == "preview":
         release_to_preview(ctx, repository_path)
     elif ctx.stage == "staging":

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -5,17 +5,18 @@ from ..stacks import StackPlan
 from .. import build
 
 
-@click.argument('repository_path', nargs=1, type=click.Path(exists=True))
+@click.argument('app_name', nargs=1)
 @click.option('--release-name')
 @click.option('--from-account')
 @cli_command('release', max_apps=0)
-def release_cmd(ctx, repository_path, release_name=None, from_account=None):
+def release_cmd(ctx, app_name, release_name=None, from_account=None):
     """Release an application to preview, staging or production.
 
     If releasing to preview create a new release tag and push the artefact up.
     If releasing to staging copy the artefact over from the development account.
     If releasing to production just promote the current staging releasee to production.
     """
+    repository_path = build.clone_or_update(app_name)
     if ctx.stage == "preview":
         release_to_preview(ctx, repository_path)
     elif ctx.stage == "staging":

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -7,20 +7,20 @@ from .. import build
 
 @click.argument('app_name', nargs=1)
 @click.option('--release-name')
-@click.option('--from-account')
+@click.option('--from-profile')
 @cli_command('release', max_apps=0)
-def release_cmd(ctx, app_name, release_name=None, from_account=None):
+def release_cmd(ctx, app_name, release_name=None, from_profile=None):
     """Release an application to preview, staging or production.
 
     If releasing to preview create a new release tag and push the artefact up.
-    If releasing to staging copy the artefact over from the development account.
+    If releasing to staging copy the artefact over from the development profile.
     If releasing to production just promote the current staging releasee to production.
     """
     repository_path = build.clone_or_update(ctx.stacks[app_name].repo_url)
     if ctx.stage == "preview":
         release_to_preview(ctx, repository_path)
     elif ctx.stage == "staging":
-        release_to_staging(ctx, repository_path, release_name, from_account)
+        release_to_staging(ctx, repository_path, release_name, from_profile)
     elif ctx.stage == "production":
         release_to_production(ctx, repository_path)
     else:
@@ -48,11 +48,11 @@ def release_to_preview(ctx, repository_path):
     deploy.deploy(version, ctx.stage)
 
 
-def release_to_staging(ctx, repository_path, release_name, from_account):
+def release_to_staging(ctx, repository_path, release_name, from_profile):
     if release_name is None:
         raise ValueError("Release name required for staging release")
-    if from_account is None:
-        raise ValueError("Source account required for staging release")
+    if from_profile is None:
+        raise ValueError("Source profile required for staging release")
 
     deploy = get_deploy(ctx, repository_path)
 
@@ -60,7 +60,7 @@ def release_to_staging(ctx, repository_path, release_name, from_account):
         source_plan = StackPlan.from_ctx(ctx,
                                          stage='preview',
                                          environment='master',
-                                         profile_name=from_account)
+                                         profile_name=from_profile)
         source_deploy = source_plan.get_deploy(repository_path)
         package_path = source_deploy.download_package(release_name)
 

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -6,8 +6,10 @@ from .deploy import Deploy
 
 
 class Stack(object):
-    def __init__(self, name, template, parameters, dependencies=None):
+    def __init__(self, name, template, parameters,
+                 dependencies=None, repo_url=None):
         self.name = name
+        self.repo_url = repo_url
         self.template = template
         self.parameters = parameters or {}
         self.dependencies = dependencies or []

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -14,7 +14,7 @@ if [ "$APPLICATION_NAME" = "Select one" -o "$STAGE" = ""]; then
 fi
 
 if [ "$STAGE" = "staging" ]; then
-  OPTIONS="--from-account=development --release-name=$RELEASE_NAME"
+  OPTIONS="--from-profile=preview --release-name=$RELEASE_NAME"
 fi
 
 AWS_PROFILE="$STAGE" dmaws $STAGE $STAGE release $APPLICATION_NAME $OPTIONS

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+[ -d venv ] || virtualenv venv
+pip install -e .
+
+if [ "$STAGE" = "Select one" -o "$STAGE" = "" ]; then
+  >&2 echo "You must select an environment."
+  exit 1
+fi
+
+if [ "$APPLICATION_NAME" = "Select one" -o "$STAGE" = ""]; then
+  >&2 echo "You must select an application name."
+  exit 1
+fi
+
+if [ "$STAGE" = "staging" ]; then
+  OPTIONS="--from-account=development --release-name=$RELEASE_NAME"
+fi
+
+AWS_PROFILE="$STAGE" dmaws $STAGE $STAGE release $APPLICATION_NAME $OPTIONS

--- a/stacks.yml
+++ b/stacks.yml
@@ -47,6 +47,7 @@ api_app:
 
 api:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}"
+  repo_url: "git@github.com:alphagov/digitalmarketplace-api.git"
   template: cloudformation_templates/aws_digitalmarketplace_api.json
   dependencies:
     - api_app
@@ -107,6 +108,7 @@ search_api_app:
 
 search_api:
   name: "digitalmarketplace-search-api-{{ stage }}-{{ environment }}"
+  repo_url: "git@github.com:alphagov/digitalmarketplace-search-api.git"
   template: cloudformation_templates/aws_digitalmarketplace_search_api.json
   dependencies:
     - search_api_app
@@ -131,6 +133,7 @@ admin_frontend_app:
 
 admin_frontend:
   name: "digitalmarketplace-admin-frontend-{{ stage }}-{{ environment }}"
+  repo_url: "git@github.com:alphagov/digitalmarketplace-admin-frontend.git"
   template: cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
   dependencies:
     - documents_s3


### PR DESCRIPTION
The release command is going to be called from Jenkins. This means that
there will not be an existing, safe chekout of the app repositories.
This commit solves that problem by changing release to accept an app
name and then cloning the app's repo locally.