### PR TITLE
Create and delete exit status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - "2.7"
-# - "3.4" :(
+  - "3.4"
 install:
   - pip install -r requirements_for_test.txt
 script:

--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -23,10 +23,6 @@
       "Type": "AWS::EC2::KeyPair::KeyName",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
     },
-    "SSHCidrIp": {
-      "Type": "String",
-      "Description": "CIDR IP to use for SSH access security group rules"
-    },
     "Port": {
       "Type": "Number",
       "Default": "9200",
@@ -80,17 +76,6 @@
         "FromPort": {"Ref": "Port"},
         "ToPort": {"Ref": "Port"},
         "SourceSecurityGroupName": {"Ref": "LoadBalancerSecurityGroup"}
-      }
-    },
-
-    "SSHIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupName": {"Ref": "InstanceSecurityGroup"},
-        "IpProtocol": "tcp",
-        "FromPort": "22",
-        "ToPort": "22",
-        "CidrIp": {"Ref": "SSHCidrIp"}
       }
     },
 

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -54,10 +54,6 @@
       "Type": "AWS::EC2::KeyPair::KeyName",
       "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
     },
-    "SSHCidrIp": {
-      "Type": "String",
-      "Description": "CIDR IP to use for SSH access security group rules"
-    },
     "InstanceImage" : {
       "Description" : "EC2 instance image",
       "Type" : "String"
@@ -106,17 +102,6 @@
         "FromPort": 80,
         "ToPort": 80,
         "SourceSecurityGroupName": {"Ref": "LoadBalancerSecurityGroup"}
-      }
-    },
-
-    "SSHIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupName": {"Ref": "InstanceSecurityGroup"},
-        "IpProtocol": "tcp",
-        "FromPort": "22",
-        "ToPort": "22",
-        "CidrIp": {"Ref": "SSHCidrIp"}
       }
     },
 

--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -102,7 +102,7 @@ def get_other_tags(cwd, tag):
 def get_release_name_for_tag(cwd, tag):
     """Return release tag pointing to the same commit"""
     tags = get_other_tags(cwd, tag)
-    tags = filter(RELEASE_TAG_PATTERN.match, tags)
+    tags = list(filter(RELEASE_TAG_PATTERN.match, tags))
 
     if len(tags) == 1:
         return tags[0]

--- a/dmaws/cloudformation.py
+++ b/dmaws/cloudformation.py
@@ -66,8 +66,15 @@ class Cloudformation(object):
     def describe_stack(self, stack):
         try:
             stack = self.conn.describe_stacks(stack.name)[0]
-        except boto.exception.BotoServerError:
-            return {}
+        except boto.exception.BotoServerError as e:
+            if 'does not exist' in e.message:
+                return {}
+            elif 'Rate exceeded' in e.message:
+                time.sleep(5)
+                return self.describe_stack(stack)
+            else:
+                self.log(e.message)
+                raise e
 
         return {
             'status': stack.stack_status,

--- a/dmaws/cloudformation.py
+++ b/dmaws/cloudformation.py
@@ -23,7 +23,7 @@ class Cloudformation(object):
             )
         except boto.exception.BotoServerError as e:
             if e.error_code == 'AlreadyExistsException':
-                self.log(e.message)
+                self.log('==> ' + e.message)
                 return self.update_stack(stack)
             else:
                 raise e
@@ -33,7 +33,7 @@ class Cloudformation(object):
     def update_stack(self, stack):
         info = self.describe_stack(stack)
         if not info:
-            self.log('Stack [%s] does not exist', stack.name)
+            self.log('==> Stack [%s] does not exist', stack.name, color='red')
             return self._response(info, failed=True)
 
         try:
@@ -46,10 +46,11 @@ class Cloudformation(object):
         except boto.exception.BotoServerError as e:
             info = self.describe_stack(stack)
             if e.message == 'No updates are to be performed.':
-                self.log('Stack [%s] is up-to-date', stack.name)
+                self.log('==> Stack [%s] is up-to-date', stack.name,
+                         color='green')
                 return self._response(info)
             else:
