### PR TITLE
Add account and stage for monitoring emails

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,7 +4,7 @@ ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/sta
 iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
 
 monitoring:
-  email: support@digitalmarketplace.service.gov.uk
+  email: "support+development-preview@digitalmarketplace.service.gov.uk"
 
 database:
   multi_az: "false"

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -4,7 +4,7 @@ ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 
 monitoring:
-  email: support@digitalmarketplace.service.gov.uk
+  email: "support+production-production@digitalmarketplace.service.gov.uk"
 
 database:
   multi_az: "true"

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -4,7 +4,7 @@ ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016
 iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
 
 monitoring:
-  email: support@digitalmarketplace.service.gov.uk
+  email: "support+production-staging@digitalmarketplace.service.gov.uk"
 
 database:
   multi_az: "true"


### PR DESCRIPTION
It is hard to tell where a monitoring alert came from. This is a simple
way of making it clear which account / stage the alert came from.