### PR TITLE
Stage-only CNAME for main stage environments

### DIFF
--- a/dmaws/commands/debug.py
+++ b/dmaws/commands/debug.py
@@ -1,0 +1,26 @@
+import click
+
+from ..cli import cli_command
+from ..stacks import StackPlan
+
+
+@cli_command('debug-value', max_apps=0)
+@click.argument('values', nargs=-1)
+def debug_value_cmd(ctx, values):
+    """Get values of the given dotted variables."""
+
+    plan = StackPlan.from_ctx(ctx, apps=['all'], logger=None)
+    plan.info(with_aws=False)
+
+    for value in values:
+        ctx.log("%s: %s", value, plan.get_value(value))
+
+
+@cli_command('debug-template', max_apps=1)
+def debug_template_cmd(ctx):
+    """Print the app CloudFormation template after Jinja processing."""
+    plan = StackPlan.from_ctx(ctx, logger=None)
+
+    for name, stack in plan.stacks(with_dependencies=False):
+        built_stack = plan.build_stack(stack)
+        ctx.log(built_stack.template_body)

--- a/stacks.yml
+++ b/stacks.yml
@@ -89,7 +89,7 @@ api:
     MaxInstanceCount: "{{ api.max_instance_count }}"
     RDSSecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
 
-    Domain: "{{ stage }}-{{ environment }}-api.{{ root_domain }}"
+    Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 api_cloudfront:
@@ -169,7 +169,7 @@ search_api:
     ElasticsearchPort: "{{ elasticsearch.port }}"
     ElasticsearchSecurityGroup: "{{ stacks.elasticsearch.outputs.LoadBalancerSecurityGroup }}"
 
-    Domain: "{{ stage }}-{{ environment }}-search-api.{{ root_domain }}"
+    Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-search-api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 admin_frontend_app:
@@ -204,7 +204,7 @@ admin_frontend:
     MinInstanceCount: "{{ admin_frontend.min_instance_count }}"
     MaxInstanceCount: "{{ admin_frontend.max_instance_count }}"
 
-    Domain: "{{ stage }}-{{ environment }}-admin-frontend.{{ root_domain }}"
+    Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-admin-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 buyer_frontend_app:
@@ -239,7 +239,7 @@ buyer_frontend:
     MinInstanceCount: "{{ buyer_frontend.min_instance_count }}"
     MaxInstanceCount: "{{ buyer_frontend.max_instance_count }}"
 
-    Domain: "{{ stage }}-{{ environment }}-buyer-frontend.{{ root_domain }}"
+    Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-buyer-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 supplier_frontend_app:
@@ -271,7 +271,7 @@ supplier_frontend:
     MinInstanceCount: "{{ supplier_frontend.min_instance_count }}"
     MaxInstanceCount: "{{ supplier_frontend.max_instance_count }}"
 
-    Domain: "{{ stage }}-{{ environment }}-supplier-frontend.{{ root_domain }}"
+    Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-supplier-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
 www_cloudfront:


### PR DESCRIPTION
`preview-preview-<app>.domain` becomes `preview-<app>.domain`, while `preview-master-<app>.domain` will still keep the environment.

Won't clash with cloudfront in preview/staging thanks to the `-cloudfront` CNAME suffix.
Won't clash with production cloudfront since the apps will still have the `production-` prefix.