### PR TITLE
Add JSONLogGroupName to the application stacks

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -54,6 +54,10 @@
       "Type": "String",
       "Description": "Name of CloudWatch log group"
     },
+    "JSONLogGroupName": {
+      "Type": "String",
+      "Description": "Name of CloudWatch JSON log group"
+    },
     "MonitoringSNSTopic": {
       "Type": "String",
       "Description": "SNS topic for monitoring events"
@@ -247,6 +251,11 @@
             "Namespace": "aws:elasticbeanstalk:customoption",
             "OptionName": "LogGroupName",
             "Value": {"Ref": "LogGroupName"}
+          },
+          {
+            "Namespace": "aws:elasticbeanstalk:customoption",
+            "OptionName": "JSONLogGroupName",
+            "Value": {"Ref": "JSONLogGroupName"}
           },
           {
             "Namespace": "aws:elasticbeanstalk:customoption",

--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -63,6 +63,10 @@
       "Description": "Log group",
       "Value": {"Ref": "LogGroup"}
     },
+    "JSONLogGroupName": {
+      "Description": "JSON log group",
+      "Value": {"Ref": "JSONLogGroup"}
+    },
     "MonitoringSNSTopic": {
       "Description": "SNS topic for monitoring events",
       "Value": {"Ref": "MonitoringSNSTopic"}

--- a/stacks.yml
+++ b/stacks.yml
@@ -138,6 +138,7 @@ api:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
     MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 database_dev_access:
@@ -228,6 +229,7 @@ search_api:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
     MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 admin_frontend_app:
@@ -273,6 +275,7 @@ admin_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
     MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 buyer_frontend_app:
@@ -319,6 +322,7 @@ buyer_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
     MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 supplier_frontend_app:
@@ -364,6 +368,7 @@ supplier_frontend:
     HostedZoneName: "{{ stacks.route53zone.outputs.InternalHostedZoneName }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
+    JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
     MonitoringSNSTopic: "{{ stacks.monitoring.outputs.MonitoringSNSTopic }}"
 
 nginx:


### PR DESCRIPTION
It is easier and less error prone to pass this in to the application stacks rather than generating it in each application stack.