### PR TITLE
Glob path patterns for WWW distribution

### DIFF
--- a/cloudformation_templates/aws_cloudfront_www.json
+++ b/cloudformation_templates/aws_cloudfront_www.json
@@ -89,7 +89,7 @@
           "CacheBehaviors": [
             {
               "TargetOriginId": "SupplierOriginId",
-              "PathPattern": "/supplier",
+              "PathPattern": "/supplier*",
               "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
               "ViewerProtocolPolicy": "allow-all",
               "SmoothStreaming": false,
@@ -100,7 +100,7 @@
             },
             {
               "TargetOriginId": "AdminOriginId",
-              "PathPattern": "/admin",
+              "PathPattern": "/admin*",
               "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
               "ViewerProtocolPolicy": "allow-all",
               "SmoothStreaming": false,


### PR DESCRIPTION
A path pattern of `/admin` will just match the path `/admin`. If we need to match all paths starting with `/admin` it needs to be `/admin*`.