### PR TITLE
Add rds backup and snapshot

### DIFF
--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -20,6 +20,29 @@
         "LogGroupName": {"Ref": "LogGroupName"},
         "RetentionInDays": {"Ref": "RetentionInDays"}
       }
+    },
+
+    "RDSSNSTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "DisplayName": "RDSEvents",
+        "Subscription": [
+          {
+            "Protocol": "email",
+            "Endpoint": "support@digitalmarketplace.service.gov.uk"
+          }
+        ]
+      }
+    },
+
+    "RDSEventSubscription": {
+      "Type": "AWS::RDS::EventSubscription",
+      "Properties": {
+        "Enabled": true,
+        "EventCategories": ["deletion"],
+        "SnsTopicArn": {"Ref": "RDSSNSTopic"},
+        "SourceType": "db-instance"
+      }
     }
   },
 

--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -10,6 +10,10 @@
     "RetentionInDays": {
       "Type": "Number",
       "Description": "Number of days logs should be kept before being deleted."
+    },
+    "Email": {
+      "Type": "String",
+      "Description": "The email address that alert emails will go to."
     }
   },
 
@@ -29,7 +33,7 @@
         "Subscription": [
           {
             "Protocol": "email",
-            "Endpoint": "support@digitalmarketplace.service.gov.uk"
+            "Endpoint": {"Ref": "Email"}
           }
         ]
       }

--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -39,6 +39,17 @@
     }
   },
 
+  "Conditions": {
+    "UseDbSnapshot": {
+      "Fn::Not": [{
+        "Fn::Equals" : [
+          {"Ref": "DBSnapshotIdentifier"},
+          ""
+        ]
+      }]
+    }
+  },
+
   "Resources": {
     "SecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
@@ -50,9 +61,10 @@
 
     "DB": {
       "Type": "AWS::RDS::DBInstance",
+      "DeletionPolicy": "Snapshot",
       "Properties": {
         "Engine": "postgres",
-        "DBName": {"Ref": "DBName"},
+        "DBName": {"Fn::If": ["UseDbSnapshot", {"Ref": "AWS::NoValue"}, {"Ref": "DBName"}]},
         "MasterUsername": {"Ref": "DBUser"},
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
@@ -60,7 +72,7 @@
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},
-        "DBSnapshotIdentifier": {"Ref": "DBSnapshotIdentifier"}
+        "DBSnapshotIdentifier": {"Fn::If": ["UseDbSnapshot", {"Ref": "DBSnapshotIdentifier"}, {"Ref": "AWS::NoValue"}]}
       }
     }
   },

--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -28,6 +28,14 @@
     "MultiAZ": {
       "Type": "String",
       "Description": "Whether the instance is multi AZ or not"
+    },
+    "BackupRetentionPeriod": {
+      "Type": "String",
+      "Description": "Number of days to keep automatic backups for"
+    },
+    "DBSnapshotIdentifier": {
+      "Type": "String",
+      "Description": "The identifier for the DB snapshot to restore from."
     }
   },
 
@@ -50,7 +58,9 @@
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
-        "MultiAZ": {"Ref": "MultiAZ"}
+        "MultiAZ": {"Ref": "MultiAZ"},
+        "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},
+        "DBSnapshotIdentifier": {"Ref": "DBSnapshotIdentifier"}
       }
     }
   },

--- a/stacks.yml
+++ b/stacks.yml
@@ -57,9 +57,9 @@ database:
     DBPassword: "{{ database.password }}"
     DBInstanceType: "{{ database.instance_type }}"
     DBAllocatedStorage: "{{ database.allocated_storage }}"
-    MultiAZ: "{{ rds.multi_az }}"
-    BackupRetentionPeriod: "{{ rds.backup_retention_period }}"
-    DBSnapshotIdentifier: "{{ rds.snapshot_id }}"
+    MultiAZ: "{{ database.multi_az }}"
+    BackupRetentionPeriod: "{{ database.backup_retention_period }}"
+    DBSnapshotIdentifier: "{{ database.snapshot_id }}"
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -57,7 +57,9 @@ database:
     DBPassword: "{{ database.password }}"
     DBInstanceType: "{{ database.instance_type }}"
     DBAllocatedStorage: "{{ database.allocated_storage }}"
