### PR TITLE
Fix build stderr capture

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -150,7 +150,7 @@ def run_project_build_script(cwd):
         stdout=subprocess.PIPE
     )
 
-    return build_output.split('\n')
+    return [line.strip() for line in build_output.split('\n') if line.strip()]
 
 
 def add_build_artefacts_to_archive(cwd, archive, build_artefacts):

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -12,14 +12,36 @@ from jinja2.runtime import StrictUndefined
 DEFAULT_TEMPLATES_PATH = 'cloudformation_templates/'
 
 
-def run_cmd(args, env=None, cwd=None, stdout=None,
+def run_cmd(args, env=None, cwd=None, stdout=None, stderr=None,
             logger=None, ignore_errors=False):
+    """Run an external process command.
+
+    :param args: a list of command arguments, including the command name
+    :param env: a dictionary of environment variables to add to the current
+                os.environ
+    :param cwd: a directory path to use as working directory when running
+                the command
+    :param stdout: sets the destination for command STDOUT. Set to ``None``
+                   to print the STDOUT or to ``subporcess.PIPE`` to capture
+                   STDOUT for ``run_cmd`` return value
+    :param stderr: sets the destination for command STDERR. Set to ``None``
+                   to print the STDERR or to ``subprocess.STDOUT`` to
+                   capture STDERR for return value when STDOUT is being
+                   captured
+    :param ignore_errors: if set to ``True`` will raise an exception if the
+                          command process exits with non-zero status code
+
+    :return: string containing captured stdout and stderr if stdout and stderr
+             parameters where set. Otherwise returns ``None`` by default
+
+    """
     cmd_env = os.environ.copy()
     cmd_env.update(env or {})
     if logger:
         logger("Running %s", args[0])
     cmd = subprocess.Popen(args, env=cmd_env, cwd=cwd,
-                           stdout=stdout, stderr=subprocess.STDOUT)
+                           stdout=stdout,
+                           stderr=stderr)
     streamdata = cmd.communicate()[0]
     if logger:
         logger("%s completed with return code %s", args[0], cmd.returncode)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -136,7 +136,7 @@ class TestArchiveCreation(object):
         add_directory_to_archive('does-not', 'exist', '/dev/null')
 
     def test_run_project_build_script(self, run_cmd):
-        run_cmd.return_value = 'path\npath2\npath3'
+        run_cmd.return_value = 'path\n\n  path2 \n  \npath3'
 
         assert run_project_build_script('./') == ['path', 'path2', 'path3']
 


### PR DESCRIPTION
Setting stderr to subprocess.STDOUT means it's capture whenever
STDOUT is being captured. Setting it to None by default makes run_cmd
only capture STDOUT. Can be overwritten by passing `subprocess.STDOUT`
as argument value for `stdout`.

We use output capture to parse results of git commands, but they're
written to STDOUT so this change shouldn't affect the release process.

### Ignore empty lines in project build script output
Empty lines (or a trailing \n) leads to the root project directory
being added to the release archive.