### PR TITLE
Release existing version to preview

### DIFF
--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -50,6 +50,11 @@ def release_to_preview(ctx, repository_path):
     deploy = get_deploy(ctx, repository_path)
 
     release_name = build.get_release_name_for_repo(repository_path)
+
+    if deploy.version_exists(release_name):
+        ctx.log('Redeploying existing version %s', release_name)
+        return deploy.deploy(release_name), release_name
+
     if build.tag_exists(repository_path, release_name):
         raise ValueError("Already have a tag for {}".format(release_name))
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.1',
     packages=find_packages(),
     description='Digital Marketplace AWS deployment scripts',
-    licence='MIT',
+    license='MIT',
 
     install_requires=install_requires,
 


### PR DESCRIPTION
If preview release failed to deploy for some reason, rerunning the task would fail when creating the release tag.

Instead, if the current release version already exists the release command will use it for the EB deploy process.