### PR TITLE
Nginx and ELB status fixes

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -220,6 +220,11 @@
             "Value": "80"
           },
           {
+            "Namespace": "aws:elb:policies",
+            "OptionName": "ConnectionDrainingEnabled",
+            "Value": true
+          },
+          {
             "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
             "OptionName": "RollingUpdateEnabled",
             "Value": true

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -175,8 +175,13 @@
           },
 {% endfor %}
           {
+            "Namespace": "aws:elasticbeanstalk:application",
+            "OptionName": "Application Healthcheck URL",
+            "Value": "{% block url_prefix %}/{% endblock %}_status?ignore-dependencies"
+          },
+          {
             "Namespace": "aws:elasticbeanstalk:container:python:staticfiles",
-            "OptionName": "{% block static_url %}/static/{% endblock %}",
+            "OptionName": "{{ self.url_prefix() }}static/",
             "Value": "app/static/"
           },
           {

--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -1,3 +1,3 @@
 {% extends "app_base.j2" %}
 
-{% block static_url %}/admin/static/{% endblock %}
+{% block url_prefix %}/admin/{% endblock %}

--- a/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
@@ -1,3 +1,3 @@
 {% extends "app_base.j2" %}
 
-{% block static_url %}/suppliers/static/{% endblock %}
+{% block url_prefix %}/suppliers/{% endblock %}

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -196,7 +196,7 @@
           {"Fn::GetAtt": ["LoadBalancerSecurityGroup", "GroupId"]}
         ],
         "HealthCheck": {
-          "Target": "HTTP:80/",
+          "Target": "HTTP:80/_status",
           "HealthyThreshold": "3",
           "UnhealthyThreshold": "5",
           "Interval": "30",

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -8,6 +8,11 @@
       "Description": "Group Tag"
     },
 
