### PR TITLE
Add MultiAZ parameter to RDS instances

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -24,6 +24,10 @@
     "DBAllocatedStorage": {
       "Type": "String",
       "Description": "Database allocated storage"
+    },
+    "MultiAZ": {
+      "Type": "Boolean",
+      "Description": "Whether the instance is multi AZ or not"
     }
   },
 
@@ -45,7 +49,8 @@
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}]
+        "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
+        "MultiAZ": {"Ref": "MultiAZ"}
       }
     }
   },

--- a/stacks.yml
+++ b/stacks.yml
@@ -54,6 +54,7 @@ database:
     DBPassword: "{{ database.password }}"
     DBInstanceType: "{{ database.instance_type }}"
     DBAllocatedStorage: "{{ database.allocated_storage }}"
+    MultiAZ: "{{ rds_multi_az }}"
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -2,6 +2,7 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
+rds_multi_az: false
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -2,6 +2,7 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
+rds_multi_az: false
 subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -2,6 +2,7 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
+rds_multi_az: true
 subnets:
   - subnet-9a9713ed
   - subnet-63b1683a

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -2,6 +2,7 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
+rds_multi_az: true
 subnets:
   - subnet-9a9713ed
   - subnet-63b1683a


### PR DESCRIPTION
In development and preview RDS instances do not need to be MultiAZ in
staging and production they do.

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-multiaz