### PR TITLE
Set static URL prefixes for admin and supplier apps

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -146,7 +146,7 @@
 {% endfor %}
           {
             "Namespace": "aws:elasticbeanstalk:container:python:staticfiles",
-            "OptionName": "/static/",
+            "OptionName": "{% block static_url %}/static/{% endblock %}",
             "Value": "app/static/"
           },
           {

--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -1,1 +1,3 @@
 {% extends "app_base.j2" %}
+
+{% block static_url %}/admin/static/{% endblock %}

--- a/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
@@ -1,1 +1,3 @@
 {% extends "app_base.j2" %}
+
+{% block static_url %}/supplier/static/{% endblock %}


### PR DESCRIPTION
http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html
docs mention that the /static/ option name can be any arbitrary value.

Uses template block since there's no parameter that has the correct
value and the admin/supplier paths are hardcoded in the CloudFront template.