### PR TITLE
Rename Security Group Ingress resource to trigger an update

### DIFF
--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -57,7 +57,7 @@
       }
     },
 
-    "ClusterDiscoveryIngress": {
+    "ClusterDiscoverySecurityGroupIngress": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupName": {"Ref": "InstanceSecurityGroup"},


### PR DESCRIPTION
Applying previous change removed the Ingress rule instead of updating it.
Cloud formation logs show that a new resource was created before cleanup
deleted the old one, but the result in security group didn't have the new rule.

Changing the resource name to trigger another update.
