### PR TITLE
Increase the number of app instances on production

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -16,3 +16,23 @@ subnets:
   - subnet-9a9713ed
   - subnet-63b1683a
   - subnet-ad0894c8
+
+api:
+  min_instance_count: 3
+  max_instance_count: 3
+
+search_api:
+  min_instance_count: 3
+  max_instance_count: 3
+
+admin_frontend:
+  min_instance_count: 3
+  max_instance_count: 3
+
+buyer_frontend:
+  min_instance_count: 3
+  max_instance_count: 3
+
+supplier_frontend:
+  min_instance_count: 3
+  max_instance_count: 3


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/92327910

Increase the number of EC2 instances per app in production to 3. This
matches the number of availability zones for the EU west region. The
assumption is that elastic beanstalk will automatically create the
instances across the availability zones. This will be tested when this
goes out.