### PR TITLE
Update nginx ami

### DIFF
--- a/packer_templates/elasticsearch.json
+++ b/packer_templates/elasticsearch.json
@@ -8,7 +8,11 @@
     "source_ami": "ami-234ecc54",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
-    "ami_name": "elasticsearch-{{isotime | clean_ami_name}}"
+    "ami_name": "elasticsearch-{{isotime | clean_ami_name}}",
+    "ami_users": [
+      "050019655025",
+      "381494870249"
+    ]
   }],
   "provisioners": [
     {

--- a/packer_templates/nginx.json
+++ b/packer_templates/nginx.json
@@ -8,7 +8,11 @@
     "source_ami": "ami-234ecc54",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
-    "ami_name": "nginx-{{isotime | clean_ami_name}}"
+    "ami_name": "nginx-{{isotime | clean_ami_name}}",
+    "ami_users": [
+      "050019655025",
+      "381494870249"
+    ]
   }],
   "provisioners": [
     {

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-ad442eda
+  instance_image: ami-697f081e


### PR DESCRIPTION
## Add permissions to AMI templates
This allows both the production and development accounts access to the
nginx and elasticsearch AMIs.

See: https://www.packer.io/docs/builders/amazon-ebs.html#ami_users

## Update Nginx AMI
Make suppliers nginx location a regex

See: https://github.com/alphagov/digitalmarketplace-aws/pull/86