### PR TITLE
Add root DNS records

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -1,0 +1,69 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Additional DNS records that are needed on the root domain.",
+
+  "Parameters": {
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "Hosted zone name"
+    }
+  },
+
+  "Resources": {
+    "GoogleMailServers": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Ref": "HostedZoneName"},
+        "Type": "MX",
+        "ResourceRecords": [
+          "30 ALT4.ASPMX.L.GOOGLE.COM.",
+          "30 ALT3.ASPMX.L.GOOGLE.COM.",
+          "20 ALT2.ASPMX.L.GOOGLE.COM.",
+          "20 ALT1.ASPMX.L.GOOGLE.COM.",
+          "10 ASPMX.L.GOOGLE.COM."
+        ],
+        "TTL": "3600"
+      }
+    },
+    "SPFRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Ref": "HostedZoneName"},
+        "Type": "SPF",
+        "ResourceRecords": "v=spf1 include:_spf.google.com include:spf.mandrillapp.com ~all",
+        "TTL": "3600"
+      }
+    },
+
+    "GoogleVerification": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Ref": "HostedZoneName"},
+        "Type": "TXT",
+        "ResourceRecords": "google-site-verification=j6RvC0_ipOIvcyTR0WBAwa8C5SPblqFaJOS8QByISGI",
+        "TTL": "3600"
+      }
+    },
+
+    "Development": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["", [
+          "development", ".", {"Ref": "HostedZoneName"}
+        ]]},
+        "Type": "NS",
+        "ResourceRecords": [
+          "ns-656.awsdns-18.net.",
+          "ns-1989.awsdns-56.co.uk.",
+          "ns-318.awsdns-39.com.",
+          "ns-1117.awsdns-11.org."
+        ],
+        "TTL": "3600"
+      }
+    }
+  }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -48,6 +48,14 @@ route53zone:
     VPCId: "{{ vpc_id }}"
     InternalRootDomain: "{{ internal_root_domain }}"
 
+route53rootrecords:
+  name: "route53-root-records"
+  template: cloudformation_templates/aws_route53_root_records.json
+  dependencies:
+    - route53zone
+  parameters:
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+
 database:
   name: "rds-database-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_rds_database.json


### PR DESCRIPTION
Add the MX and SPF records from Dyn for email on digitalmarketplace.service.gov.uk and a TXT record that we think is for verifying ownership of the site.

Also adds the development subdomain.