### PR TITLE
Increase max instace count on production

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,20 +19,20 @@ subnets:
 
 api:
   min_instance_count: 3
-  max_instance_count: 3
+  max_instance_count: 4
 
 search_api:
   min_instance_count: 3
-  max_instance_count: 3
+  max_instance_count: 4
 
 admin_frontend:
   min_instance_count: 3
-  max_instance_count: 3
+  max_instance_count: 4
 
 buyer_frontend:
   min_instance_count: 3
-  max_instance_count: 3
+  max_instance_count: 4
 
 supplier_frontend:
   min_instance_count: 3
-  max_instance_count: 3
+  max_instance_count: 4


### PR DESCRIPTION
The default parameters beanstalk rolling update require the
max_instance_count to be at least one larger than the min_instance_count
so that one instance can be changed without going either over or under
the limits.

See:
http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html