### PR TITLE
Update frontend artifacts paths included in the release

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -122,8 +122,9 @@ def get_release_name_for_repo(cwd):
 
 
 def add_directory_to_archive(cwd, path, archive_path):
+    full_path = utils.safe_path_join(cwd, path)
     with zipfile.ZipFile(archive_path, 'a') as archive:
-        for root, dirs, files in os.walk(os.path.join(cwd, path)):
+        for root, dirs, files in os.walk(full_path):
             for f in dirs + files:
                 file_path = os.path.join(root, f)
                 archive.write(os.path.join(root, f),
@@ -143,12 +144,13 @@ def create_git_archive(cwd):
 
 
 def run_project_build_script(cwd):
-    utils.run_cmd(['./scripts/build.sh'], cwd=cwd)
+    build_output = utils.run_cmd(['./scripts/build.sh'], cwd=cwd)
+    return build_output.split('\n')
 
 
-def add_build_artefacts_to_archive(cwd, archive):
-    add_directory_to_archive(cwd, 'app/static', archive)
-    add_directory_to_archive(cwd, 'bower_components', archive)
+def add_build_artefacts_to_archive(cwd, archive, build_artefacts):
+    for artefact in build_artefacts:
+        add_directory_to_archive(cwd, artefact, archive)
 
 
 def add_version_label_to_archive(archive_path, version_label):
@@ -159,8 +161,8 @@ def add_version_label_to_archive(archive_path, version_label):
 def create_archive(cwd):
     ref, sha, archive_path = create_git_archive(cwd)
     try:
-        run_project_build_script(cwd)
-        add_build_artefacts_to_archive(cwd, archive_path)
+        build_artefacts = run_project_build_script(cwd)
+        add_build_artefacts_to_archive(cwd, archive_path, build_artefacts)
     except OSError:
         pass
 

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -33,6 +33,17 @@ def run_cmd(args, env=None, cwd=None, stdout=None,
     return streamdata
 
 
+def safe_path_join(basedir, path):
+    path = os.path.join(basedir, path)
+    abs_path = os.path.abspath(path)
+    abs_basedir = os.path.abspath(basedir)
+
+    if not abs_path.startswith(abs_basedir):
+        raise ValueError('Path outside base directory %s' % abs_basedir)
+
+    return path
+
+
 def read_yaml_file(path):
     with open(path) as f:
         return yaml.load(f) or {}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,7 +9,9 @@ from dmaws.build import push_tag
 from dmaws.build import get_other_tags
 from dmaws.build import get_release_name_for_tag, get_release_name_for_repo
 from dmaws.build import create_archive, create_git_archive
+from dmaws.build import run_project_build_script
 from dmaws.build import add_directory_to_archive
+from dmaws.build import add_build_artefacts_to_archive
 
 
 class TestRunGitCmd(object):
@@ -133,7 +135,16 @@ class TestArchiveCreation(object):
     def test_add_directory_to_archive(self):
         add_directory_to_archive('does-not', 'exist', '/dev/null')
 
-    def test_create_archive(self):
+    def test_run_project_build_script(self, run_cmd):
+        run_cmd.return_value = 'path\npath2\npath3'
+
+        assert run_project_build_script('./') == ['path', 'path2', 'path3']
+
+    def test_add_build_artefacts_to_archive(self):
+        add_build_artefacts_to_archive('./', mock.Mock(), ['path1', 'path2'])
+
+    def test_create_archive(self, run_cmd):
+        run_cmd.return_value = 'path1\npath2'
         assert create_archive('does-not-exist')[2] == '/tmp/tempfile'
 
     def test_create_archive_patched(self, git_info):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 from dmaws.utils import run_cmd, CalledProcessError
+from dmaws.utils import safe_path_join
 from dmaws.utils import dict_from_path, merge_dicts
 from dmaws.utils import DEFAULT_TEMPLATES_PATH
 from dmaws.utils import template, template_string, LazyTemplateMapping
@@ -71,6 +72,29 @@ class TestRunCmd(object):
             mock.call(mock.ANY, "ls"),
             mock.call(mock.ANY, "ls", 7)
         ])
+
+
+class TestSafePathJoin(object):
+    def test_simple_subpath(self):
+        assert safe_path_join('', 'app/static') == 'app/static'
+
+    def test_relative_basedir_subpath(self):
+        assert safe_path_join('./', 'app/static') == './app/static'
+
+    def test_relative_basedir_relative_subpath(self):
+        assert safe_path_join('./', './app/static') == '././app/static'
+
+    def test_relative_basedir_parent_subpath(self):
+        with pytest.raises(ValueError):
+            safe_path_join('./', '../../app/static')
+
+    def test_relative_basedir_root_subpath(self):
+        with pytest.raises(ValueError):
+            safe_path_join('./', '/app/static')
+
+    def test_relative_basedir_root_subdir_subpath(self):
+        with pytest.raises(ValueError):
+            safe_path_join('./', '/../../app/static')
 
 
 class TestDictFromPath(object):


### PR DESCRIPTION
Expects project build script to output artefact paths to be included
into the release archive. One path per line.

This requires the build script to redirect any other output to STDERR.
No longer includes any paths on top of the git archive by default.

Adding directory to archive verifies that path is relative to the
project root to prevent root path traversal (eg doesn't allow adding
'/' or '../')