### PR TITLE
nginx and elasticsearch AMI cloudwatch logs

### DIFF
--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -7,6 +7,10 @@
       "Type": "String",
       "Description": "Group Tag"
     },
+    "LogGroupName": {
+      "Type": "String",
+      "Description": "Name of CloudWatch log group"
+    },
     "LoadBalancerName": {
       "Type": "String",
       "Description": "ELB name prefix"
@@ -114,6 +118,25 @@
               "Resource": "*"
             }]
           }
+        }, {
+          "PolicyName": "elasticsearch-cloudwatch-policy",
+          "PolicyDocument": {
+            "Version" : "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:GetLogEvents",
+                "logs:PutLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                "arn:aws:logs:eu-west-1:*:*"
+              ]
+            }]
+          }
         }]
       }
     },
@@ -190,6 +213,7 @@
             "ansible-playbook -c local -i localhost, elasticsearch_playbook.yml ",
             "-t instance-config ",
             "-e aws_region=", {"Ref": "AWS::Region"}, " ",
+            "-e cloudwatch_log_group=", {"Ref": "LogGroupName"}, " ",
             "-e elasticsearch_name=", {"Ref": "GroupTag"}
         ]]}}
       }

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -130,7 +130,26 @@
           } ]
         },
         "Path": "/",
-        "Policies": []
+        "Policies": [{
+          "PolicyName": "nginx-cloudwatch-policy",
+          "PolicyDocument": {
+            "Version" : "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:GetLogEvents",
+                "logs:PutLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+              ],
+              "Resource": [
+                "arn:aws:logs:eu-west-1:*:*"
+              ]
+            }]
+          }
+        }]
       }
     },
     "InstanceProfile": {

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -34,6 +34,10 @@
       "Description": "Documents S3 bucket URL"
     },
 
