### PR TITLE
Add ROLLBACK_FAILED to the list of wait_for statuses

### DIFF
--- a/dmaws/cloudformation.py
+++ b/dmaws/cloudformation.py
@@ -96,6 +96,7 @@ class Cloudformation(object):
                 self.log('Stack [%s] is now %s', stack.name, info['status'])
                 return self._response(info)
             elif info.get('status') in ['ROLLBACK_COMPLETE',
+                                        'ROLLBACK_FAILED',
                                         '%s_ROLLBACK_COMPLETE' % operation,
                                         '%s_FAILED' % operation]:
                 return self._response(info, failed=True)


### PR DESCRIPTION
Otherwise wait_for blocks forever if the CF stack fails to ROLLBACK
due to missing permissions.