### PR TITLE
Fix supplier-frontend static assets URL prefix

### DIFF
--- a/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
@@ -1,3 +1,3 @@
 {% extends "app_base.j2" %}
 
-{% block static_url %}/supplier/static/{% endblock %}
+{% block static_url %}/suppliers/static/{% endblock %}


### PR DESCRIPTION
The app prefix was changed to /suppliers/, but the Elasticbeanstalk
assets prefix was not updated, which means that static assets were
served by the python app and not directly by Apache.