### PR TITLE
User IPs ingress for www ELB

### DIFF
--- a/cloudformation_templates/aws_dev_access.json
+++ b/cloudformation_templates/aws_dev_access.json
@@ -7,9 +7,9 @@
       "Type": "String",
       "Description": "Target security group name"
     },
-    "CidrIp": {
+    "CidrIPs": {
       "Type": "String",
-      "Description": "CIDR IP to use for security group rules"
+      "Description": "List of CIDR IPs to use for security group rules"
     },
     "FromPort": {
       "Type": "Number",
@@ -22,15 +22,18 @@
   },
 
   "Resources": {
-    "DeveloperIngress": {
+{% for dev_ip in parameters.CidrIPs.split(',') %}
+    "DeveloperIngress{{ loop.index }}": {
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupName": {"Ref": "SecurityGroup"},
         "IpProtocol": "tcp",
         "FromPort": {"Ref": "FromPort"},
         "ToPort": {"Ref": "ToPort"},
-        "CidrIp": {"Ref": "CidrIp"}
+        "CidrIp": "{{ dev_ip }}"
       }
-    }
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
   }
 }

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -8,9 +8,14 @@
       "Description": "Group Tag"
     },
 
+    "UserIPs": {
+      "Type": "String",
+      "Description": "Comma-separated list of CIDRs for ELB ingress rule"
+    },
+
     "AdminUserIPs": {
       "Type": "String",
-      "Description": "Comma-separated list of IPs for nginx /admin allow rule"
+      "Description": "Comma-separated list of CIDRs/IPs for nginx /admin allow rule"
     },
 
     "RootDomain": {
@@ -106,18 +111,13 @@
     "LoadBalancerSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "ELB security group"
-      }
-    },
+        "GroupDescription": "ELB security group",
+        "SecurityGroupIngress": [
+{% for user_ip in parameters.UserIPs.split(",") %}
+          {"IpProtocol": "tcp", "CidrIp": "{{ user_ip }}", "FromPort": 443, "ToPort": 443}{% if not loop.last %},{% endif %}
 
-    "LoadBalancerIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "GroupName": {"Ref": "LoadBalancerSecurityGroup"},
-        "IpProtocol": "tcp",
-        "FromPort": 443,
-        "ToPort": 443,
-        "CidrIp": "0.0.0.0/0"
+{% endfor %}
+        ]
       }
     },
 

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -66,6 +66,7 @@ class BuiltStack(Stack):
             return s2.upper().replace('ENV_VAR_', '')
 
         return template(template_body, {
+            "parameters": self.parameters,
             "environment_variables": environment_variables,
             "param_to_env": param_to_env,
         })

--- a/stacks.yml
+++ b/stacks.yml
@@ -147,7 +147,7 @@ database_dev_access:
   dependencies:
     - database
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: "{{ database.port }}"
     ToPort: "{{ database.port }}"
     SecurityGroup: "{{ stacks.database.outputs.SecurityGroup }}"
@@ -174,7 +174,7 @@ elasticsearch_dev_access:
   dependencies:
     - elasticsearch
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: "{{ elasticsearch.port }}"
     ToPort: "{{ elasticsearch.port }}"
     SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
@@ -185,7 +185,7 @@ elasticsearch_ssh_access:
   dependencies:
     - elasticsearch
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.elasticsearch.outputs.InstanceSecurityGroup }}"
@@ -414,7 +414,7 @@ nginx_ssh_access:
   dependencies:
     - nginx
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.nginx.outputs.InstanceSecurityGroup }}"
@@ -425,7 +425,7 @@ api_ssh_access:
   dependencies:
     - api
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.api.outputs.InstanceSecurityGroup }}"
@@ -436,7 +436,7 @@ search_api_ssh_access:
   dependencies:
     - search_api
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.search_api.outputs.InstanceSecurityGroup }}"
@@ -447,7 +447,7 @@ admin_frontend_ssh_access:
   dependencies:
     - admin_frontend
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.admin_frontend.outputs.InstanceSecurityGroup }}"
@@ -458,7 +458,7 @@ buyer_frontend_ssh_access:
   dependencies:
     - buyer_frontend
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.buyer_frontend.outputs.InstanceSecurityGroup }}"
@@ -469,7 +469,7 @@ supplier_frontend_ssh_access:
   dependencies:
     - supplier_frontend
   parameters:
-    CidrIp: "{{ dev_user_ip }}"
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
     FromPort: 22
     ToPort: 22
     SecurityGroup: "{{ stacks.supplier_frontend.outputs.InstanceSecurityGroup }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -383,6 +383,7 @@ nginx:
     - monitoring
   parameters:
     KeyName: "{{ key_name }}"
+    UserIPs: "{{ user_ips | join(',') }}"
     AdminUserIPs: "{{ admin_user_ips | join(',') }}"
 
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"

--- a/user.yml.sample
+++ b/user.yml.sample
@@ -1,7 +1,9 @@
 ---
 key_name: ***
 
-dev_user_ip: ***
+dev_user_ips:
+  - ***
+
 admin_user_ips:
   - ***
 

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -2,6 +2,9 @@
 aws_region: eu-west-1
 internal_root_domain: dmdev
 
+user_ips:
+  - 0.0.0.0/0
+
 api:
   instance_type: t2.micro
   min_instance_count: 1

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -5,6 +5,9 @@ internal_root_domain: dmdev
 user_ips:
   - 0.0.0.0/0
 
+dev_user_ips:
+  - 127.0.0.1/32
+
 api:
   instance_type: t2.micro
   min_instance_count: 1


### PR DESCRIPTION
## Add UserIPs parameter to nginx stack
[#99310600](https://www.pivotaltracker.com/story/show/99310600)

Sets the ELB ingress rule to only allow connections from the given
IPs/CIDR ranges. Defaults to 0.0.0.0/0 in vars/common.

Overwriting the `user_ips` list in user.yml allows limiting access
to full preview/staging environments.

## Use a list of dev_user_ips for ssh/dev-access tasks
Creates a separate ingress resource for each developer IP/CIDR range.

Requires:
- [ ]  digitalmarketplace-credentials variables update (PR 21)