### PR TITLE
Add loaddata command and some related changes

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -11,7 +11,7 @@
     },
 {% endfor %}
     "KeyName": {
-      "Type": "String",
+      "Type": "AWS::EC2::KeyPair::KeyName",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
     },
     "ApplicationName": {

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -16,7 +16,7 @@
       "Description": "List of subnets for internal ELB"
     },
     "KeyName": {
-      "Type": "String",
+      "Type": "AWS::EC2::KeyPair::KeyName",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
     },
     "SSHCidrIp": {

--- a/dmaws/commands/deploy.py
+++ b/dmaws/commands/deploy.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from ..cli import cli_command
@@ -17,4 +19,9 @@ def deploy_cmd(ctx, repository_path):
     deploy = StackPlan.from_ctx(ctx).get_deploy(repository_path)
 
     version, created = deploy.create_version(app, with_sha=True)
-    deploy.deploy(version)
+    url = deploy.deploy(version)
+
+    if not url:
+        sys.exit(1)
+
+    ctx.log("URL: http://%s/", url)

--- a/dmaws/commands/loaddata.py
+++ b/dmaws/commands/loaddata.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+import click
+import boto.ec2
+import requests
+
+from ..cli import cli_command
+from ..stacks import StackPlan
+from ..utils import run_cmd
+
+from ..deploy import S3Client
+
+LOADDATA_BUCKET = 'digitalmarketplace-dev-loaddata'
+
+
+@cli_command('loaddata', max_apps=0)
+@click.argument('api_repo_path')
+@click.argument('tasks', nargs=-1)
+def loaddata_cmd(ctx, api_repo_path, tasks):
+    """Load test data for development or preview environment."""
+
+    if not tasks:
+        tasks = ['database', 'search']
+
+    plan = StackPlan.from_ctx(ctx, apps=['dev_access'])
+
+    status = plan.create(create_dependencies=False)
+    if not status:
+        sys.exit(1)
+
+    plan.info(['api'])
+
+    elasticsearch_ip = get_tagged_ec2_instances(
+        ctx.variables['aws_region'],
+        'elasticsearch-{}-{}'.format(ctx.stage, ctx.environment)
+    )[0].ip_address
+
+    db_path = "postgres://{}:{}@{}".format(
+        plan.get_value('database.user'),
+        plan.get_value('database.password'),
+        plan.get_value('stacks.database.outputs.URL')
+    )
+
+    s3 = S3Client(ctx.variables['aws_region'], logger=ctx.log)
+    dump_file = s3.download_package(LOADDATA_BUCKET,
+                                    'digitalmarketplace_dev.dump')
+
+    if 'database' in tasks:
+        ctx.log('Inserting data into the database')
+        run_cmd([
+            'psql', '-d', db_path, '-f', dump_file
+        ], ignore_errors=True)
+
+    if 'search' in tasks:
+        ctx.log('Creating Elasticsearch index')
+        es_endpoint = 'http://{}:9200/services/'.format(elasticsearch_ip)
+        requests.put(es_endpoint)
+
+        ctx.log('Inserting data into Elasticsearch')
+        run_cmd([
+            './scripts/process-g6-into-elastic-search.py',
+            es_endpoint,
+            plan.get_value('stacks.api.outputs.URL') + '/services',
+            plan.get_value('api.auth_tokens')[0]
+        ], cwd=api_repo_path, ignore_errors=True)
+
+    os.remove(dump_file)
+    plan.delete()
+
+
+def get_tagged_ec2_instances(region, tag):
+    ec2 = boto.ec2.connect_to_region(region)
+    reservations = ec2.get_all_instances(filters={
+        "tag:Group": tag
+    })
+    instances = [i for r in reservations for i in r.instances]
+
+    return instances

--- a/dmaws/commands/loaddata.py
+++ b/dmaws/commands/loaddata.py
@@ -50,7 +50,7 @@ def loaddata_cmd(ctx, api_repo_path, tasks):
         ctx.log('Inserting data into the database')
         run_cmd([
             'psql', '-d', db_path, '-f', dump_file
-        ], ignore_errors=True)
+        ], logger=ctx.log, ignore_errors=True)
 
     if 'search' in tasks:
         ctx.log('Creating Elasticsearch index')
