### PR TITLE
Notify on beanstalk alarms

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -53,6 +53,10 @@
     "LogGroupName": {
       "Type": "String",
       "Description": "Name of CloudWatch log group"
+    },
+    "MonitoringSNSTopic": {
+      "Type": "String",
+      "Description": "SNS topic for monitoring events"
     }{%- if self.parameters() %},
     {% endif %}
 
@@ -238,6 +242,11 @@
             "Namespace": "aws:elasticbeanstalk:customoption",
             "OptionName": "ApplicationName",
             "Value": {"Ref": "ApplicationName"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:sns:topics",
+            "OptionName": "Notification Topic ARN",
+            "Value": {"Ref": "MonitoringSNSTopic"}
           }
         ]
       }

--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -54,6 +54,10 @@
     "LogGroupName": {
       "Description": "Log group",
       "Value": {"Ref": "LogGroup"}
+    },
+    "MonitoringSNSTopic": {
+      "Description": "SNS topic for monitoring events",
+      "Value": {"Ref": "MonitoringSNSTopic"}
     }
   }
 }

--- a/stacks.yml
+++ b/stacks.yml
@@ -130,6 +130,7 @@ api:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 database_dev_access:
   name: "digitalmarketplace-api-{{ stage }}-{{ environment }}-dev-access"
@@ -219,6 +220,7 @@ search_api:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 admin_frontend_app:
   name: "digitalmarketplace-admin-frontend-app"
@@ -263,6 +265,7 @@ admin_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 buyer_frontend_app:
   name: "digitalmarketplace-buyer-frontend-app"
@@ -308,6 +311,7 @@ buyer_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 supplier_frontend_app:
   name: "digitalmarketplace-supplier-frontend-app"
@@ -352,6 +356,7 @@ supplier_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 nginx:
   name: "nginx-{{ stage }}-{{ environment }}"


### PR DESCRIPTION
## Wire up Beanstalk alarms with the monitoring SNS

This will also alarm on Beanstalk state changes. It may be too noisy, if so we can pass the SNS topic in a custom option.

## Add dummy log group to monitoring

The monitoring stack will not be rebuilt because only the outputs have changed. This introduces a dummy resource to force a rebuild. This resource will be removed after this has been applied.
