### PR TITLE
Configure nginx to re-resolve upstream hosts

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -294,6 +294,7 @@
             "ansible-playbook -c local -i localhost, nginx_playbook.yml ",
             "-t instance-config ",
             "-e aws_region=", {"Ref": "AWS::Region"}, " ",
+            "-e nameserver_ip=$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)",
             "-e cloudwatch_log_group=", {"Ref": "LogGroupName"}, " ",
             "-e assets_subdomain=", {"Ref": "AssetsSubdomain"}, " ",
             "-e documents_s3_url=", {"Ref": "DocumentsS3URL"}, " ",

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -14,7 +14,7 @@
             dest=/etc/nginx/nginx.conf
             backup=no
   notify: reload nginx
-  tags: image-setup
+  tags: instance-config
 
 - name: Create the Nginx configuration files
   template: src={{ item }}.j2

--- a/playbooks/roles/nginx/templates/api.j2
+++ b/playbooks/roles/nginx/templates/api.j2
@@ -2,6 +2,8 @@ server {
     listen 80;
     server_name {{ api_subdomain }}.*;
 
+    set $api_url "{{ api_url }}";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -9,7 +11,7 @@ server {
 
         proxy_redirect http:// https://;
 
-        proxy_pass {{ api_url }};
+        proxy_pass $api_url;
     }
 }
 
@@ -17,6 +19,8 @@ server {
     listen 80;
     server_name {{ search_api_subdomain }}.*;
 
+    set $search_api_url "{{ search_api_url }}";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -24,6 +28,6 @@ server {
 
         proxy_redirect http:// https://;
 
-        proxy_pass {{ search_api_url }};
+        proxy_pass $search_api_url;
     }
 }

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -3,11 +3,13 @@ server {
     server_name {{ assets_subdomain }}.*;
     error_page 400 401 402 403 404 = /404;
 
+    set $documents_s3_url "{{ documents_s3_url }}";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
-        proxy_pass {{ documents_s3_url }};
+        proxy_pass $documents_s3_url;
     }
 
     location /404 {

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -7,8 +7,10 @@ events {
 }
 
 http {
-    # Basic Settings
+    # Set DNS resolver address
+    resolver {{ nameserver_ip }} valid=300s;
 
+    # Basic Settings
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -2,6 +2,10 @@ server {
     listen 80;
     server_name {{ www_subdomain }}.*;
 
+    set $buyer_frontend_url "{{ buyer_frontend_url }}";
+    set $admin_frontend_url "{{ admin_frontend_url }}";
+    set $supplier_frontend_url "{{ supplier_frontend_url }}";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -9,7 +13,7 @@ server {
 
         proxy_redirect http:// https://;
 
-        proxy_pass {{ buyer_frontend_url }};
+        proxy_pass $buyer_frontend_url;
     }
 
     location /admin {
@@ -19,7 +23,7 @@ server {
 
         proxy_redirect http:// https://;
 
-        proxy_pass {{ admin_frontend_url }};
+        proxy_pass $admin_frontend_url;
     }
 
     location /suppliers {
@@ -29,6 +33,6 @@ server {
 
         proxy_redirect http:// https://;
 
-        proxy_pass {{ supplier_frontend_url }};
+        proxy_pass $supplier_frontend_url;
     }
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-dfdfb4a8
+  instance_image: ami-ad442eda


### PR DESCRIPTION
When proxy_pass is used with a predefined URL nginx will resolve
the host during startup and will cache the IP address indefinitely.

This is a problem when proxying requests to AWS ELBs, since ELB IPs
change without notice.

To force nginx to re-resolve DNS proxy_pass destination must be set
to a variable and resolver must be defined in server configuration.

Nginx can't use the nameserver IP from system resolv.conf, so we're
passing it in as another variable.

Since we set resolver in nginx.conf and the variable is only set
in cloud-init stage nginx.conf is now run during instance-config.

nameserver_ip is set by user data cloud-init script by running the `resolv.conf` through `awk`.