### PR TITLE
Add ApplicationName custom option

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -214,6 +214,11 @@
             "Namespace": "aws:elasticbeanstalk:customoption",
             "OptionName": "LogGroupName",
             "Value": {"Ref": "LogGroupName"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:customoption",
+            "OptionName": "ApplicationName",
+            "Value": {"Ref": "ApplicationName"}
           }
         ]
       }


### PR DESCRIPTION
This is used by the CloudFormation rules in .ebextensions in the apps to
generate the log stream names.