### PR TITLE
Increase instance counts on production

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -16,3 +16,23 @@ subnets:
   - subnet-9a9713ed
   - subnet-63b1683a
   - subnet-ad0894c8
+
+api:
+  min_instance_count: 3
+  max_instance_count: 4
+
+search_api:
+  min_instance_count: 3
+  max_instance_count: 4
+
+admin_frontend:
+  min_instance_count: 3
+  max_instance_count: 4
+
+buyer_frontend:
+  min_instance_count: 3
+  max_instance_count: 4
+
+supplier_frontend:
+  min_instance_count: 3
+  max_instance_count: 4


### PR DESCRIPTION
This reverts https://github.com/alphagov/digitalmarketplace-aws/pull/93 which in turn reverted https://github.com/alphagov/digitalmarketplace-aws/pull/89 EC2 instance limits have been increased so this can go out now.