### PR TITLE
Fix deploy command docstring

### DIFF
--- a/dmaws/commands/deploy.py
+++ b/dmaws/commands/deploy.py
@@ -11,7 +11,6 @@ from ..build import get_application_name
 @cli_command('deploy', max_apps=0)
 def deploy_cmd(ctx, repository_path):
     """Deploy a new application version to the Elastic Beanstalk environment.
-
     """
 
     app = get_application_name(repository_path)


### PR DESCRIPTION
If this blank line is in the docstring then click blows up. This is a bug in click but it's easy to fix here.