### PR TITLE
Make suppliers nginx location a regex

### DIFF
--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -26,7 +26,7 @@ server {
         proxy_pass $admin_frontend_url;
     }
 
-    location /suppliers {
+    location ~ ^/suppliers(/|$) {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
This allows /suppliers-guide to be a route on the buyers app.
The regular expression will only match strings are exactly /suppliers or
start with /suppliers/