### PR TITLE
Update nginx to 1.8

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Add nginx apt key
+  apt_key:
+    url: http://nginx.org/keys/nginx_signing.key
+    state: present
+  tags: image-setup
+
+- name: Add Nginx repository
+  apt_repository:
+    repo: 'deb http://nginx.org/packages/ubuntu/ trusty nginx'
+    state: present
+  tags: image-setup
+
+- name: Update apt cache if repository just added.
+  apt: update_cache=yes
+  tags: image-setup
+
 - name: Install Nginx
   apt: name=nginx update_cache=yes state=installed
   tags: image-setup

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-2b99ee5c
+  instance_image: ami-d94739ae


### PR DESCRIPTION
Uses nginx apt repository to install the latest version
Allows installing nginx 1.8.0 on Ubuntu 14.04