### PR TITLE
Add Beanstalk configoptions for rolling deploy

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -153,6 +153,21 @@
             "Namespace": "aws:elb:loadbalancer",
             "OptionName": "CrossZone",
             "Value": true
+          },
+          {
+            "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+            "OptionName": "RollingUpdateEnabled",
+            "Value": true
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:command",
+            "OptionName": "BatchSize",
+            "Value": "1"
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:command",
+            "OptionName": "BatchSizeType",
+            "Value": "Fixed"
           }
         ]
       }


### PR DESCRIPTION
This ensures that deploys only go out to one instance at a time.
See:
http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html

I have tested this by increasing the number of instances and running a
deploy while providing constant load with vegeta. When the app is
experiencing no load the deploys appear to overlap. However, when there
is load and these configuration options are set there are no 504s. When
these options are not set there are a small number of 504s (3%).