### PR TITLE
Change Elastic search cluster firewall

### DIFF
--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -62,8 +62,8 @@
       "Properties": {
         "GroupName": {"Ref": "InstanceSecurityGroup"},
         "IpProtocol": "-1",
-        "FromPort": "0",
-        "ToPort": "65535",
+        "FromPort": "9300",
+        "ToPort": "9300",
         "SourceSecurityGroupName": {"Ref": "InstanceSecurityGroup"}
       }
     },


### PR DESCRIPTION
Limited to only port that ES uses: port 9300,
instead of all ports.

Pivotal story: https://www.pivotaltracker.com/story/show/97093870

Paired with @allait 