### PR TITLE
nginx robots.txt, max request size and ASG update policy

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -293,6 +293,12 @@
         "MinSize" : {"Ref": "InstanceCount"},
         "MaxSize" : {"Ref": "InstanceCount"},
         "DesiredCapacity" : {"Ref": "InstanceCount"}
+      },
+      "UpdatePolicy" : {
+        "AutoScalingRollingUpdate": {
+          "MinInstancesInService": "1",
+          "MaxBatchSize": "1"
+        }
       }
     },
 

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -288,6 +288,8 @@
         "AvailabilityZones" : {"Fn::GetAZs": ""},
         "LaunchConfigurationName" : {"Ref": "LaunchConfiguration"},
         "LoadBalancerNames": [{"Ref": "LoadBalancer"}],
+        "HealthCheckType": "ELB",
+        "HealthCheckGracePeriod": 300,
         "MinSize" : {"Ref": "InstanceCount"},
         "MaxSize" : {"Ref": "InstanceCount"},
         "DesiredCapacity" : {"Ref": "InstanceCount"}

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -4,3 +4,5 @@ nginx_configs:
   - api
   - assets
   - healthcheck
+
+static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/files/robots.txt
+++ b/playbooks/roles/nginx/files/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /admin
+Disallow: /suppliers
+Disallow: /g-cloud/search?

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -44,6 +44,14 @@
   notify: reload nginx
   tags: instance-config
 
+- name: Ensure {{ static_files_root }} dir exists
+  file: path={{ static_files_root }} state=directory
+  tags: image-setup
+
+- name: Copy robots.txt file
+  copy: src=robots.txt dest={{ static_files_root }}/robots.txt owner=root group=root mode=0644
+  tags: image-setup
+
 - name: Create the Nginx configuration files
   template: src={{ item }}.j2
             dest=/etc/nginx/sites-available/{{ item }}

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -27,6 +27,9 @@ http {
     # Raise bucket size for long domain names
     server_names_hash_bucket_size 128;
 
+    # Set max request size (up to 4 files x 10Mb size limit)
+    client_max_body_size 40m;
+
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -8,6 +8,10 @@ server {
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
+    location /robots.txt {
+        alias {{ static_files_root }}/robots.txt;
+    }
+
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-5c155c2b
+  instance_image: ami-80cf9bf7


### PR DESCRIPTION
### Set nginx request size limit to 40Mb to allow file uploads
Default `client_max_body_size` is 1Mb and nginx returns 413 if
requests exceeds the size limit.

### Add robots.txt to block /admin and /suppliers indexing
[#99500206](https://www.pivotaltracker.com/story/show/99500206)

Adds robots.txt file served from the root of www. Disallows any
URLs starting with `/admin` or `/suppliers`, so that both root
pages and all other pages of admin and supplier apps are not
indexed.

Since suppliers-guide was moved to `/g-cloud/suppliers-guide`,
there's no need to add an allow rule for it.

### Set nginx ASG health check to use ELB status
By default Auto Scaling Groups use EC2 instance status
checks to add or remove instances from the group. Which
means that even if the instance doesn't respond to the
ELB health checks it will still be "InService".

Changing the ASG health check to "ELB" makes sure that only
instances that pass all attached ELB health checks are added
to the group and any instances that are reported as "OutOfService"
by the load balancer are replaced.

The health check grace period set to 5 minutes ensures that instance
has enough time to boot up before the health check is performed,
otherwise launching instances could be marked as unhealthy before
that have finished setting up nginx.

(http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-add-elb-healthcheck.html)

### Add cloudformation policy to cycle nginx instances on update
Setting update policy on the AutoScalingGroup resource makes
cloudformation replace instances if the launch configuration
has changed. This way there's no need to terminate the nginx
instances manually after AMI changes.

With ELB-based health checks set for the nginx ASG setting
batch size and min number of live instances should be enough
to make sure that Cloudformation replaces instances one at a
time and waits for the instance to complete setup steps before
shutting down the next one.

(http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html)