### PR TITLE
Add the supplier and admin frontends to cloudfront

### DIFF
--- a/cloudformation_templates/aws_cloudfront_www.json
+++ b/cloudformation_templates/aws_cloudfront_www.json
@@ -7,6 +7,14 @@
       "Type": "String",
       "Description": "The origin domain for the admin frontend app."
     },
+    "BuyerOrigin": {
+      "Type": "String",
+      "Description": "The origin domain for the buyer frontend app."
+    },
+    "SupplierOrigin": {
+      "Type": "String",
+      "Description": "The origin domain for the supplier frontend app."
+    },
     "Domain": {
       "Type": "String",
       "Description": "The domain that CloudFront should serve off."
@@ -34,6 +42,22 @@
                 "HTTPPort": "80",
                 "OriginProtocolPolicy": "http-only"
               }
+            },
+            {
+              "DomainName": {"Ref": "BuyerOrigin"},
+              "Id": "BuyerOriginId",
+              "CustomOriginConfig": {
+                "HTTPPort": "80",
+                "OriginProtocolPolicy": "http-only"
+              }
+            },
+            {
+              "DomainName": {"Ref": "SupplierOrigin"},
+              "Id": "SupplierOriginId",
+              "CustomOriginConfig": {
+                "HTTPPort": "80",
+                "OriginProtocolPolicy": "http-only"
+              }
             }
           ],
           "Enabled": true,
@@ -52,7 +76,7 @@
           "Aliases": [ {"Ref": "Domain"} ],
 
           "DefaultCacheBehaviour": {
-            "TargetOriginId": "AdminOriginId",
+            "TargetOriginId": "BuyerOriginId",
             "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
             "ViewerProtocolPolicy": "allow-all",
             "SmoothStreaming": false,
@@ -60,7 +84,32 @@
               "Headers": ["Authorization", "Host"],
               "QueryString": true
             }
-          }
+          },
+
+          "CacheBehaviours": [
+            {
+              "TargetOriginId": "SupplierOriginId",
+              "PathPattern": "/supplier",
+              "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
+              "ViewerProtocolPolicy": "allow-all",
+              "SmoothStreaming": false,
+              "ForwardedValues": {
+                "Headers": ["Authorization", "Host"],
+                "QueryString": true
+              }
+            },
+            {
+              "TargetOriginId": "AdminOriginId",
+              "PathPattern": "/admin",
+              "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
+              "ViewerProtocolPolicy": "allow-all",
+              "SmoothStreaming": false,
+              "ForwardedValues": {
+                "Headers": ["Authorization", "Host"],
+                "QueryString": true
+              }
+            }
+          ]
         }
       }
     },

--- a/stacks.yml
+++ b/stacks.yml
@@ -279,9 +279,13 @@ www_cloudfront:
   template: cloudformation_templates/aws_cloudfront_www.json
   dependencies:
     - admin_frontend
+    - buyer_frontend
+    - supplier_frontend
     - logs_s3
   parameters:
-    Origin: "{{ stacks.api.parameters.Domain }}"
+    AdminOrigin: "{{ stacks.admin_frontend.parameters.Domain }}"
+    BuyerOrigin: "{{ stacks.buyer_frontend.parameters.Domain }}"
+    SupplierOrigin: "{{ stacks.supplier_frontend.parameters.Domain }}"
     Domain: "{% if stage != 'production' %}{{ stage }}-cloudfront-{% endif %}www.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"


### PR DESCRIPTION
This changes the byers app to be the default origin. It also serves the supplier app under `/supplier` and the admin app under `/admin`. During the architecture meeting we seemed to all agree that the admin app should live on a subdomain rather than through CloudFront. What was the consensus on that (cc/ @minglis).

This has some implications for the supplier and admin apps. All their routes must be under `/supplier` and `/admin` respectively or they will not work through the www sub-domain. This will require some changes.