### PR TITLE
Add cloudfront for API and Admin frontend.

### DIFF
--- a/cloudformation_templates/aws_cloudfront_app.json
+++ b/cloudformation_templates/aws_cloudfront_app.json
@@ -1,0 +1,83 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Digital Marketplace Application CloudFront Distribution",
+
+  "Parameters": {
+    "Origin": {
+      "Type": "String",
+      "Description": "The origin domain for the upstream application."
+    },
+    "Domain": {
+      "Type": "String",
+      "Description": "The domain CloudFront should serve off."
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "The Route53 hosted zone"
+    },
+    "LogsBucket": {
+      "Type": "String",
+      "Description": "S3 bucket name for the logs"
+    }
+  },
+
+  "Resources": {
+    "CloudFrontDistribution": {
+      "Type": "AWS::CloudFront::Distribution",
+      "Properties": {
+        "DistributionConfig": {
+          "Origins": [
+            {
+              "DomainName": {"Ref": "Origin"},
+              "Id": "OriginId",
+              "CustomOriginConfig": {
+                "HTTPPort": "80",
+                "OriginProtocolPolicy": "http-only"
+              }
+            }
+          ],
+          "Enabled": true,
+          "Logging": {
+            "IncludeCookies": false,
+            "Bucket": {"Ref": "LogsBucket"},
+            "Prefix": {
+              "Fn::Join": ["", [
+                "cloudfront/",
+                {"Ref": "Domain"},
+                "/"
+              ]]
+            }
+          },
+
+          "Aliases": [ {"Ref": "Domain"} ],
+
+          "DefaultCacheBehavior": {
+            "TargetOriginId": "OriginId",
+            "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
+            "ViewerProtocolPolicy": "allow-all",
+            "SmoothStreaming": false,
+            "ForwardedValues": {
+              "Headers": ["Authorization", "Host"],
+              "QueryString": true
+            }
+          },
+          "PriceClass": "PriceClass_100"
+        }
+      }
+    },
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+            {"Ref": "Domain"}, "."]]
+        },
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["CloudFrontDistribution", "DomainName"]}
+        ],
+        "TTL": "300"
+      }
+    }
+  }
+}

--- a/cloudformation_templates/aws_cloudfront_www.json
+++ b/cloudformation_templates/aws_cloudfront_www.json
@@ -1,0 +1,82 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Digital Marketplace WWW CloudFront Distribution",
+
+  "Parameters": {
+    "AdminOrigin": {
+      "Type": "String",
+      "Description": "The origin domain for the admin frontend app."
+    },
+    "Domain": {
+      "Type": "String",
+      "Description": "The domain that CloudFront should serve off."
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "The Route53 hosted zone"
+    },
+    "LogsBucket": {
+      "Type": "String",
+      "Description": "S3 bucket name for the logs"
+    }
+  },
+
+  "Resources": {
+    "WWWCloudFrontDistribution": {
+      "Type": "AWS::CloudFront::Distribution",
+      "Properties": {
+        "DistributionConfig": {
+          "Origins": [
+            {
+              "DomainName": {"Ref": "AdminOrigin"},
+              "Id": "AdminOriginId",
+              "CustomOriginConfig": {
+                "HTTPPort": "80",
+                "OriginProtocolPolicy": "http-only"
+              }
+            }
+          ],
+          "Enabled": true,
+          "Logging": {
+            "IncludeCookies": false,
+            "Bucket": {"Ref": "LogsBucket"},
+            "Prefix": {
+              "Fn::Join": ["", [
+                "cloudfront/",
+                {"Ref": "Domain"},
+                "/"
+              ]]
+            }
+          },
+
+          "Aliases": [ {"Ref": "Domain"} ],
+
+          "DefaultCacheBehaviour": {
+            "TargetOriginId": "AdminOriginId",
+            "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
+            "ViewerProtocolPolicy": "allow-all",
+            "SmoothStreaming": false,
+            "ForwardedValues": {
+              "Headers": ["Authorization", "Host"],
+              "QueryString": true
+            }
+          }
+        }
+      }
+    },
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+            {"Ref": "Domain"}, "."]]
+        },
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["CloudFrontDistribution", "DomainName"]}
+        ],
+        "TTL": "300"
+      }
+    }
+  }
+}

