### PR TITLE
Nginx config typo fix

### DIFF
--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -19,8 +19,8 @@ server {
     }
 
     location /admin {
-        {% for ip in admin_user_ips.split(",") %}
-        allow {{ user_ip }};
+        {% for admin_ip in admin_user_ips.split(",") %}
+        allow {{ admin_ip }};
         {% endfor %}
         deny all;
 

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-e6105991
+  instance_image: ami-5c155c2b


### PR DESCRIPTION
Tested everything else:
* User IP forwarding works, real IPs in logs now
* Admin access work
* `service nginx status` and `logrotate` fixed