### PR TITLE
Specify protocol for elastic search ClusterDiscoveryIngressGroup

### DIFF
--- a/cloudformation_templates/aws_elasticsearch.json
+++ b/cloudformation_templates/aws_elasticsearch.json
@@ -61,7 +61,7 @@
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupName": {"Ref": "InstanceSecurityGroup"},
-        "IpProtocol": "-1",
+        "IpProtocol": "tcp",
         "FromPort": "9300",
         "ToPort": "9300",
         "SourceSecurityGroupName": {"Ref": "InstanceSecurityGroup"}


### PR DESCRIPTION
Not setting the protocol sets ports to 'all', despite the port range
being limited.