### PR TITLE
Add version file to artefact

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -122,6 +122,11 @@ def add_build_artefacts_to_archive(cwd, archive):
     add_directory_to_archive(cwd, 'bower_components', archive)
 
 
+def set_version_label_on_archive(archive_path, version_label):
+    with zipfile.ZipFile(archive_path, 'a') as archive:
+        archive.writestr('version_label', "{}\n".format(version_label))
+
+
 def create_archive(cwd):
     ref, sha, archive_path = create_git_archive(cwd)
     try:

--- a/dmaws/deploy.py
+++ b/dmaws/deploy.py
@@ -29,6 +29,8 @@ class Deploy(object):
         if with_sha:
             version_label = '{}-{}-{}'.format(version_label, ref, sha[:7])
 
+        build.set_version_label_on_archive(package_path, version_label)
+
         package_name = self.get_package_name(version_label)
 
         bucket = self.get_storage_location()


### PR DESCRIPTION
Add a file containing the version label to the release artefact. The
intention is that this will be picked up by apps and shown through their
status URL.