-                self.log(e.message)
+                self.log('    ' + e.message, color='red')
                 return self._response(info, failed=True)
 
         return self.wait_for(stack, 'UPDATE')
@@ -57,7 +58,7 @@ class Cloudformation(object):
     def delete_stack(self, stack):
         info = self.describe_stack(stack)
         if not info:
-            self.log('Stack [%s] does not exist', stack.name)
+            self.log('==> Stack [%s] does not exist', stack.name)
             return self._response(info)
 
         self.conn.delete_stack(stack.name)
@@ -82,7 +83,7 @@ class Cloudformation(object):
                 (o.key, o.value) for o in stack.outputs
             ),
             'events': [
-                (ev.timestamp, str(ev))
+                (ev.timestamp, self._format_event(ev))
                 for ev in stack.describe_events()
             ],
             'resources': dict(
@@ -91,28 +92,44 @@ class Cloudformation(object):
             ),
         }
 
+    def _format_event(self, event):
+        msg = "{} {} {}".format(
+            event.resource_type,
+            event.logical_resource_id,
+            event.resource_status,
+        )
+
+        if event.resource_status_reason:
+            msg = '{} ({})'.format(msg, event.resource_status_reason)
+
+        return msg
+
     def wait_for(self, stack, operation, delay=5):
         last = datetime.datetime.utcnow()
-        self.log('Waiting for [%s] to %s', stack.name, operation)
+        self.log('=== Waiting for [%s] to %s', stack.name, operation)
         while True:
             info = self.describe_stack(stack)
             if not info and operation == 'DELETE':
-                self.log('Stack [%s] is now deleted', stack.name)
+                self.log('==> Stack [%s] is now deleted', stack.name,
+                         color='yellow')
                 return self._response(info)
             elif info.get('status') == '%s_COMPLETE' % operation:
-                self.log('Stack [%s] is now %s', stack.name, info['status'])
+                self.log('==> Stack [%s] is now %s', stack.name,
+                         info['status'], color='green')
                 return self._response(info)
             elif info.get('status') in ['ROLLBACK_COMPLETE',
                                         'ROLLBACK_FAILED',
                                         '%s_ROLLBACK_COMPLETE' % operation,
                                         '%s_FAILED' % operation]:
+                self.log('==> Stack [%s] is now %s', stack.name,
+                         info['status'], color='red')
                 return self._response(info, failed=True)
             else:
                 new_events = list(
                     takewhile(lambda x: x[0] > last, info.get('events', []))
                 )
                 for ts, event in reversed(new_events):
-                    self.log('%s %s', ts, event)
+                    self.log('    %s %s', ts, event)
                     last = ts
                 time.sleep(delay)
 

--- a/dmaws/commands/create.py
+++ b/dmaws/commands/create.py
@@ -1,3 +1,4 @@
+import sys
 import click
 
 from ..stacks import StackPlan
@@ -11,4 +12,6 @@ def create_cmd(ctx, ignore_dependencies):
     """Create AWS environment and launch instances"""
 
     plan = StackPlan.from_ctx(ctx)
-    plan.create(create_dependencies=not ignore_dependencies)
+    status = plan.create(create_dependencies=not ignore_dependencies)
+    if not status:
+        sys.exit(1)

--- a/dmaws/commands/delete.py
+++ b/dmaws/commands/delete.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from ..stacks import StackPlan
@@ -11,4 +13,6 @@ def delete_cmd(ctx, ignore_dependencies):
     """Destroy AWS environment and terminate running instances."""
 
     plan = StackPlan.from_ctx(ctx)
-    plan.delete(ignore_dependencies)
+    status = plan.delete(ignore_dependencies)
+    if not status:
+        sys.exit(1)

--- a/dmaws/context.py
+++ b/dmaws/context.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import click
 
@@ -51,11 +50,13 @@ class Context(object):
             else:
                 self.stacks[key] = val
 
-    def log(self, msg, *args):
+    def log(self, msg, *args, **kwargs):
         """Logs a message to stderr."""
         if args:
             msg %= args
