### PR TITLE
Add CloudWatch logs

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -84,6 +84,19 @@
                 "cloudwatch:PutMetricData"
               ],
               "Resource": "*"
+            }, {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:GetLogEvents",
+                "logs:PutLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                "arn:aws:logs:eu-west-1:*:*"
+              ]
             }]
           }
         }]
@@ -148,6 +161,11 @@
             "Namespace": "aws:elasticbeanstalk:container:python:staticfiles",
             "OptionName": "/static/",
             "Value": "app/static/"
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:hostmanager",
+            "OptionName": "LogPublicationControl",
+            "Value": "true"
           },
           {
             "Namespace": "aws:elb:loadbalancer",

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -41,6 +41,10 @@
     "MaxInstanceCount": {
       "Type": "Number",
       "Description": "MaxSize of the Auto Scaling group"
+    },
+    "LogGroupName": {
+      "Type": "String",
+      "Description": "Name of CloudWatch log group"
     }{%- if self.parameters() %},
     {% endif %}
 
@@ -87,7 +91,6 @@
             }, {
               "Effect": "Allow",
               "Action": [
-                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:GetLogEvents",
                 "logs:PutLogEvents",
@@ -186,6 +189,11 @@
             "Namespace": "aws:elasticbeanstalk:command",
             "OptionName": "BatchSizeType",
             "Value": "Fixed"
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:customoption",
+            "OptionName": "LogGroupName",
+            "Value": {"Ref": "LogGroupName"}
           }
         ]
       }

--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -1,0 +1,32 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Monitoring log group",
+
+  "Parameters": {
+    "LogGroupName": {
+      "Type": "String",
+      "Description": "The log group name"
+    },
+    "RetentionInDays": {
+      "Type": "Number",
+      "Description": "Number of days logs should be kept before being deleted."
+    }
+  },
+
+  "Resources": {
+    "LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {"Ref": "LogGroupName"},
+        "RetentionInDays": {"Ref": "RetentionInDays"}
+      }
+    }
+  },
+
+  "Outputs": {
+    "LogGroupName": {
+      "Description": "Log group",
+      "Value": {"Ref": "LogGroup"}
+    }
+  }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -60,6 +60,13 @@ logs_s3:
   parameters:
     BucketName: "digitalmarketplace-logs-{{ stage }}-{{ environment }}"
 
+monitoring:
+  name: "monitoring-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_monitoring.json
+  parameters:
+    LogGroupName: "{{ stage }}-{{ environment }}"
+    RetentionInDays: 3653
+
 api_app:
   name: "digitalmarketplace-api-app"
   template: cloudformation_templates/aws_elasticbeanstalk_app.json
@@ -74,6 +81,7 @@ api:
     - api_app
     - database
     - route53zone
+    - monitoring
   parameters:
     ApplicationName: "{{ stacks.api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmapi-{{ stage[:3] }}-{{ environment }}"
@@ -91,6 +99,10 @@ api:
 
     Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+
+
 
 api_cloudfront:
   name: "digitalmarketplace-api-cloudfront-{{ stage }}"
@@ -154,6 +166,7 @@ search_api:
     - search_api_app
     - elasticsearch
     - route53zone
+    - monitoring
   parameters:
     ApplicationName: "{{ stacks.search_api_app.parameters.ApplicationName }}"
     EnvironmentName: "dmsearch-{{ stage[:3] }}-{{ environment }}"
@@ -173,6 +186,8 @@ search_api:
     Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-search-api.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+
 admin_frontend_app:
   name: "digitalmarketplace-admin-frontend-app"
   template: cloudformation_templates/aws_elasticbeanstalk_app.json
@@ -188,6 +203,7 @@ admin_frontend:
     - api
     - admin_frontend_app
     - route53zone
+    - monitoring
   parameters:
     ApplicationName: "{{ stacks.admin_frontend_app.parameters.ApplicationName }}"
     EnvironmentName: "dmadmin-{{ stage[:3] }}-{{ environment }}"
@@ -208,6 +224,8 @@ admin_frontend:
     Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-admin-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+
 buyer_frontend_app:
   name: "digitalmarketplace-buyer-frontend-app"
   template: cloudformation_templates/aws_elasticbeanstalk_app.json
@@ -224,6 +242,7 @@ buyer_frontend:
     - search_api
     - buyer_frontend_app
     - route53zone
+    - monitoring
   parameters:
     ApplicationName: "{{ stacks.buyer_frontend_app.parameters.ApplicationName }}"
     EnvironmentName: "dmbuyer-{{ stage[:3] }}-{{ environment }}"
@@ -243,6 +262,8 @@ buyer_frontend:
     Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-buyer-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+
 supplier_frontend_app:
   name: "digitalmarketplace-supplier-frontend-app"
   template: cloudformation_templates/aws_elasticbeanstalk_app.json
@@ -258,6 +279,7 @@ supplier_frontend:
     - api
     - supplier_frontend_app
     - route53zone
+    - monitoring
   parameters:
     ApplicationName: "{{ stacks.supplier_frontend_app.parameters.ApplicationName }}"
     EnvironmentName: "dmsuppl-{{ stage[:3] }}-{{ environment }}"
@@ -274,6 +296,8 @@ supplier_frontend:
 
     Domain: "{{ stage }}{% if stage != environment %}-{{ environment }}{% endif %}-supplier-frontend.{{ root_domain }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
 
 www_cloudfront:
   name: "digitalmarketplace-www-cloudfront-{{ stage }}"


### PR DESCRIPTION
This change gives the beanstalk EC2 instances access to write log events to CloudWatch and also creates the CloudWatch log group to be used by all apps in the environment.