### PR TITLE
Add logs:CreateLogGroup permission to EB instances

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -91,6 +91,7 @@
             }, {
               "Effect": "Allow",
               "Action": [
+                "logs:CreateLogGroup",
                 "logs:CreateLogStream",
                 "logs:GetLogEvents",
                 "logs:PutLogEvents",


### PR DESCRIPTION
The awslogs daemon is failing because it does not have this permission.
This permission was originally removed because we're creating the log group
in our CloudFormation code.