@@ -63,7 +63,7 @@ def loaddata_cmd(ctx, api_repo_path, tasks):
             es_endpoint,
             plan.get_value('stacks.api.outputs.URL') + '/services',
             plan.get_value('api.auth_tokens')[0]
-        ], cwd=api_repo_path, ignore_errors=True)
+        ], cwd=api_repo_path, logger=ctx.log, ignore_errors=True)
 
     os.remove(dump_file)
     plan.delete()

--- a/dmaws/deploy.py
+++ b/dmaws/deploy.py
@@ -178,7 +178,7 @@ class BeanstalkClient(object):
                 self.log('Environment status is now %s', info['Status'])
                 last_status = info['Status']
             if info['Status'] == 'Ready':
-                return success
+                return success and info['CNAME']
             elif info['Status'] != 'Updating':
                 raise BeanstalkStatusError(
                     "Unexpected Beanstalk status {}".format(info['Status']))

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -93,8 +93,9 @@ class StackPlan(object):
             raise ValueError("'stacks' is a reserved variable name")
         self.stack_context['stacks'] = {}
 
-    def stacks(self, with_dependencies=False):
-        return get_stacks(self._stacks, self.apps, with_dependencies)
+    def stacks(self, apps=None, with_dependencies=False):
+        apps = sorted(flatten_stack_groups(self._stacks, apps or self.apps))
+        return get_stacks(self._stacks, apps or self.apps, with_dependencies)
 
     def dependant_stacks(self):
         return get_stacks(
@@ -114,8 +115,8 @@ class StackPlan(object):
                 vars_dict = getattr(vars_dict, key)
         return vars_dict
 
-    def info(self, with_aws=True):
-        stacks = self.stacks(with_dependencies=True)
+    def info(self, apps=None, with_aws=True):
+        stacks = self.stacks(apps, with_dependencies=True)
         self.log('Gathering info about %s stacks',
                  ', '.join(s[0] for s in stacks))
 

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -105,6 +105,15 @@ class StackPlan(object):
     def build_stack(self, stack):
         return stack.build(self.stage, self.environment, self.stack_context)
 
+    def get_value(self, path):
+        vars_dict = self.stack_context
+        for key in path.split('.'):
+            try:
+                vars_dict = vars_dict[key]
+            except TypeError:
+                vars_dict = getattr(vars_dict, key)
+        return vars_dict
+
     def info(self, with_aws=True):
         stacks = self.stacks(with_dependencies=True)
         self.log('Gathering info about %s stacks',

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -8,12 +8,17 @@ import jinja2
 from jinja2.runtime import StrictUndefined
 
 
-def run_cmd(args, env=None, cwd=None, stdout=None, ignore_errors=False):
+def run_cmd(args, env=None, cwd=None, stdout=None,
+            logger=None, ignore_errors=False):
     cmd_env = os.environ.copy()
     cmd_env.update(env or {})
+    if logger:
+        logger("Running %s", args[0])
     cmd = subprocess.Popen(args, env=cmd_env, cwd=cwd,
                            stdout=stdout, stderr=subprocess.STDOUT)
     streamdata = cmd.communicate()[0]
+    if logger:
+        logger("%s completed with return code %s", args[0], cmd.returncode)
     if cmd.returncode and not ignore_errors:
         raise CalledProcessError(
             cmd.returncode,

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -8,13 +8,13 @@ import jinja2
 from jinja2.runtime import StrictUndefined
 
 
-def run_cmd(args, env=None, cwd=None, stdout=None):
+def run_cmd(args, env=None, cwd=None, stdout=None, ignore_errors=False):
     cmd_env = os.environ.copy()
     cmd_env.update(env or {})
     cmd = subprocess.Popen(args, env=cmd_env, cwd=cwd,
                            stdout=stdout, stderr=subprocess.STDOUT)
     streamdata = cmd.communicate()[0]
-    if cmd.returncode:
+    if cmd.returncode and not ignore_errors:
         raise CalledProcessError(
             cmd.returncode,
             args,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ click==3.3
 Jinja2==2.7.3
 PyYAML==3.11
 toposort==1.1
+
+# loaddata dependencies
+requests==2.6.0


### PR DESCRIPTION
Downloads a database dump from S3 and runs it on the environment RDS instance.

Runs Elasticsearch import script from the digitalmarketplace-api repository with environment API and Elasticsearch as arguments.

A lot of this will change once we have write endpoints on api and search-api that would allow loading data throught them instead of using the databases directly.