-        click.echo(msg, file=sys.stderr)
+        if 'color' in kwargs:
+            msg = click.style(msg, fg=kwargs['color'])
+        click.echo(msg, err=True)
 
 
 pass_context = click.make_pass_decorator(Context, ensure=True)

--- a/dmaws/context.py
+++ b/dmaws/context.py
@@ -1,6 +1,7 @@
 import os
 
 import click
+import six
 
 from .utils import merge_dicts, dict_from_path, read_yaml_file
 from .stacks import Stack
@@ -19,7 +20,7 @@ class Context(object):
         self.create_dependencies = False
 
     def add_apps(self, app):
-        if isinstance(app, basestring):
+        if isinstance(app, six.string_types):
             app = [app]
         elif not app:
             app = []
@@ -44,7 +45,7 @@ class Context(object):
 
     def load_stacks(self, path):
         stacks = read_yaml_file(path)
-        for key, val in stacks.iteritems():
+        for key, val in stacks.items():
             if isinstance(val, dict):
                 self.stacks[key] = Stack(**val)
             else:

--- a/dmaws/deploy.py
+++ b/dmaws/deploy.py
@@ -116,7 +116,7 @@ class S3Client(object):
         return package_path
 
 
-class BeanstalkStatusError(StandardError):
+class BeanstalkStatusError(ValueError):
     pass
 
 

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -177,7 +177,7 @@ class StackPlan(object):
 
     def get_deploy(self, repository_path=None):
         if len(self.apps) != 1:
-            raise StandardError("Can only deploy a single app at a time")
+            raise ValueError("Can only deploy a single app at a time")
         stack_info = self.info(with_aws=False)[self.apps[0]]
 
         return Deploy(

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -117,7 +117,7 @@ class StackPlan(object):
 
     def info(self, apps=None, with_aws=True):
         stacks = self.stacks(apps, with_dependencies=True)
-        self.log('Gathering info about %s stacks',
+        self.log('Gathering info about %s stacks\n',
                  ', '.join(s[0] for s in stacks))
 
         for name, stack in stacks:
@@ -134,11 +134,10 @@ class StackPlan(object):
         return self.stack_context['stacks']
 
     def create(self, create_dependencies=True):
-        self.log('Creating %s', ', '.join(self.apps))
+        self.log('\nCreating %s', ', '.join(self.apps))
 
         stacks = self.stacks(with_dependencies=True)
-        self.log('Will run %s stacks', ', '.join(s[0] for s in stacks),
-                 color='yellow')
+        self.log('Will run %s stacks\n', ', '.join(s[0] for s in stacks))
 
         for name, stack in stacks:
             built_stack = self.build_stack(stack)
@@ -150,7 +149,7 @@ class StackPlan(object):
                 stack_info = self.cfn.describe_stack(built_stack)
                 if not stack_info:
                     self.log("Dependency %s doesn't exists, can't continue",
-                             built_stack.name)
+                             built_stack.name, color='red')
                     return False
 
             self.stack_context['stacks'][name].update_info(stack_info)
@@ -158,10 +157,10 @@ class StackPlan(object):
         return True
 
     def delete(self, ignore_dependencies=False):
-        self.log('Deleting %s', ', '.join(self.apps))
+        self.log('\nDeleting %s', ', '.join(self.apps))
 
         stacks = self.dependant_stacks()
-        self.log('Will check %s stacks', ', '.join(s[0] for s in stacks))
+        self.log('Will check %s stacks\n', ', '.join(s[0] for s in stacks))
 
         for name, stack in stacks:
             built_stack = self.build_stack(stack)
@@ -170,7 +169,7 @@ class StackPlan(object):
                 self.cfn.delete_stack(built_stack)
             elif status and name not in self.apps and not ignore_dependencies:
                 self.log("Dependant stack %s exists, can't continue",
-                         built_stack.name)
+                         built_stack.name, color='red')
                 return False
 
         return True

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -137,7 +137,8 @@ class StackPlan(object):
         self.log('Creating %s', ', '.join(self.apps))
 
         stacks = self.stacks(with_dependencies=True)
