### PR TITLE
Serve CloudFront over SSL

### DIFF
--- a/cloudformation_templates/aws_cloudfront_app.json
+++ b/cloudformation_templates/aws_cloudfront_app.json
@@ -58,7 +58,7 @@
           "DefaultCacheBehavior": {
             "TargetOriginId": "OriginId",
             "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
             "SmoothStreaming": false,
             "ForwardedValues": {
               "Headers": ["Authorization", "Host"],

--- a/cloudformation_templates/aws_cloudfront_app.json
+++ b/cloudformation_templates/aws_cloudfront_app.json
@@ -18,6 +18,10 @@
     "LogsBucket": {
       "Type": "String",
       "Description": "S3 bucket name for the logs"
+    },
+    "IamCertificateId": {
+      "Type": "String",
+      "Description": "IAM SSL certificate ID"
     }
   },
 
@@ -32,7 +36,7 @@
               "Id": "OriginId",
               "CustomOriginConfig": {
                 "HTTPPort": "80",
-                "OriginProtocolPolicy": "http-only"
+                "OriginProtocolPolicy": "match-viewer"
               }
             }
           ],
@@ -61,7 +65,12 @@
               "QueryString": true
             }
           },
-          "PriceClass": "PriceClass_100"
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": {
+            "IamCertificateId": {"Ref": "IamCertificateId"},
+            "SslSupportMethod": "sni-only",
+            "MinimumProtocolVersion": "TLSv1"
+          }
         }
       }
     },

--- a/cloudformation_templates/aws_cloudfront_www.json
+++ b/cloudformation_templates/aws_cloudfront_www.json
@@ -26,6 +26,10 @@
     "LogsBucket": {
       "Type": "String",
       "Description": "S3 bucket name for the logs"
+    },
+    "IamCertificateId": {
+      "Type": "String",
+      "Description": "IAM SSL certificate ID"
     }
   },
 
@@ -40,7 +44,7 @@
               "Id": "AdminOriginId",
               "CustomOriginConfig": {
                 "HTTPPort": "80",
-                "OriginProtocolPolicy": "http-only"
+                "OriginProtocolPolicy": "match-viewer"
               }
             },
             {
@@ -85,7 +89,6 @@
               "QueryString": true
             }
           },
-
           "CacheBehaviors": [
             {
               "TargetOriginId": "SupplierOriginId",
@@ -111,7 +114,13 @@
                 "QueryString": true
               }
             }
-          ]
+          ],
+          "PriceClass": "PriceClass_100",
+          "ViewerCertificate": {
+            "IamCertificateId": {"Ref": "IamCertificateId"},
+            "SslSupportMethod": "sni-only",
+            "MinimumProtocolVersion": "TLSv1"
+          }
         }
       }
     },

--- a/cloudformation_templates/aws_cloudfront_www.json
+++ b/cloudformation_templates/aws_cloudfront_www.json
@@ -82,7 +82,7 @@
           "DefaultCacheBehavior": {
             "TargetOriginId": "BuyerOriginId",
             "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
-            "ViewerProtocolPolicy": "allow-all",
+            "ViewerProtocolPolicy": "redirect-to-https",
             "SmoothStreaming": false,
             "ForwardedValues": {
               "Headers": ["Authorization", "Host"],
@@ -94,7 +94,7 @@
               "TargetOriginId": "SupplierOriginId",
               "PathPattern": "/supplier*",
               "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
               "SmoothStreaming": false,
               "ForwardedValues": {
                 "Cookies": {"Forward": "all"},
@@ -106,7 +106,7 @@
               "TargetOriginId": "AdminOriginId",
               "PathPattern": "/admin*",
               "AllowedMethods": ["POST", "PATCH", "GET", "DELETE", "OPTIONS", "PUT", "HEAD" ],
-              "ViewerProtocolPolicy": "allow-all",
+              "ViewerProtocolPolicy": "redirect-to-https",
               "SmoothStreaming": false,
               "ForwardedValues": {
                 "Cookies": {"Forward": "all"},

--- a/stacks.yml
+++ b/stacks.yml
@@ -114,6 +114,7 @@ api_cloudfront:
   parameters:
     Origin: "{{ stacks.api.parameters.Domain }}"
     Domain: "{% if stage != 'production' %}{{ stage }}-cloudfront-{% endif %}api.{{ root_domain }}"
+    IamCertificateId: "{{ iam_certificate_id }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"
 
@@ -317,5 +318,6 @@ www_cloudfront:
     BuyerOrigin: "{{ stacks.buyer_frontend.parameters.Domain }}"
     SupplierOrigin: "{{ stacks.supplier_frontend.parameters.Domain }}"
     Domain: "{% if stage != 'production' %}{{ stage }}-cloudfront-{% endif %}www.{{ root_domain }}"
+    IamCertificateId: "{{ iam_certificate_id }}"
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Domain }}"

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -1,6 +1,7 @@
 ---
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
+iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,6 +1,7 @@
 ---
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
+iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,6 +1,7 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/cloudfront/star-digitalmarketplace/star-digitalmarketplace"
+iam_certificate_id: "ASCAI2XK7NR4IUWWPPRIQ"
 subnets:
   - subnet-9a9713ed
   - subnet-63b1683a

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,6 +1,7 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/cloudfront/star-digitalmarketplace/star-digitalmarketplace"
+iam_certificate_id: "ASCAI2XK7NR4IUWWPPRIQ"
 subnets:
   - subnet-9a9713ed
   - subnet-63b1683a


### PR DESCRIPTION
This introduces IamCertificateId which is a different identifier to the
same IAM SSL certificates. This is needed because CloudFront requires a
different ID to the one that Elastic Beanstalk uses.

TLSv1 is required as minimum protocol version because we're using
sni-only.