### PR TITLE
[#92327956] Add RDS backup related fields to CF

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -28,6 +28,14 @@
     "MultiAZ": {
       "Type": "String",
       "Description": "Whether the instance is multi AZ or not"
+    },
+    "BackupRetentionPeriod": {
+      "Type": "String",
+      "Description": "Number of days to keep automatic backups for"
+    },
+    "DBSnapshotIdentifier": {
+      "Type": "String",
+      "Description": "The identifier for the DB snapshot to restore from."
     }
   },
 
@@ -50,7 +58,9 @@
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
-        "MultiAZ": {"Ref": "MultiAZ"}
+        "MultiAZ": {"Ref": "MultiAZ"},
+        "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},
+        "DBSnapshotIdentifier": {"Ref": "DBSnapshotIdentifier"}
       }
     }
   },

--- a/stacks.yml
+++ b/stacks.yml
@@ -57,7 +57,9 @@ database:
     DBPassword: "{{ database.password }}"
     DBInstanceType: "{{ database.instance_type }}"
     DBAllocatedStorage: "{{ database.allocated_storage }}"
-    MultiAZ: "{{ rds_multi_az }}"
+    MultiAZ: "{{ rds.multi_az }}"
+    BackupRetentionPeriod: "{{ rds.backup_retention_period }}"
+    DBSnapshotIdentifier: "{{ rds.snapshot_id }}"
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -2,6 +2,9 @@
 aws_region: eu-west-1
 internal_root_domain: dmdev
 
+rds:
+  snapshot_id: ""
+
 api:
   instance_type: t2.micro
   min_instance_count: 1

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -2,7 +2,10 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
-rds_multi_az: "false"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "1"
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -2,7 +2,10 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
-rds_multi_az: "false"
+
+rds:
+  multi_az: "false"
+  backup_retention_period: "1"
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -2,7 +2,10 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
-rds_multi_az: "true"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "30"
 
 vpc_id: vpc-70319115
 subnets:

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -2,7 +2,10 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
-rds_multi_az: "true"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "1"
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
Add RDS backup related fields to the CloudFormation template.

## BackupRetentionPeriod
Number of days to keep automatic snapshots around. Set to 1 for
non-production and 30 for production.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-BackupRetentionPeriod

## DBSnapshotIdentifier
A snapshot identifier to use to restore a database from a snapshot. It
is defaulted to blank. The idea being it would be provided as a custom
variable to restore an environment to a snapshot.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsnapshotidentifier