### PR TITLE
Do not require user.yml to be present

### DIFF
--- a/dmaws/cli.py
+++ b/dmaws/cli.py
@@ -44,11 +44,13 @@ def cli_command(cmd_name, max_apps=-1):
         def wrapped(ctx, vars_file, var, stacks_file, load_default_files,
                     dry_run, app=None, *args, **kwargs):
             if load_default_files:
-                vars_file = [
+                default_vars_files = [
                     'vars/common.yml',
                     'vars/{}.yml'.format(ctx.stage),
-                    'vars/user.yml',
-                ] + list(vars_file)
+                ]
+                if os.path.exists('vars/user.yml'):
+                    default_vars_files.append('vars/user.yml')
+                vars_file = default_vars_files + list(vars_file)
 
             ctx.load_variables(files=vars_file, pairs=[v.split('=') for v in var])
             ctx.load_stacks(stacks_file)

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -73,6 +73,19 @@ def template(item, variables, **kwargs):
         return item
 
 
+class LazyTemplateMapping(object):
+    def __init__(self, mapping, variables, **kwargs):
+        self._mapping = mapping
+        self._cache = {}
+        self._variables = merge_dicts(variables, kwargs)
+
+    def __getitem__(self, key):
+        if key not in self._cache:
+            self._cache[key] = template(self._mapping[key], self._variables)
+
+        return self._cache[key]
+
+
 def template_string(string, variables):
     jinja_env = jinja2.Environment(
         trim_blocks=True,

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -8,7 +8,7 @@ if [ "$STAGE" = "Select one" -o "$STAGE" = "" ]; then
   exit 1
 fi
 
-if [ "$APPLICATION_NAME" = "Select one" -o "$STAGE" = ""]; then
+if [ "$APPLICATION_NAME" = "Select one" -o "$STAGE" = "" ]; then
   >&2 echo "You must select an application name."
   exit 1
 fi


### PR DESCRIPTION
It is not needed for releases from the jenkins machine.
This change prevents the user.yml being added to the vars files if it
does not exist.
It also changes the built stack parameters to be lazy so that some can
be evaluated without all being evaluated. This is needed for the release
command so that parameters not required for release do not have to be
evaluated.