### PR TITLE
Run CloudFormation templates through Jinja

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -3,6 +3,13 @@
   "Description": "Digital Marketplace Admin Frontend Environment",
 
   "Parameters": {
+{% for variable in environment_variables %}
+    "{{ variable }}": {
+        "Type": "String",
+        "Description": "Elastic Beanstalk environment variable",
+        "NoEcho": "true"
+    },
+{% endfor %}
     "KeyName": {
       "Type": "String",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
@@ -18,24 +25,6 @@
     "MaxInstanceCount": {
       "Type": "Number",
       "Description": "MaxSize of the Auto Scaling group"
-    },
-    "APIAuthTokens": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Digital Marketplace API Auth Token"
-    },
-    "DigitalmarketplaceAPIURL": {
-      "Type": "String",
-      "Description": "Digital Markeplace API ELB URL"
-    },
-    "S3Bucket": {
-      "Type": "String",
-      "Description": "Document S3 Bucket name"
-    },
-    "AdminPasswordHash": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Password hash to use for admin app authentication"
     },
     "ApplicationName": {
       "Type": "String",
@@ -105,6 +94,13 @@
         "Description": "Default Configuration Version 1.0",
         "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
         "OptionSettings": [
+{% for variable in environment_variables %}
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "{{ param_to_env(variable) }}",
+            "Value": {"Ref": "{{ variable }}"}
+          },
+{% endfor %}
           {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
@@ -124,26 +120,6 @@
             "Namespace": "aws:autoscaling:asg",
             "OptionName": "MaxSize",
             "Value": {"Ref": "MaxInstanceCount"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_ADMIN_FRONTEND_API_AUTH_TOKEN",
-            "Value": {"Ref": "APIAuthTokens"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_API_URL",
-            "Value": {"Ref": "DigitalmarketplaceAPIURL"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_S3_DOCUMENT_BUCKET",
-            "Value": {"Ref": "S3Bucket"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_ADMIN_FRONTEND_PASSWORD_HASH",
-            "Value": {"Ref": "AdminPasswordHash"}
           },
           {
             "Namespace": "aws:autoscaling:launchconfiguration",

--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -3,6 +3,13 @@
   "Description": "Digital Marketplace API Environment",
 
   "Parameters": {
+{% for variable in environment_variables %}
+    "{{ variable }}": {
+        "Type": "String",
+        "Description": "Elastic Beanstalk environment variable",
+        "NoEcho": "true"
+    },
+{% endfor %}
     "KeyName": {
       "Type": "String",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
@@ -22,24 +29,6 @@
     "RDSSecurityGroup": {
       "Type": "String",
       "Description": "Name of the RDS instances security group"
-    },
-    "DBUser": {
-      "Type": "String",
-      "Description": "Database admin account name"
-    },
-    "DBPassword": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Database admin account password"
-    },
-    "DBPath": {
-      "Type": "String",
-      "Description": "Full database URI"
-    },
-    "APIAuthTokens": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Digital Marketplace API Auth Token"
     },
     "ApplicationName": {
       "Type": "String",
@@ -121,6 +110,13 @@
         "Description": "Default Configuration Version 1.0",
         "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
         "OptionSettings": [
+{% for variable in environment_variables %}
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "{{ param_to_env(variable) }}",
+            "Value": {"Ref": "{{ variable }}"}
+          },
+{% endfor %}
           {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
@@ -140,28 +136,6 @@
             "Namespace": "aws:autoscaling:asg",
             "OptionName": "MaxSize",
             "Value": {"Ref": "MaxInstanceCount"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "SQLALCHEMY_DATABASE_URI",
-            "Value": {
-              "Fn::Join": [
-                "",
-                [
-                  "postgres://",
-                  {"Ref": "DBUser"},
-                  ":",
-                  {"Ref": "DBPassword"},
-                  "@",
-                  {"Ref": "DBPath"}
-                ]
-              ]
-            }
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_API_AUTH_TOKENS",
-            "Value": {"Ref": "APIAuthTokens"}
           },
           {
             "Namespace": "aws:autoscaling:launchconfiguration",

--- a/cloudformation_templates/aws_digitalmarketplace_search_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_search_api.json
@@ -3,6 +3,13 @@
   "Description": "Digital Marketplace Search API Environment",
 
   "Parameters": {
+{% for variable in environment_variables %}
+    "{{ variable }}": {
+        "Type": "String",
+        "Description": "Elastic Beanstalk environment variable",
+        "NoEcho": "true"
+    },
+{% endfor %}
     "KeyName": {
       "Type": "String",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
@@ -19,19 +26,10 @@
       "Type": "Number",
       "Description": "MaxSize of the Auto Scaling group"
     },
-    "SearchAPIAuthTokens": {
-      "NoEcho": "true",
-      "Type": "String",
-      "Description": "Digital Marketplace Search API Auth Token"
-    },
     "ElasticsearchPort": {
       "Type": "Number",
       "Default": "9200",
       "Description": "Elasticsearch port"
-    },
-    "ElasticsearchHost": {
-      "Type": "String",
-      "Description": "Elasticsearch cluster ELB URL"
     },
     "ElasticsearchSecurityGroup": {
       "Type": "String",
@@ -116,6 +114,13 @@
         "Description": "Default Configuration Version 1.0",
         "SolutionStackName": "64bit Amazon Linux 2014.09 v1.1.0 running Python 2.7",
         "OptionSettings": [
+{% for variable in environment_variables %}
+          {
+            "Namespace": "aws:elasticbeanstalk:application:environment",
+            "OptionName": "{{ param_to_env(variable) }}",
+            "Value": {"Ref": "{{ variable }}"}
+          },
+{% endfor %}
           {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
@@ -135,21 +140,6 @@
             "Namespace": "aws:autoscaling:asg",
             "OptionName": "MaxSize",
             "Value": {"Ref": "MaxInstanceCount"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_SEARCH_API_AUTH_TOKENS",
-            "Value": {"Ref": "SearchAPIAuthTokens"}
-          },
-          {
-            "Namespace": "aws:elasticbeanstalk:application:environment",
-            "OptionName": "DM_ELASTICSEARCH_URL",
-            "Value": {"Fn::Join": ["", [
-              "http://",
-              {"Ref": "ElasticsearchHost"},
-              ":",
-              {"Ref": "ElasticsearchPort"}
-            ]]}
           },
           {
             "Namespace": "aws:autoscaling:launchconfiguration",

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -79,6 +79,14 @@ class LazyTemplateMapping(object):
         self._cache = {}
         self._variables = merge_dicts(variables, kwargs)
 
+    def keys(self):
+        return self._mapping.keys()
+
+    def items(self):
+        for key in self.keys():
+            self.__getitem__(key)
+        return self._cache.items()
+
     def __getitem__(self, key):
         if key not in self._cache:
             self._cache[key] = template(self._mapping[key], self._variables)

--- a/stacks.yml
+++ b/stacks.yml
@@ -55,14 +55,16 @@ api:
   parameters:
     ApplicationName: "{{ stacks.api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmapi-{{ stage[:3] }}-{{ environment }}"
+
+    # EnvVar* variables are written to Elastic Beanstalk environment
+    # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarSqlalchemyDatabaseUri: "postgres://{{ database.user }}:{{ database.password}}@{{ stacks.database.outputs.URL }}"
+    EnvVarDmApiAuthTokens: "{{ api.auth_tokens | join(':') }}"
+
     KeyName: "{{ key_name }}"
     InstanceType: "{{ api.instance_type }}"
     MinInstanceCount: "{{ api.min_instance_count }}"
     MaxInstanceCount: "{{ api.max_instance_count }}"
-    APIAuthTokens: "{{ api.auth_tokens | join(':') }}"
-    DBUser: "{{ database.user }}"
-    DBPassword: "{{ database.password }}"
-    DBPath: "{{ stacks.database.outputs.URL }}"
     RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
 
 database_dev_access:
@@ -116,12 +118,16 @@ search_api:
   parameters:
     ApplicationName: "{{ stacks.search_api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmsearch-{{ stage[:3] }}-{{ environment }}"
+
+    # EnvVar* variables are written to Elastic Beanstalk environment
+    # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmElasticsearchUrl: "http://{{ stacks.elasticsearch.outputs.URL }}:{{ elasticsearch.port }}"
+    EnvVarDmSearchApiAuthTokens: "{{ search_api.auth_tokens | join(':') }}"
+
     KeyName: "{{ key_name }}"
     InstanceType: "{{ search_api.instance_type }}"
     MinInstanceCount: "{{ search_api.min_instance_count }}"
     MaxInstanceCount: "{{ search_api.max_instance_count }}"
-    SearchAPIAuthTokens: "{{ search_api.auth_tokens | join(':') }}"
-    ElasticsearchHost: "{{ stacks.elasticsearch.outputs.URL }}"
     ElasticsearchPort: "{{ elasticsearch.port }}"
     ElasticsearchSecurityGroup: "{{ stacks.elasticsearch.outputs.LoadBalancerSecurityGroup }}"
 
@@ -142,11 +148,15 @@ admin_frontend:
   parameters:
     ApplicationName: "{{ stacks.admin_frontend_app.parameters.ApplicationName }}"
     EnvironmentName: "dmadmin-{{ stage[:3] }}-{{ environment }}"
+
+    # EnvVar* variables are written to Elastic Beanstalk environment
+    # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
+    EnvVarDmS3DocumentBucket: "{{ stacks.documents_s3.outputs.Name }}"
+    EnvVarDmAdminFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
+    EnvVarDmAdminFrontendPasswordHash: "{{ admin_frontend.admin_password_hash | replace('$', '\\$') }}"
+
     KeyName: "{{ key_name }}"
     InstanceType: "{{ admin_frontend.instance_type }}"
     MinInstanceCount: "{{ admin_frontend.min_instance_count }}"
     MaxInstanceCount: "{{ admin_frontend.max_instance_count }}"
-    APIAuthTokens: "{{ api.auth_tokens[0] }}"
-    DigitalmarketplaceAPIURL: "{{ stacks.api.outputs.URL }}"
-    S3Bucket: "{{ stacks.documents_s3.outputs.Name }}"
-    AdminPasswordHash: "{{ admin_frontend.admin_password_hash | replace('$', '\\$') }}"


### PR DESCRIPTION
Takes all `EnvVar*` parameters from the stack parameters list and:

1. Adds a parameter declaration to CloudFormation template
2. Adds OptionSetting to set parameter value to environment variable with the `param_to_env(name)` in the Elastic Beanstalk environment

Loaded CloudFormation template is run through jinja2 using selected values from the stack as context.

Right now the only variables available to jinja are:

* `environment_variables` – a subset of parameter names and
* `param_to_env` – a transform function to get environment variable
name out of parameter name.

Parameter is added to 'environment_variables' if its name starts with 'EnvVar' (CloudFormation doesn't allow underscores in parameter names so direct mapping using actual environment variable names doesn't work. And 'Env' appears in 'EnvironmentName').

This is a first step to make changing CloudFormation templates easier and less error-prone and reducing duplication. Jinja will allow us to use includes and macros for commonly repeated parts of templates as well as generating list of accepted parameters from stacks info.

I'm not moving the environment variables to a new stack field separate from parameters yet, since it's a bigger change, but it's something we might do at some point.

