### PR TITLE
Upgrade instances to Amazon Linux 2014.09 v1.2.0

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -92,7 +92,7 @@
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
         "Description": "Default Configuration Version 1.0",
-        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
+        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.2.0 running Python 2.7",
         "OptionSettings": [
 {% for variable in environment_variables %}
           {

--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -108,7 +108,7 @@
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
         "Description": "Default Configuration Version 1.0",
-        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
+        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.2.0 running Python 2.7",
         "OptionSettings": [
 {% for variable in environment_variables %}
           {

--- a/cloudformation_templates/aws_digitalmarketplace_search_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_search_api.json
@@ -112,7 +112,7 @@
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
         "Description": "Default Configuration Version 1.0",
-        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
+        "SolutionStackName": "64bit Amazon Linux 2014.09 v1.2.0 running Python 2.7",
         "OptionSettings": [
 {% for variable in environment_variables %}
           {


### PR DESCRIPTION
Upgrade Digital Marketplace instances running in Elastic Beanstalk to Amazon Linux 2014.09 v1.2.0.