--- a/cloudformation_templates/aws_s3.json
+++ b/cloudformation_templates/aws_s3.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "S3 bucket for Digital Marketplace documents",
+  "Description": "S3 bucket",
   "Parameters": {
     "BucketName": {
       "Type": "String",
@@ -22,6 +22,10 @@
     "Name": {
       "Description": "S3 bucket name",
       "Value": {"Ref": "S3Bucket"}
+    },
+    "Domain": {
+      "Description": "S3 bucket domain name",
+      "Value": {"Fn::GetAtt": ["S3Bucket", "DomainName"]}
     },
     "URL" : {
       "Value" : {"Fn::Join": ["", [

--- a/stacks.yml
+++ b/stacks.yml
@@ -96,7 +96,7 @@ api_cloudfront:
     - logs_s3
   parameters:
     Origin: "{{ stacks.api.parameters.Domain }}"
-    Domain: "{% if stage != 'production' %}{{ stage }}-{% endif %}api.{{ root_domain }}"
+    Domain: "{% if stage != 'production' %}{{ stage }}-cloudfront-{% endif %}api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"
 
@@ -211,6 +211,6 @@ www_cloudfront:
     - logs_s3
   parameters:
     Origin: "{{ stacks.api.parameters.Domain }}"
-    Domain: "{% if stage != 'production' %}{{ stage }}-{% endif %}www.{{ root_domain }}"
+    Domain: "{% if stage != 'production' %}{{ stage }}-cloudfront-{% endif %}www.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -16,6 +16,7 @@ eb_apps:
 
 cloudfront:
   - api_cloudfront
+  - www_cloudfront
 
 data_storage:
   - database
@@ -201,3 +202,15 @@ admin_frontend:
 
     Domain: "{{ stage }}-{{ environment }}-admin-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
+www_cloudfront:
+  name: "digitalmarketplace-www-cloudfront-{{ stage }}"
+  template: cloudformation_templates/aws_cloudfront_www.json
+  dependencies:
+    - admin_frontend
+    - logs_s3
+  parameters:
+    Origin: "{{ stacks.api.parameters.Domain }}"
+    Domain: "{% if stage != 'production' %}{{ stage }}-{% endif %}www.{{ root_domain }}"
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -14,9 +14,13 @@ eb_apps:
   - search_api_app
   - admin_frontend_app
 
+cloudfront:
+  - api_cloudfront
+
 data_storage:
   - database
   - documents_s3
+  - logs_s3
   - elasticsearch
 
 dev_access:
@@ -44,6 +48,12 @@ documents_s3:
   template: cloudformation_templates/aws_s3.json
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
+
+logs_s3:
+  name: "logs-s3-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_s3.json
+  parameters:
+    BucketName: "digitalmarketplace-logs-{{ stage }}-{{ environment }}"
 
 api_app:
   name: "digitalmarketplace-api-app"
@@ -76,6 +86,18 @@ api:
 
     Domain: "{{ stage }}-{{ environment }}-api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
+api_cloudfront:
+  name: "digitalmarketplace-api-cloudfront-{{ stage }}"
+  template: cloudformation_templates/aws_cloudfront_app.json
+  dependencies:
+    - api
+    - logs_s3
+  parameters:
+    Origin: "{{ stacks.api.parameters.Domain }}"
+    Domain: "{% if stage != 'production' %}{{ stage }}-{% endif %}api.{{ root_domain }}"
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"
 
 database_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"

--- a/stacks.yml
+++ b/stacks.yml
@@ -41,7 +41,7 @@ database:
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"
-  template: cloudformation_templates/aws_documents_s3.json
+  template: cloudformation_templates/aws_s3.json
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
 


### PR DESCRIPTION
- This is HTTP only until we can get the necessary SSL certificates.
- PriceClass_100 only includes edge locations in the US and Europe. Given
  most of our customers are UK this cheapest option seems sensible.
- All methods are allowed because CloudFormation only allows two
  options, [GET, OPTIONS] or everything and we need POSTing.
- As we only have one frontend app at the moment it is set as the
  DefaultCacheBehaviour. Admin should not ultimately be the default.