### PR TITLE
Fix nginx sites directories

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -19,6 +19,18 @@
   apt: name=nginx update_cache=yes state=installed
   tags: image-setup
 
+- name: Ensure that sites-available directory exists
+  file:
+    path: /src/nginx/sites-available
+    state: directory
+  tags: image-setup
+
+- name: Ensure that sites-enabled directory exists
+  file:
+    path: /src/nginx/sites-enabled
+    state: directory
+  tags: image-setup
+
 - name: Ensure that the default site is disabled
   command: rm /etc/nginx/sites-enabled/default
            removes=/etc/nginx/sites-enabled/default

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -35,6 +35,5 @@ http {
 
     # Virtual Host Configs
 
-    include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-d94739ae
+  instance_image: ami-2de59b5a


### PR DESCRIPTION
nginx 1.8 package provided by the nginx apt repository doesn't seem
to create them by default. Instead we create them using ansible.

Also removes loading configuration files from conf.d/, since that's
where the 1.8 keeps default configuration examples.