+    "LogGroupName": {
+      "Type": "String",
+      "Description": "Name of CloudWatch log group"
+    },
     "HostedZoneName": {
       "Type": "String",
       "Description": "Route53 hosted zone name to serve the Beanstalk environment from"
@@ -252,6 +256,8 @@
             "cd /home/ubuntu/provisioning && ",
             "ansible-playbook -c local -i localhost, nginx_playbook.yml ",
             "-t instance-config ",
+            "-e aws_region=", {"Ref": "AWS::Region"}, " ",
+            "-e cloudwatch_log_group=", {"Ref": "LogGroupName"}, " ",
             "-e assets_domain=", {"Ref": "AssetsDomain"}, " ",
             "-e documents_s3_url=", {"Ref": "DocumentsS3URL"}, " ",
             "-e www_domain=", {"Ref": "Domain"}, " ",

--- a/dmaws/commands/create.py
+++ b/dmaws/commands/create.py
@@ -1,10 +1,14 @@
+import click
+
 from ..stacks import StackPlan
 from ..cli import cli_command
 
 
 @cli_command('create')
-def create_cmd(ctx):
+@click.option('--ignore-dependencies', is_flag=True,
+              help='Do not update or create dependencies')
+def create_cmd(ctx, ignore_dependencies):
     """Create AWS environment and launch instances"""
 
     plan = StackPlan.from_ctx(ctx)
-    plan.create()
+    plan.create(create_dependencies=not ignore_dependencies)

--- a/packer_templates/elasticsearch.json
+++ b/packer_templates/elasticsearch.json
@@ -1,9 +1,10 @@
 {
   "variables": {
+      "aws_region": "eu-west-1"
   },
   "builders": [{
     "type": "amazon-ebs",
-    "region": "eu-west-1",
+    "region": "{{ user `aws_region` }}",
     "source_ami": "ami-234ecc54",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
@@ -21,9 +22,13 @@
     {
       "type": "ansible-local",
       "playbook_file": "playbooks/elasticsearch_playbook.yml",
-      "role_paths": ["playbooks/roles/elasticsearch/"],
+      "role_paths": [
+        "playbooks/roles/elasticsearch/",
+        "playbooks/roles/cloudwatch/"
+      ],
       "extra_arguments": [
-        "-t image-setup"
+        "-t image-setup",
+        "-e aws_region={{ user `aws_region` }}"
       ],
       "staging_directory": "/home/ubuntu/provisioning/"
     }

--- a/packer_templates/nginx.json
+++ b/packer_templates/nginx.json
@@ -1,9 +1,10 @@
 {
   "variables": {
+      "aws_region": "eu-west-1"
   },
   "builders": [{
     "type": "amazon-ebs",
-    "region": "eu-west-1",
+    "region": "{{ user `aws_region` }}",
     "source_ami": "ami-234ecc54",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
@@ -21,9 +22,13 @@
     {
       "type": "ansible-local",
       "playbook_file": "playbooks/nginx_playbook.yml",
-      "role_paths": ["playbooks/roles/nginx/"],
+      "role_paths": [
+        "playbooks/roles/nginx/",
+        "playbooks/roles/cloudwatch/"
+      ],
       "extra_arguments": [
-        "-t image-setup"
+        "-t image-setup",
+        "-e aws_region={{ user `aws_region` }}"
       ],
       "staging_directory": "/home/ubuntu/provisioning/"
     }

--- a/playbooks/elasticsearch_playbook.yml
+++ b/playbooks/elasticsearch_playbook.yml
@@ -8,3 +8,6 @@
   roles:
     - role: elasticsearch
       tags: elasticsearch
+    - role: cloudwatch
+      tags: cloudwatch
+      config_name: elasticsearch

--- a/playbooks/nginx_playbook.yml
+++ b/playbooks/nginx_playbook.yml
@@ -7,3 +7,6 @@
   roles:
     - role: nginx
       tags: nginx
+    - role: cloudwatch
+      tags: cloudwatch
+      config_name: nginx

--- a/playbooks/roles/cloudwatch/defaults/main.yml
+++ b/playbooks/roles/cloudwatch/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+aws_log_agent_url: https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py

--- a/playbooks/roles/cloudwatch/tasks/main.yml
+++ b/playbooks/roles/cloudwatch/tasks/main.yml
@@ -11,16 +11,16 @@
     content: ""
   tags: image-setup
 
-- name: Install the cwlogs agent
+- name: Install the awslogs agent
   shell: /usr/bin/python /tmp/awslogs-agent-setup.py -n -r {{ aws_region }} -c /tmp/general.conf
   tags: image-setup
 
-- name: Make sure the AWS Logs config is present
+- name: Make sure the awslogs config is present
   template:
-    src: awslogs.conf.j2
+    src: "{{ config_name }}_awslogs.conf.j2"
     dest: /var/awslogs/etc/awslogs.conf
   tags: instance-config
 
-- name: Ensure Nginx service is started
+- name: Ensure awslogs service is started
   service: name=awslogs state=restarted enabled=yes
   tags: instance-config

--- a/playbooks/roles/cloudwatch/tasks/main.yml
+++ b/playbooks/roles/cloudwatch/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Download awslogs installer
+  get_url:
+    url: "{{ aws_log_agent_url }}"
+    dest: /tmp/awslogs-agent-setup.py
+  tags: image-setup
+
+- name: Create empty initial awslogs config
+  copy:
+    dest: /tmp/general.conf
+    content: ""
+  tags: image-setup
+
+- name: Install the cwlogs agent
+  shell: /usr/bin/python /tmp/awslogs-agent-setup.py -n -r {{ aws_region }} -c /tmp/general.conf
+  tags: image-setup
+
+- name: Make sure the AWS Logs config is present
+  template:
+    src: awslogs.conf.j2
+    dest: /var/awslogs/etc/awslogs.conf
+  tags: instance-config
+
+- name: Ensure Nginx service is started
+  service: name=awslogs state=restarted enabled=yes
+  tags: instance-config

--- a/playbooks/roles/cloudwatch/templates/elasticsearch_awslogs.conf.j2
+++ b/playbooks/roles/cloudwatch/templates/elasticsearch_awslogs.conf.j2
@@ -1,0 +1,8 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[elasticsearch-log]
+file = /var/log/elasticsearch/{{ elasticsearch_name }}.log
+log_group_name = {{ cloudwatch_log_group }}
+log_stream_name = {{ elasticsearch_name }}
+datetime_format = %Y-%m-%d %H:%M:%S

--- a/playbooks/roles/cloudwatch/templates/nginx_awslogs.conf.j2
+++ b/playbooks/roles/cloudwatch/templates/nginx_awslogs.conf.j2
@@ -1,0 +1,8 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[nginx-access-log]
+file = /var/log/nginx/access.log
+log_group_name = {{ cloudwatch_log_group }}
+log_stream_name = nginx-access-logs
+datetime_format = %d/%b/%Y:%H:%M:%S %z

--- a/stacks.yml
+++ b/stacks.yml
@@ -330,10 +330,12 @@ nginx:
     - buyer_frontend
     - documents_s3
     - route53zone
+    - monitoring
   parameters:
     KeyName: "{{ key_name }}"
     SSHCidrIp: "{{ user_cidr_ip }}"
 
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     DocumentsS3URL: "{{stacks.documents_s3.outputs.URL}}"
     AdminFrontendURL: "{{stacks.admin_frontend.outputs.URL}}"
     BuyerFrontendURL: "{{stacks.buyer_frontend.outputs.URL}}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -137,9 +137,12 @@ database_dev_access:
 elasticsearch:
   name: "elasticsearch-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_elasticsearch.json
+  dependencies:
+    - monitoring
   parameters:
     KeyName: "{{ key_name }}"
     SSHCidrIp: "{{ user_cidr_ip }}"
+    LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     Port: "{{ elasticsearch.port }}"
     LoadBalancerName: "elasticsearch-{{ stage }}-{{ environment }}"
     LoadBalancerSubnets: "{{ subnets | join(',') }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -37,9 +37,9 @@ elasticsearch:
   port: 9200
   instance_type: t2.micro
   instance_count: 3
-  instance_image: ami-21214c56
+  instance_image: ami-2999f65e
 
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-63492414
+  instance_image: ami-79422f0e


### PR DESCRIPTION
Adds cloudwatch streams for nginx and elasticsearch.
Provided awslogs configs will send nginx access_log and general elasticsearch cluster log to cloudwatch.
New AMIs contiain the cloudwatch ansible role and have awslogs preinstalled.