### PR TITLE
Add new environment vars for sending password reset emails

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -314,7 +314,6 @@ supplier_frontend:
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ supplier_frontend.mandrill_key }}"
     EnvVarDmPasswordSecretKey: "{{ supplier_frontend.password_key }}"
-    EnvVarDmResetPasswordSalt: "{{ supplier_frontend.password_salt }}"
 
     KeyName: "{{ key_name }}"
     InstanceType: "{{ supplier_frontend.instance_type }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -312,6 +312,9 @@ supplier_frontend:
     EnvVarDmSupplierFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmDataApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
+    EnvVarDmMandrillApiKey: "{{ supplier_frontend.mandrill_key }}"
+    EnvVarDmPasswordSecretKey: "{{ supplier_frontend.password_key }}"
+    EnvVarDmResetPasswordSalt: "{{ supplier_frontend.password_salt }}"
 
     KeyName: "{{ key_name }}"
     InstanceType: "{{ supplier_frontend.instance_type }}"

--- a/user.yml.sample
+++ b/user.yml.sample
@@ -18,3 +18,7 @@ search_api:
 admin_frontend:
   admin_password_hash: ***
   cookie_secret: ***
+
+supplier_frontend:
+  mandrill_key: ***
+  password_key: ***

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -25,6 +25,7 @@ supplier_frontend:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
+  password_salt: ResetPasswordSalt
 
 database:
   port: 5432

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -25,7 +25,6 @@ supplier_frontend:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
-  password_salt: ResetPasswordSalt
 
 database:
   port: 5432


### PR DESCRIPTION
To send emails the app needs a Mandrill key, secret password salt and a 'namespacing' salt.
This adds these three parameters as environment variables for the supplier app.

This PR should be merged before: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/17