-        self.log('Will run %s stacks', ', '.join(s[0] for s in stacks))
+        self.log('Will run %s stacks', ', '.join(s[0] for s in stacks),
+                 color='yellow')
 
         for name, stack in stacks:
             built_stack = self.build_stack(stack)

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -3,6 +3,7 @@ import collections
 import subprocess
 from subprocess import CalledProcessError
 
+import six
 import yaml
 import jinja2
 from jinja2.runtime import StrictUndefined
@@ -44,7 +45,7 @@ def load_file(path):
 
 def dict_from_path(path, value):
     result = {}
-    if isinstance(path, basestring):
+    if isinstance(path, six.string_types):
         path = path.split('.')
 
     if not path:
@@ -62,7 +63,7 @@ def merge_dicts(a, b):
         ))
 
     result = a.copy()
-    for key, val in b.iteritems():
+    for key, val in b.items():
         if isinstance(result.get(key), collections.Mapping):
             result[key] = merge_dicts(a[key], b[key])
         else:
@@ -74,7 +75,7 @@ def merge_dicts(a, b):
 def template(item, variables, **kwargs):
     variables = merge_dicts(variables, kwargs)
 
-    if isinstance(item, basestring):
+    if isinstance(item, (str, bytes)):
         varname = template_string(item, variables)
         return varname
 
@@ -83,7 +84,7 @@ def template(item, variables, **kwargs):
 
     elif isinstance(item, collections.Mapping):
         result = {}
-        for (key, val) in item.iteritems():
+        for (key, val) in item.items():
             result[key] = template(val, variables)
         return result
 
@@ -121,10 +122,10 @@ def template_string(string, variables, templates_path=None):
 
     try:
         template = jinja_env.from_string(string)
-    except jinja2.exceptions.TemplateSyntaxError, e:
+    except jinja2.exceptions.TemplateSyntaxError as e:
         raise ValueError(u"Template error: {}".format(e))
 
     try:
         return template.render(variables)
-    except jinja2.exceptions.UndefinedError, e:
+    except jinja2.exceptions.UndefinedError as e:
         raise ValueError(u"Variable {} in '{}'".format(e, string))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,7 @@ Jinja2==2.7.3
 PyYAML==3.11
 toposort==1.1
 
+six==1.9.0
+
 # loaddata dependencies
 requests==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.36.0
 
-click==3.3
+click==4.0
 Jinja2==2.7.3
 PyYAML==3.11
 toposort==1.1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
 from setuptools import setup, find_packages
+
+import pip.download
 from pip.req import parse_requirements
 
 
