### PR TITLE
Roll back to a new RDS snapshot ID

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -9,7 +9,7 @@ monitoring:
 database:
   multi_az: "true"
   backup_retention_period: "1"
-  snapshot_id: "stage-2015-05-13t1454"
+  snapshot_id: "staging-2015-07-17t1003"
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
This tests out the documentation at
https://github.gds/pages/gds/digitalmarketplace-manual/rds-backup-recovery.html
in the run up to going live.