### PR TITLE
Set nginx ELB TLS cipher policy

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -177,9 +177,18 @@
         "LoadBalancerName": {"Ref": "LoadBalancerName"},
         "AvailabilityZones": {"Fn::GetAZs": ""},
         "CrossZone": "true",
+        "Policies": [{
+          "PolicyName": "LoadBalancerSSLPolicy",
+          "PolicyType": "SSLNegotiationPolicyType",
+          "Attributes": [{
+            "Name" : "Reference-Security-Policy",
+            "Value" : "ELBSecurityPolicy-2015-05"
+          }]
+        }],
         "Listeners": [{
           "LoadBalancerPort": "443",
           "InstancePort": "80",
+          "PolicyNames": ["LoadBalancerSSLPolicy"],
           "SSLCertificateId": {"Ref": "SSLCertificateId"},
           "Protocol": "HTTPS"
         }],


### PR DESCRIPTION
Updates the ELB TLS policy to ELBSecurityPolicy-2015-05, which disables
DHE ciphersuites in response to the [Logjam attack](https://weakdh.org)

https://forums.aws.amazon.com/ann.jspa?annID=3061

This changes the SSLLabs SSL Report overall rating from "B" to "A".