-install_requires = [str(r.req) for r in parse_requirements('requirements.txt')]
+install_requires = [
+    str(r.req) for r in parse_requirements('requirements.txt',
+                                           session=pip.download.PipSession())]
 
 setup(
     name='digitalmarketplace-aws',

--- a/stacks.yml
+++ b/stacks.yml
@@ -1,5 +1,6 @@
 ---
 all:
+  - www
   - apps
   - dev_access
   - data_storage
@@ -30,6 +31,7 @@ data_storage:
   - documents_s3
   - logs_s3
   - elasticsearch
+  - monitoring
 
 dev_access:
   - database_dev_access

--- a/stacks.yml
+++ b/stacks.yml
@@ -146,7 +146,7 @@ elasticsearch:
     SSHCidrIp: "{{ user_cidr_ip }}"
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     Port: "{{ elasticsearch.port }}"
-    LoadBalancerName: "elasticsearch-{{ stage }}-{{ environment }}"
+    LoadBalancerName: "elasticsearch-{{ stage[:3] }}-{{ environment }}"
     LoadBalancerSubnets: "{{ subnets | join(',') }}"
     GroupTag: "elasticsearch-{{ stage }}-{{ environment }}"
     InstanceCount: "{{ elasticsearch.instance_count }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -36,6 +36,8 @@ data_storage:
 dev_access:
   - database_dev_access
   - elasticsearch_dev_access
+  - elasticsearch_ssh_access
+  - nginx_ssh_access
 
 route53zone:
   name: "route53-zone"
@@ -143,7 +145,6 @@ elasticsearch:
     - monitoring
   parameters:
     KeyName: "{{ key_name }}"
-    SSHCidrIp: "{{ user_cidr_ip }}"
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     Port: "{{ elasticsearch.port }}"
     LoadBalancerName: "elasticsearch-{{ stage[:3] }}-{{ environment }}"
@@ -162,6 +163,17 @@ elasticsearch_dev_access:
     CidrIp: "{{ user_cidr_ip }}"
     FromPort: "{{ elasticsearch.port }}"
     ToPort: "{{ elasticsearch.port }}"
+    SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
+
+elasticsearch_ssh_access:
+  name: "elasticsearch-{{ stage }}-{{ environment }}-ssh-access"
+  template: cloudformation_templates/aws_dev_access.json
+  dependencies:
+    - elasticsearch
+  parameters:
+    CidrIp: "{{ user_cidr_ip }}"
+    FromPort: 22
+    ToPort: 22
     SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
 
 search_api_app:
@@ -338,7 +350,6 @@ nginx:
     - monitoring
   parameters:
     KeyName: "{{ key_name }}"
-    SSHCidrIp: "{{ user_cidr_ip }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     DocumentsS3URL: "{{stacks.documents_s3.outputs.URL}}"
@@ -356,6 +367,17 @@ nginx:
     InstanceCount: "{{ nginx.instance_count }}"
     InstanceType: "{{ nginx.instance_type }}"
     InstanceImage: "{{ nginx.instance_image }}"
+
+nginx_ssh_access:
+  name: "nginx-{{ stage }}-{{ environment }}-ssh-access"
+  template: cloudformation_templates/aws_dev_access.json
+  dependencies:
+    - nginx
+  parameters:
+    CidrIp: "{{ user_cidr_ip }}"
+    FromPort: 22
+    ToPort: 22
+    SecurityGroup: "{{ stacks.nginx.outputs.InstanceSecurityGroup }}"
 
 www_cloudfront:
   name: "digitalmarketplace-www-cloudfront-{{ stage }}"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,9 @@ def set_cloudformation_stack(cloudformation_mock, stack_name, status,
         if stack in cloudformation_mock._stacks:
             return [cloudformation_mock._stacks[stack]]
         else:
-            raise boto.exception.BotoServerError(404, 'No Stack')
+            exc = boto.exception.BotoServerError(400, '')
+            exc.message = 'Stack does not exist'
+            raise exc
 
     def create_stack(stack, *args, **kwargs):
         if stack in cloudformation_mock._stacks:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -141,7 +141,7 @@ class TestBeanstalkClient(object):
 
         logger.assert_has_calls([
             mock.call(mock.ANY, mock.ANY, 'UPDATE', 'msg'),
-            mock.call(mock.ANY, 'Ready'),
+            mock.call(mock.ANY, mock.ANY, 'Ready', color=mock.ANY),
         ])
 
     def test_wait_for_ready_error_event(self, beanstalk_conn):
@@ -158,7 +158,7 @@ class TestBeanstalkClient(object):
 
         logger.assert_has_calls([
             mock.call(mock.ANY, mock.ANY, 'ERROR', ''),
-            mock.call(mock.ANY, 'Ready'),
+            mock.call(mock.ANY, mock.ANY, 'Ready', color=mock.ANY),
         ])
 
     def test_wait_for_ready_unknown_status(self, beanstalk_conn):
@@ -179,7 +179,7 @@ class TestBeanstalkClient(object):
 
         logger.assert_has_calls([
             mock.call(mock.ANY, mock.ANY, 'UPDATE', 'msg'),
-            mock.call(mock.ANY, 'NotARealStatus'),
+            mock.call(mock.ANY, mock.ANY, 'NotARealStatus', color=mock.ANY),
         ])
 
     def test_wait_for_ready_status_change(self, beanstalk_conn):
@@ -217,9 +217,9 @@ class TestBeanstalkClient(object):
         logger.assert_has_calls([
             mock.call(mock.ANY, mock.ANY, 'UPDATE', '0'),
             mock.call(mock.ANY, mock.ANY, 'UPDATE', '1'),
-            mock.call(mock.ANY, 'Updating'),
+            mock.call(mock.ANY, mock.ANY, 'Updating', color=mock.ANY),
             mock.call(mock.ANY, mock.ANY, 'UPDATE', '2'),
-            mock.call(mock.ANY, 'Ready'),
+            mock.call(mock.ANY, mock.ANY, 'Ready', color=mock.ANY),
         ])
 
     def test_update_environment(self):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -460,5 +460,5 @@ class TestStackPlan(object):
             'api': Stack('api', 'api.json'),
         }, 'stage', 'env', {'aws_region': AWS_REGION}, ['aws', 'api'])
 
