### PR TITLE
Fixes for the admin-frontend release command

### DIFF
--- a/dmaws/cli.py
+++ b/dmaws/cli.py
@@ -1,9 +1,11 @@
 from functools import wraps
 import os
+import sys
 
 import click
 
 from .context import pass_context
+from .utils import CalledProcessError
 
 
 STAGES = [
@@ -62,7 +64,11 @@ def cli_command(cmd_name, max_apps=-1):
             ctx.add_apps(app)
             ctx.dry_run = dry_run
 
-            return cmd(ctx, *args, **kwargs)
+            try:
+                return cmd(ctx, *args, **kwargs)
+            except CalledProcessError as e:
+                ctx.log("%s:\n\n%s", str(e), e.output)
+                sys.exit(1)
 
         if max_apps:
             wrapped = click.argument('app', nargs=max_apps)(wrapped)

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -7,11 +7,10 @@ from ..stacks import StackPlan
 from .. import build
 
 
-@click.argument('app_name', nargs=1)
 @click.option('--release-name')
 @click.option('--from-profile')
-@cli_command('release', max_apps=0)
-def release_cmd(ctx, app_name, release_name=None, from_profile=None):
+@cli_command('release', max_apps=1)
+def release_cmd(ctx, release_name=None, from_profile=None):
     """Release an application to preview, staging or production.
 
     If releasing to preview:
@@ -24,7 +23,7 @@ def release_cmd(ctx, app_name, release_name=None, from_profile=None):
         just promote the current staging releasee to production.
 
     """
-    repository_path = build.clone_or_update(ctx.stacks[app_name].repo_url)
+    repository_path = build.clone_or_update(ctx.stacks[ctx.apps[0]].repo_url)
     if ctx.stage == "preview":
         success = release_to_preview(ctx, repository_path)
     elif ctx.stage == "staging":

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -53,8 +53,8 @@ def release_to_preview(ctx, repository_path):
     if build.tag_exists(repository_path, release_name):
         raise ValueError("Already have a tag for {}".format(release_name))
 
-    build.push_tag(repository_path, release_name)
     version, created = deploy.create_version(release_name)
+    build.push_tag(repository_path, release_name)
 
     return deploy.deploy(version, ctx.stage)
 

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -1,6 +1,7 @@
 import os
-import subprocess
 import collections
+import subprocess
+from subprocess import CalledProcessError
 
 import yaml
 import jinja2
@@ -12,7 +13,15 @@ def run_cmd(args, env=None, cwd=None, stdout=None):
     cmd_env.update(env or {})
     cmd = subprocess.Popen(args, env=cmd_env, cwd=cwd,
                            stdout=stdout, stderr=subprocess.STDOUT)
-    return cmd.communicate()[0]
+    streamdata = cmd.communicate()[0]
+    if cmd.returncode:
+        raise CalledProcessError(
+            cmd.returncode,
+            args,
+            output=streamdata
+        )
+
+    return streamdata
 
 
 def read_yaml_file(path):


### PR DESCRIPTION
Fix the `admin-frontend` `KeyError` and abort the build if the subprocess fails