### PR TITLE
Rename monitoring SNS topic

### DIFF
--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -26,10 +26,10 @@
       }
     },
 
-    "RDSSNSTopic": {
+    "MonitoringSNSTopic": {
       "Type": "AWS::SNS::Topic",
       "Properties": {
-        "DisplayName": "RDSEvents",
+        "DisplayName": "MonitoringEvents",
         "Subscription": [
           {
             "Protocol": "email",
@@ -44,7 +44,7 @@
       "Properties": {
         "Enabled": true,
         "EventCategories": ["deletion"],
-        "SnsTopicArn": {"Ref": "RDSSNSTopic"},
+        "SnsTopicArn": {"Ref": "MonitoringSNSTopic"},
         "SourceType": "db-instance"
       }
     }


### PR DESCRIPTION
SNS topics cannot be updated updated with CloudFormation. The hope is that CloudFormation will remove the old topic and create a new one.

I have tested this on preview and reports that it creates the new SNS topic and RDS event subscription, and deletes the old RDS event subscription but makes no mention of the old SNS topic. However, checking through the AWS console shows that the old SNS topic is no longer there.