### PR TITLE
Add a CloudWatch log group for JSON logs

### DIFF
--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -26,6 +26,14 @@
       }
     },
 
+    "JSONLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {"Fn::Join": ["", [{"Ref": "LogGroupName"}, "-json"]]},
+        "RetentionInDays": 30
+      }
+    },
+
     "MonitoringSNSTopic": {
       "Type": "AWS::SNS::Topic",
       "Properties": {


### PR DESCRIPTION
Performing more complex metric filters is much easier with JSON logs.

See: http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/FilterAndPatternSyntax.html#d0e11216