### PR TITLE
nginx connection draining

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -200,6 +200,10 @@
         "SecurityGroups": [
           {"Fn::GetAtt": ["LoadBalancerSecurityGroup", "GroupId"]}
         ],
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 300
+        },
         "HealthCheck": {
           "Target": "HTTP:80/_status",
           "HealthyThreshold": "3",

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -18,4 +18,8 @@ server {
     location /404 {
         proxy_pass $buyer_frontend_url;
     }
+
+    location /static {
+        proxy_pass $buyer_frontend_url;
+    }
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -43,4 +43,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-80cf9bf7
+  instance_image: ami-acf9addb


### PR DESCRIPTION
### Enable connection draining for nginx ELB
Connection draining will keep instance InService for the given
time to allow existing requests to finish. This way nginx AMI
updates could be applied without interrupting or failing any
requests.

This is the same setting we've enabled to fix failing requests on
application deploys.

### Add /static forwarding to buyer frontend for assets domain
404 page forwarded from the buyer frontend to handle missing service
documents references static files required to display the page.

When handling requests for /static URLs nginx tries to request them
from S3, gets a 404 and returns the same buyer frontend 404 page.

Adding a /static location forwarded to the buyer frontend fixes the
issue.