### PR TITLE
Fix deployed-to-{stage} tagging

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -73,18 +73,23 @@ def tag_exists(cwd, tag_name):
     return found_tag_name == tag_name
 
 
-def push_tag(cwd, tag_name, tag_message=None):
+def push_tag(cwd, tag_name, tag_message=None, force=False, ref=None):
     if tag_message is None:
         tag_message = tag_name
 
-    run_git_cmd(['tag', '-a', tag_name, '-m', tag_message],
-                cwd).strip()
-    run_git_cmd(['push', 'origin', tag_name],
-                cwd).strip()
+    create_tag = ['tag', '-a', tag_name, '-m', tag_message]
+    push_tag = ['push', 'origin', tag_name]
+    if ref is not None:
+        create_tag.append(ref)
+    if force:
+        create_tag.append('-f')
+        push_tag.append('-f')
+    run_git_cmd(create_tag, cwd).strip()
+    run_git_cmd(push_tag, cwd).strip()
 
 
-def push_deployed_to_tag(cwd, stage):
-    push_tag(cwd, 'deployed-to-{}'.format(stage))
+def push_deployed_to_tag(cwd, stage, ref):
+    push_tag(cwd, 'deployed-to-{}'.format(stage), force=True, ref=ref)
 
 
 def get_other_tags(cwd, tag):

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -25,18 +25,18 @@ def release_cmd(ctx, release_name=None, from_profile=None):
     """
     repository_path = build.clone_or_update(ctx.stacks[ctx.apps[0]].repo_url)
     if ctx.stage == "preview":
-        success = release_to_preview(ctx, repository_path)
+        success, release_name = release_to_preview(ctx, repository_path)
     elif ctx.stage == "staging":
-        success = release_to_staging(ctx, repository_path,
-                                     release_name, from_profile)
+        success, release_name = release_to_staging(ctx, repository_path,
+                                                   release_name, from_profile)
     elif ctx.stage == "production":
-        success = release_to_production(ctx, repository_path)
+        success, release_name = release_to_production(ctx, repository_path)
     else:
         raise ValueError("Invalid stage for release {}".format(ctx.stage))
 
     if not success:
         sys.exit(1)
-    build.push_deployed_to_tag(repository_path, ctx.stage)
+    build.push_deployed_to_tag(repository_path, ctx.stage, release_name)
 
 
 def get_deploy(ctx, repository_path):
@@ -56,7 +56,7 @@ def release_to_preview(ctx, repository_path):
     version, created = deploy.create_version(release_name)
     build.push_tag(repository_path, release_name)
 
-    return deploy.deploy(version)
+    return deploy.deploy(version), release_name
 
 
 def release_to_staging(ctx, repository_path, release_name, from_profile):
@@ -77,7 +77,7 @@ def release_to_staging(ctx, repository_path, release_name, from_profile):
 
         deploy.create_version(release_name, from_file=package_path)
 
-    return deploy.deploy(release_name)
+    return deploy.deploy(release_name), release_name
 
 
 def release_to_production(ctx, repository_path):
@@ -88,4 +88,4 @@ def release_to_production(ctx, repository_path):
     if release_tag is None:
         raise StandardError("Could not find release tag for staging")
 
-    return deploy.deploy(release_tag)
+    return deploy.deploy(release_tag), release_tag


### PR DESCRIPTION
- The tag must be force pushed because it already exists and we will be
  recreating it each time we deploy.
- When deploying to staging or production the repository will not, by
  default be on the tag we're releasing so we must tag the specific
  commit.