### PR TITLE
Bump instance max count on eb

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,20 +19,20 @@ subnets:
 
 api:
   min_instance_count: 3
-  max_instance_count: 4
+  max_instance_count: 5
 
 search_api:
   min_instance_count: 3
-  max_instance_count: 4
+  max_instance_count: 5
 
 admin_frontend:
   min_instance_count: 3
-  max_instance_count: 4
+  max_instance_count: 5
 
 buyer_frontend:
   min_instance_count: 3
-  max_instance_count: 4
+  max_instance_count: 5
 
 supplier_frontend:
   min_instance_count: 3
-  max_instance_count: 4
+  max_instance_count: 5


### PR DESCRIPTION
The CloudFormation stacks have become confused because we hit our EC2
instance limit. This change basically just changes the input parameters
to the affected stacks to force them to re-run. #lolaws