+    "AdminUserIPs": {
+      "Type": "String",
+      "Description": "Comma-separated list of IPs for nginx /admin allow rule"
+    },
+
     "RootDomain": {
       "Type": "String",
       "Description": "Root domain for the public Route 53 records"
@@ -303,6 +308,7 @@
             "ansible-playbook -c local -i localhost, nginx_playbook.yml ",
             "-t instance-config ",
             "-e aws_region=", {"Ref": "AWS::Region"}, " ",
+            "-e admin_user_ips=", {"Ref": "AdminUserIPs"}, " ",
             "-e nameserver_ip=$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf) ",
             "-e cloudwatch_log_group=", {"Ref": "LogGroupName"}, " ",
             "-e assets_subdomain=", {"Ref": "AssetsSubdomain"}, " ",

--- a/packer_templates/nginx.json
+++ b/packer_templates/nginx.json
@@ -5,7 +5,7 @@
   "builders": [{
     "type": "amazon-ebs",
     "region": "{{ user `aws_region` }}",
-    "source_ami": "ami-234ecc54",
+    "source_ami": "ami-664b0a11",
     "instance_type": "t2.micro",
     "ssh_username": "ubuntu",
     "ami_name": "nginx-{{isotime | clean_ami_name}}",

--- a/playbooks/roles/nginx/templates/api.j2
+++ b/playbooks/roles/nginx/templates/api.j2
@@ -4,6 +4,8 @@ server {
 
     set $api_url "{{ api_url }}";
 
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -20,6 +22,8 @@ server {
     server_name {{ search_api_subdomain }}.*;
 
     set $search_api_url "{{ search_api_url }}";
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -6,6 +6,8 @@ server {
     set $documents_s3_url "{{ documents_s3_url }}";
     set $buyer_frontend_url "{{ buyer_frontend_url }}";
 
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -4,6 +4,7 @@ server {
     error_page 400 401 402 403 404 = /404;
 
     set $documents_s3_url "{{ documents_s3_url }}";
+    set $buyer_frontend_url "{{ buyer_frontend_url }}";
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -13,6 +14,6 @@ server {
     }
 
     location /404 {
-        proxy_pass http://localhost;
+        proxy_pass $buyer_frontend_url;
     }
 }

--- a/playbooks/roles/nginx/templates/healthcheck.j2
+++ b/playbooks/roles/nginx/templates/healthcheck.j2
@@ -1,8 +1,8 @@
 server {
     listen 80 default_server;
 
-    location / {
+    location /_status {
         access_log off;
-        return 200;
+        return 200 'nginx healthcheck status ok\n';
     }
 }

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -1,9 +1,9 @@
-user www-data;
+user nginx;
 worker_processes 4;
-pid /run/nginx.pid;
+pid /var/run/nginx.pid;
 
 events {
-    worker_connections 768;
+    worker_connections 1024;
 }
 
 http {
@@ -26,7 +26,7 @@ http {
     # Logging Settings
 
     access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/error.log;
+    error_log /var/log/nginx/error.log warn;
 
     # Gzip Settings
 

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -10,6 +10,13 @@ http {
     # Set DNS resolver address
     resolver {{ nameserver_ip }} valid=300s;
 
+    # Replace ELB IP with the real user IP
+    real_ip_header X-Forwarded-For;
+
+    # Only trust X-Forwarded-For for requests
+    # coming from the default VPC (ie ELB)
+    set_real_ip_from 172.31.0.0/16;
+
     # Basic Settings
     sendfile on;
     tcp_nopush on;

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -17,6 +17,11 @@ server {
     }
 
     location /admin {
+        {% for ip in admin_user_ips.split(",") %}
+        allow {{ user_ip }};
+        {% endfor %}
+        deny all;
+
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -6,6 +6,8 @@ server {
     set $admin_frontend_url "{{ admin_frontend_url }}";
     set $supplier_frontend_url "{{ supplier_frontend_url }}";
 
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/stacks.yml
+++ b/stacks.yml
@@ -137,7 +137,7 @@ database_dev_access:
   dependencies:
     - database
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: "{{ database.port }}"
     ToPort: "{{ database.port }}"
     SecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
@@ -164,7 +164,7 @@ elasticsearch_dev_access:
   dependencies:
     - elasticsearch
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: "{{ elasticsearch.port }}"
     ToPort: "{{ elasticsearch.port }}"
     SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
@@ -175,7 +175,7 @@ elasticsearch_ssh_access:
   dependencies:
     - elasticsearch
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
@@ -365,6 +365,7 @@ nginx:
     - monitoring
   parameters:
     KeyName: "{{ key_name }}"
+    AdminUserIPs: "{{ admin_user_ips | join(',') }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     DocumentsS3URL: "{{stacks.documents_s3.outputs.URL}}"
@@ -394,7 +395,7 @@ nginx_ssh_access:
   dependencies:
     - nginx
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.nginx.outputs.InstanceSecurityGroup }}"
@@ -405,7 +406,7 @@ api_ssh_access:
   dependencies:
     - api
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.api.outputs.InstanceSecurityGroup }}"
@@ -416,7 +417,7 @@ search_api_ssh_access:
   dependencies:
     - search_api
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.search_api.outputs.InstanceSecurityGroup }}"
@@ -427,7 +428,7 @@ admin_frontend_ssh_access:
   dependencies:
     - admin_frontend
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.admin_frontend.outputs.InstanceSecurityGroup }}"
@@ -438,7 +439,7 @@ buyer_frontend_ssh_access:
   dependencies:
     - buyer_frontend
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.buyer_frontend.outputs.InstanceSecurityGroup }}"
@@ -449,7 +450,7 @@ supplier_frontend_ssh_access:
   dependencies:
     - supplier_frontend
   parameters:
-    CidrIp: "{{ user_cidr_ip }}"
+    CidrIp: "{{ dev_user_ip }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.supplier_frontend.outputs.InstanceSecurityGroup }}"

--- a/user.yml.sample
+++ b/user.yml.sample
@@ -1,8 +1,9 @@
 ---
 key_name: ***
-ansible_ssh_private_key_file: "~/.ssh/{{ key_name }}"
 
-user_cidr_ip: ***
+dev_user_ip: ***
+admin_user_ips:
+  - ***
 
 api:
   auth_tokens:

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-15dba562
+  instance_image: ami-e6105991


### PR DESCRIPTION
### Set app ELB health checks to /_status?ignore-dependencies
[#99144578](https://www.pivotaltracker.com/story/show/99144578)

Not setting `/_status` as health check URL means that ELB might mark
the instance as healthy before the app is actually up (Apache responds
on '/' with default EB welcome page).

`?ignore-dependencies` is a simplified status page that always returns
`{"status": "ok"}` and doesn't forward the request to the APIs or DB.

### Fix nginx assets error page to use the buyer-frontend response
Request to 'http://localhosts' was handled by the default healthcheck
server, which always returns an empty 200 response.

Instead, we explicitly send the request to the buyer frontend.

### Set nginx ELB healthcheck URL to /_status
/_status makes sure request is picked up by the healthcheck server

### Limit access to the /admin app to admin_user_ips
[#96672646](https://www.pivotaltracker.com/story/show/96672646)

Sets nginx allow rules using the list if IP addresses from the
`admin_user_ips` list. Requests from any other IPs are denied.

### Fix nginx logrotate and service status issue
The nginx.conf we use was copied from the file provided by the ubuntu
deb package. Since switching to the nginx.org deb repository some of
the settings (including process owner and pid file location) no longer
match the ones in the new package config.

This caused issues with logrotate and service status since nginx
started by ansible reload was no longer writing to the new log files
and could not be started/stopped by the `service nginx`.

Setting the config values to match the nginx.org deb package config
fixes the issue.

### Add HSTS headers to www, api and assets nginx configs …
[#97094484](https://www.pivotaltracker.com/story/show/97094484)

Add HSTS headers to frontend, api and assets responses. Since
unlike other headers we set (eg frame-options and xss-protection)
HSTS is connection-related and nginx is the closest layer to TLS
that can do this it makes sense to add it here and not in the apps.

### Enable ELB connection draining
Enabling connection draining fixed error responses we get during
application deploys.

From the docs:

> You can enable connection draining if you want to keep existing
> load balancer connections open to unhealthy or deregistering
> instances to complete in-progress requests even as the load
> balancer stops sending new requests.

(http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.elb.html#using-features.managing.elb.draining)