### PR TITLE
Add Route53 managed domains for all apps

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -33,6 +33,14 @@
     "EnvironmentName": {
       "Type": "String",
       "Description": "Elastic Beanstalk Environment name"
+    },
+    "Domain": {
+      "Type": "String",
+      "Description": "Domain to serve the Beanstalk environment from"
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "Route53 hosted zone name to serve the Beanstalk environment from"
     }
   },
 
@@ -102,6 +110,11 @@
           },
 {% endfor %}
           {
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "CrossZone",
+            "Value": true
+          },
+          {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
             "Value": {"Ref": "KeyName"}
@@ -148,6 +161,22 @@
         "TemplateName": {"Ref": "ConfigurationTemplate"},
         "Description": "Digital Marketplace EB Environment"
       }
+    },
+
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+            {"Ref": "Domain"}, "."
+          ]]
+        },
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+        ],
+        "TTL": "300"
+      }
     }
   },
 
@@ -161,7 +190,7 @@
       "Value": {
         "Fn::Join": ["", [
           "http://",
-          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+          {"Ref": "Domain"}
         ]]
       }
     }

--- a/cloudformation_templates/aws_digitalmarketplace_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_api.json
@@ -37,6 +37,14 @@
     "EnvironmentName": {
       "Type": "String",
       "Description": "Elastic Beanstalk Environment name"
+    },
+    "Domain": {
+      "Type": "String",
+      "Description": "Domain to serve the Beanstalk environment from"
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "Route53 hosted zone name to serve the Beanstalk environment from"
     }
   },
 
@@ -118,6 +126,11 @@
           },
 {% endfor %}
           {
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "CrossZone",
+            "Value": true
+          },
+          {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
             "Value": {"Ref": "KeyName"}
@@ -159,6 +172,22 @@
         "TemplateName": {"Ref": "ConfigurationTemplate"},
         "Description": "Digital Marketplace API Environment"
       }
+    },
+
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+            {"Ref": "Domain"}, "."
+          ]]
+        },
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+        ],
+        "TTL": "300"
+      }
     }
   },
 
@@ -172,7 +201,7 @@
       "Value": {
         "Fn::Join": ["", [
           "http://",
-          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+          {"Ref": "Domain"}
         ]]
       }
     }

--- a/cloudformation_templates/aws_digitalmarketplace_search_api.json
+++ b/cloudformation_templates/aws_digitalmarketplace_search_api.json
@@ -42,6 +42,14 @@
     "EnvironmentName": {
       "Type": "String",
       "Description": "Elastic Beanstalk Environment name"
+    },
+    "Domain": {
+      "Type": "String",
+      "Description": "Domain to serve the Beanstalk environment from"
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "Route53 hosted zone name to serve the Beanstalk environment from"
     }
   },
 
@@ -122,6 +130,11 @@
           },
 {% endfor %}
           {
+            "Namespace": "aws:elb:loadbalancer",
+            "OptionName": "CrossZone",
+            "Value": true
+          },
+          {
             "Namespace": "aws:autoscaling:launchconfiguration",
             "OptionName": "EC2KeyName",
             "Value": {"Ref": "KeyName"}
@@ -163,6 +176,22 @@
         "TemplateName": {"Ref": "ConfigurationTemplate"},
         "Description": "Digital Marketplace Search API Environment"
       }
+    },
+
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+            {"Ref": "Domain"}, "."
+          ]]
+        },
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+        ],
+        "TTL": "300"
+      }
     }
   },
 
@@ -176,7 +205,7 @@
       "Value": {
         "Fn::Join": ["", [
           "http://",
-          {"Fn::GetAtt": ["Environment", "EndpointURL"]}
+          {"Ref": "Domain"}
         ]]
       }
     }

--- a/cloudformation_templates/aws_route53_hosted_zone.json
+++ b/cloudformation_templates/aws_route53_hosted_zone.json
@@ -1,0 +1,27 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A public hosted zone for the given root domain.",
+
+  "Parameters": {
+    "RootDomain": {
+      "Type": "String",
+      "Description": "Root domain"
+    }
+  },
+
+  "Resources": {
+    "HostedZone": {
+      "Type": "AWS::Route53::HostedZone",
+      "Properties": {
+        "Name": {"Fn::Join": ["", [{"Ref": "RootDomain"}, "."]]}
+      }
+    }
+  },
+
+  "Outputs": {
+    "HostedZoneName": {
+      "Description": "Hosted zone name",
+      "Value": {"Fn::Join": ["", [{"Ref": "RootDomain"}, "."]]}
+    }
+  }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -23,6 +23,12 @@ dev_access:
   - database_dev_access
   - elasticsearch_dev_access
 
+route53zone:
+  name: "route53-zone"
+  template: cloudformation_templates/aws_route53_hosted_zone.json
+  parameters:
+    RootDomain: "{{ root_domain }}"
+
 database:
   name: "rds-database-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_rds_database.json
@@ -52,6 +58,7 @@ api:
   dependencies:
     - api_app
     - database
+    - route53zone
   parameters:
     ApplicationName: "{{ stacks.api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmapi-{{ stage[:3] }}-{{ environment }}"
@@ -66,6 +73,9 @@ api:
     MinInstanceCount: "{{ api.min_instance_count }}"
     MaxInstanceCount: "{{ api.max_instance_count }}"
     RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
+
+    Domain: "{{ stage }}-{{ environment }}-api.{{ root_domain }}"
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 database_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"
@@ -115,6 +125,7 @@ search_api:
   dependencies:
     - search_api_app
     - elasticsearch
+    - route53zone
   parameters:
     ApplicationName: "{{ stacks.search_api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmsearch-{{ stage[:3] }}-{{ environment }}"
@@ -131,6 +142,9 @@ search_api:
     ElasticsearchPort: "{{ elasticsearch.port }}"
     ElasticsearchSecurityGroup: "{{ stacks.elasticsearch.outputs.LoadBalancerSecurityGroup }}"
 
+    Domain: "{{ stage }}-{{ environment }}-search-api.{{ root_domain }}"
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
 admin_frontend_app:
   name: "digitalmarketplace-admin-frontend-app"
   template: cloudformation_templates/aws_elasticbeanstalk_app.json
@@ -145,6 +159,7 @@ admin_frontend:
     - documents_s3
     - api
     - admin_frontend_app
+    - route53zone
   parameters:
     ApplicationName: "{{ stacks.admin_frontend_app.parameters.ApplicationName }}"
     EnvironmentName: "dmadmin-{{ stage[:3] }}-{{ environment }}"
@@ -161,3 +176,6 @@ admin_frontend:
     InstanceType: "{{ admin_frontend.instance_type }}"
     MinInstanceCount: "{{ admin_frontend.min_instance_count }}"
     MaxInstanceCount: "{{ admin_frontend.max_instance_count }}"
+
+    Subdomain: "{{ stage }}-{{ environment }}-admin.{{ root_domain }}"
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -1,4 +1,5 @@
 ---
+root_domain: "development.digitalmarketplace.service.gov.uk"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,4 +1,5 @@
 ---
+root_domain: "development.digitalmarketplace.service.gov.uk"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,4 +1,5 @@
 ---
+root_domain: "digitalmarketplace.service.gov.uk"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,1 +1,2 @@
 ---
+root_domain: "digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
Create a Route53 zone and then create domains for each app of the form
`{ stage }-{ environment }-{ app name }.{ root domain }`

This is a precursor to setting up SSL and CloudFront.