### PR TITLE
[WIP] Add cloudfront

### DIFF
--- a/cloudformation_templates/aws_cloudfront_app.json
+++ b/cloudformation_templates/aws_cloudfront_app.json
@@ -1,0 +1,72 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Digital Marketplace Application CloudFront Distribution",
+
+  "Parameters": {
+    "OriginDomain": {
+      "Type": "String",
+      "Description": "The origin domain for the upstream application."
+    },
+    "Subdomain": {
+      "Type": "String",
+      "Description": "The short name for the application, used for the logging prefix."
+    },
+    "ParentDomain": {
+      "Type": "String",
+      "Description": "The short name for the application, used for the logging prefix."
+    },
+    "LogsBucket": {
+      "Type": "String",
+      "Description": "S3 bucket name for the logs"
+    },
+    "IamCertificateId": {
+      "Type": "String",
+      "Description": "The IAM certificate ID for the SSL certificate."
+    }
+  },
+
+  "Resources": {
+    "CloudFrontDistribution": {
+      "Type": "AWS::CloudFront::Distribution",
+      "Properties": {
+        "DistributionConfig": {
+          "Origins": [
+            {
+              "DomainName": {"Ref": "OriginDomain"},
+              "Id": "OriginId",
+              "CustomOriginConfig": {
+                "HTTPPort": "80",
+                "OriginProtocolPolicy": "http-only"
+              }
+            }
+          ],
+          "Enabled": true,
+          "Logging": {
+            "IncludeCookies": false,
+            "Bucket": {"Ref": "LogsBucket"},
+            "Prefix": {"Fn::Join": ["", ["cloudfront/", {"Ref": "Subdomain"}, "/"]]}
+          },
+
+          "Aliases": [{"Fn::Join": [".", [
+            {"Ref": "Subdomain"}, {"Ref": "ParentDomain"}]]}],
+
+          "DefaultCacheBehavior": {
+            "TargetOriginId": "OriginId",
+            "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
+            "ViewerProtocolPolicy": "https-only",
+            "SmoothStreaming": false,
+            "ForwardedValues": {
+              "Headers": ["Authorization", "Host"],
+              "QueryString": true
+            }
+          },
+          "ViewerCertificate": {
+            "IamCertificateId": {"Ref": "IamCertificateId"},
+            "SslSupportMethod": "sni-only"
+          },
+          "PriceClass": "PriceClass_100"
+        }
+      }
+    }
+  }
+}

--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -167,6 +167,10 @@
       "Description": "Digital Marketplace API environment",
       "Value": {"Ref": "Environment"}
     },
+    "Domain": {
+      "Description": "The domain name of the AWS Elastic Beanstalk Environment",
+      "Value": {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+    },
     "URL": {
       "Description": "URL of the AWS Elastic Beanstalk Environment",
       "Value": {

--- a/cloudformation_templates/aws_s3.json
+++ b/cloudformation_templates/aws_s3.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "S3 bucket for Digital Marketplace documents",
+  "Description": "S3 bucket",
   "Parameters": {
     "BucketName": {
       "Type": "String",
@@ -22,6 +22,10 @@
     "Name": {
       "Description": "S3 bucket name",
       "Value": {"Ref": "S3Bucket"}
+    },
+    "DomainName": {
+      "Description": "S3 bucket domain name",
+      "Value": {"Fn::GetAtt": ["S3Bucket", "DomainName"]}
     },
     "URL" : {
       "Value" : {"Fn::Join": ["", [

--- a/stacks.yml
+++ b/stacks.yml
@@ -14,9 +14,13 @@ eb_apps:
   - search_api_app
   - admin_frontend_app
 
+cloudfront:
+  - api_cloudfront
+
 data_storage:
   - database
   - documents_s3
+  - logs_s3
   - elasticsearch
 
 dev_access:
@@ -38,6 +42,12 @@ documents_s3:
   template: cloudformation_templates/aws_s3.json
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
+
+logs_s3:
+  name: "logs-s3-{{ stage }}"
+  template: cloudformation_templates/aws_s3.json
+  parameters:
+    BucketName: "digitalmarketplace-logs-{{ stage }}"
 
 api_app:
   name: "digitalmarketplace-api-app"
@@ -66,6 +76,19 @@ api:
     MinInstanceCount: "{{ api.min_instance_count }}"
     MaxInstanceCount: "{{ api.max_instance_count }}"
     RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
+
+api_cloudfront:
+  name: "digitalmarketplace-api-cloudfront-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_cloudfront_app.json
+  dependencies:
+    - api
+    - logs_s3
+  parameters:
+    OriginDomain: "{{ stacks.api.outputs.Domain }}"
+    Subdomain: "{% if stage != 'production ' %}{{ stage }}-{% endif %}api"
+    ParentDomain: "{{ root_domain }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.DomainName }}"
+    IamCertificateId: "{{ iam_certificate_id }}"
 
 database_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"

--- a/stacks.yml
+++ b/stacks.yml
@@ -35,7 +35,7 @@ database:
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"
-  template: cloudformation_templates/aws_documents_s3.json
+  template: cloudformation_templates/aws_s3.json
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
 

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,4 +1,5 @@
 ---
+root_domain: "digitalmarketplace.service.gov.uk"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,1 +1,2 @@
 ---
+root_domain: "digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
THIS IS FOR REVIEW ONLY - PLEASE DO NOT MERGE YET

This introduces a basic and not-yet-ready-for-prime-time stack for
configuring the API in CloudFront. This is not ready for prime time
because CloudFront talks to Beanstalk over HTTP. In order to have have
CloudFront talk to Beanstalk over SSL we need to serve Beanstalk over a
domain name that we can generate an SSL certificate for. We can do this
without managing DNS in Route53 but it means the only way we're wiring
the CloudFront configuration up to a Beanstalk instance is through DNS
that is managed elsewhere which seems non-obvious.

Other things of note:
- The S3 template has been renamed to be more generic.
- This introduces a new output to the API template.
- The domain names follow the convention covered in the Google Doc shared
  within the team.
- All logs for a stage are stored in the same bucket with different
  prefixes.
- The IAM certificate is generated separately and must be provided.
- The root domain is configurable to allow the different accounts to be
  on different root domains as discussed.