### PR TITLE
Update production root domain and SSL certificate

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,7 +1,7 @@
 ---
-root_domain: "beta.digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-beta-2016-05-05"
-iam_certificate_id: "ASCAJGSVATSZD7C6QICNM"
+root_domain: "digitalmarketplace.service.gov.uk"
+ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2016-05-13"
+iam_certificate_id: "ASCAJG65ZXOA7JBRVORN6"
 
 monitoring:
   email: "support+production-production@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
This can be done before we go live. The plan is to manually create a
hosted zone for beta.digitalmarketplace.service.gov.uk after this been
deployed and manually import the zone file (using cli53 command line
tool).

[cli53](https://github.com/barnybug/cli53)