-    MultiAZ: "{{ rds_multi_az }}"
+    MultiAZ: "{{ rds.multi_az }}"
+    BackupRetentionPeriod: "{{ rds.backup_retention_period }}"
+    DBSnapshotIdentifier: "{{ rds.snapshot_id }}"
 
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -79,6 +79,7 @@ monitoring:
   parameters:
     LogGroupName: "{{ stage }}-{{ environment }}"
     RetentionInDays: 3653
+    Email: "{{ monitoring_email }}"
 
 api_app:
   name: "digitalmarketplace-api-app"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -2,6 +2,9 @@
 aws_region: eu-west-1
 internal_root_domain: dmdev
 
+rds:
+  snapshot_id: ""
+
 api:
   instance_type: t2.micro
   min_instance_count: 1

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -4,9 +4,6 @@ internal_root_domain: dmdev
 
 monitoring_email: support@digitalmarketplace.service.gov.uk
 
-rds:
-  snapshot_id: ""
-
 api:
   instance_type: t2.micro
   min_instance_count: 1

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -2,6 +2,8 @@
 aws_region: eu-west-1
 internal_root_domain: dmdev
 
+monitoring_email: support@digitalmarketplace.service.gov.uk
+
 rds:
   snapshot_id: ""
 

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -2,7 +2,10 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
-rds_multi_az: "false"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "1"
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/development.yml
+++ b/vars/development.yml
@@ -3,7 +3,7 @@ root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 
-rds:
+database:
   multi_az: "true"
   backup_retention_period: "1"
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -6,6 +6,7 @@ iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 rds:
   multi_az: "false"
   backup_retention_period: "1"
+  snapshot_id: "s2015-05-13t0953z"
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -2,7 +2,10 @@
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
-rds_multi_az: "false"
+
+rds:
+  multi_az: "false"
+  backup_retention_period: "1"
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -3,7 +3,7 @@ root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 
-rds:
+database:
   multi_az: "false"
   backup_retention_period: "1"
   snapshot_id: "s2015-05-13t0953z"

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -3,7 +3,7 @@ root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 
-rds:
+database:
   multi_az: "true"
   backup_retention_period: "30"
 

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -6,6 +6,7 @@ iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 database:
   multi_az: "true"
   backup_retention_period: "30"
+  snapshot_id: "production-2015-05-13t1508"
 
 vpc_id: vpc-70319115
 subnets:

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -2,7 +2,10 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
-rds_multi_az: "true"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "30"
 
 vpc_id: vpc-70319115
 subnets:

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -3,7 +3,7 @@ root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 
-rds:
+database:
   multi_az: "true"
   backup_retention_period: "1"
 

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -2,7 +2,10 @@
 root_domain: "beta.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
-rds_multi_az: "true"
+
+rds:
+  multi_az: "true"
+  backup_retention_period: "1"
 
 vpc_id: vpc-70319115
 subnets:

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -6,6 +6,7 @@ iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 database:
   multi_az: "true"
   backup_retention_period: "1"
+  snapshot_id: "stage-2015-05-13t1454"
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
## Add RDS backup related fields to the CloudFormation template.

### BackupRetentionPeriod
Number of days to keep automatic snapshots around. Set to 1 for
non-production and 30 for production.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-BackupRetentionPeriod

### DBSnapshotIdentifier
A snapshot identifier to use to restore a database from a snapshot. It is defaulted to blank. The idea being it would be provided as a custom variable to restore an environment to a snapshot.
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-dbsnapshotidentifier

## 	Add support for RDS snapshots

A few things get added in this commit:
- A DeletionPolicy is added to the DBInstance resource to Snapshot when
  the resource is deleted
- If DBSnapshotIdentifier is provided DBName is not provided. If a
  DBName is provided a new empty database is always created so the two
  options cannot be provided together.

This approach is largely taken from this blog post
http://blog.jasonantman.com/2014/12/aws-cloudformation-and-rds-snapshots/

## 	Restore preview to a snapshot

This snapshot was made after loading all suppliers, services and users
from production.

## Update from testing

- Deleting the database stack causes an email to be sent
- Updating the database stack requiring replacement causes an email to be sent