### PR TITLE
Fix project build script not capturing output

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -144,7 +144,12 @@ def create_git_archive(cwd):
 
 
 def run_project_build_script(cwd):
-    build_output = utils.run_cmd(['./scripts/build.sh'], cwd=cwd)
+    build_output = utils.run_cmd(
+        ['./scripts/build.sh'],
+        cwd=cwd,
+        stdout=subprocess.PIPE
+    )
+
     return build_output.split('\n')
 
 


### PR DESCRIPTION
Since we're using the output to add paths to the release archive it
needs to be captured, otherwise run_cmd returns None.