### PR TITLE
Increase sleep between wait loops

### DIFF
--- a/dmaws/deploy.py
+++ b/dmaws/deploy.py
@@ -175,7 +175,7 @@ class BeanstalkClient(object):
                 raise BeanstalkStatusError(
                     "Unexpected Beanstalk status {}".format(info['Status']))
 
-            time.sleep(1)
+            time.sleep(5)
 
     def describe_environment(self, environment_name):
         response = self.conn.describe_environments(


### PR DESCRIPTION
When deploying to preview we have hit the API throttling limit when
waiting for the deploy to happen.