-        with pytest.raises(StandardError):
+        with pytest.raises(ValueError):
             plan.get_deploy()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -320,6 +320,28 @@ class TestStackPlan(object):
                       parameters=[], capabilities=mock.ANY),
         ])
 
+    def test_stack_create_failed(self, cloudformation_conn):
+        set_cloudformation_stack(cloudformation_conn, 'api', 'CREATE_COMPLETE')
+        set_cloudformation_stack(cloudformation_conn, 'db', 'UPDATE_FAILED')
+
+        plan = StackPlan(
+            {
+                'api_list': ['api'],
+                'aws': Stack('aws', 'aws.json'),
+                'api': Stack('api', 'api.json', dependencies=['db']),
+                'db': Stack('db', 'tests/templates/aws.json'),
+            }, 'stage', 'env',
+            {'aws_region': AWS_REGION},
+            ['db']
+        )
+
+        assert not plan.create()
+
+        cloudformation_conn.create_stack.assert_has_calls([
+            mock.call(u'db', template_body=mock.ANY,
+                      parameters=[], capabilities=mock.ANY),
+        ])
+
     def test_stack_create_dependencies(self, cloudformation_conn):
         set_cloudformation_stack(cloudformation_conn, 'api', 'UPDATE_COMPLETE')
         set_cloudformation_stack(cloudformation_conn, 'db', 'UPDATE_COMPLETE')
@@ -400,6 +422,27 @@ class TestStackPlan(object):
         )
 
         assert plan.delete()
+
+        cloudformation_conn.delete_stack.assert_has_calls([
+            mock.call(u'api')
+        ])
+
+    def test_stack_delete_failed(self, cloudformation_conn):
+        set_cloudformation_stack(cloudformation_conn, 'api', 'DELETE_FAILED')
+        set_cloudformation_stack(cloudformation_conn, 'db', 'DELETE_COMPLETE')
+
+        plan = StackPlan(
+            {
+                'api_list': ['api'],
+                'aws': Stack('aws', 'aws.json'),
+                'api': Stack('api', 'api.json', dependencies=['db']),
+                'db': Stack('db', 'tests/templates/aws.json'),
+            }, 'stage', 'env',
+            {'aws_region': AWS_REGION},
+            ['api']
+        )
+
+        assert not plan.delete()
 
         cloudformation_conn.delete_stack.assert_has_calls([
             mock.call(u'api')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -208,9 +208,9 @@ class TestLazyTemplateMapping(object):
 
     def test_keys(self):
         mapping = LazyTemplateMapping({"a": "{{ var }}", "b": "{{ var }}"}, {})
-        assert mapping.keys() == ["a", "b"]
+        assert set(mapping.keys()) == set(["a", "b"])
 
     def test_items(self):
         mapping = LazyTemplateMapping({"a": "{{ var }}a", "b": "{{ var }}b"},
                                       {"var": "a"})
-        assert mapping.items() == [("a", "aa"), ("b", "ab")]
+        assert set(mapping.items()) == set([("a", "aa"), ("b", "ab")])


### PR DESCRIPTION
This is a lot of small stuff bundled together, I can split them into separate pull requests if needed.

* Returns stack create/delete/update errors as exit code 1 (I'll silence the return code in Jenkins for now, since it will always fail due to EB apps being in DELETE_FAILED state)
* Cleans up and structures log output
* Renames the elasticsearch ELB to meet the length requirements for production (requires recreating the ASG, so the cluster will be wiped)
* Fixes an error with Cloudformation RateLimit exceptions being treated as "stack missing" responses
* Restores python3 compatibility since ansible is no longer a requirement