### PR TITLE
Proxy g-cloud-7 assets to the draft documents bucket

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -308,6 +308,7 @@
       },
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate": {
+          "PauseTime" : "PT10M",
           "MinInstancesInService": "1",
           "MaxBatchSize": "1"
         }

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -61,6 +61,10 @@
       "Type": "String",
       "Description": "Subdomain to serve assets from"
     },
+    "G7DraftDocumentsS3URL": {
+      "Type": "String",
+      "Description": "G7 Draft Documents S3 bucket URL"
+    },
     "DocumentsS3URL": {
       "Type": "String",
       "Description": "Documents S3 bucket URL"
@@ -329,6 +333,7 @@
             "-e cloudwatch_log_group=", {"Ref": "LogGroupName"}, " ",
             "-e cloudwatch_json_log_group=", {"Ref": "JSONLogGroupName"}, " ",
             "-e assets_subdomain=", {"Ref": "AssetsSubdomain"}, " ",
+            "-e g7_draft_documents_s3_url=", {"Ref": "G7DraftDocumentsS3URL"}, " ",
             "-e documents_s3_url=", {"Ref": "DocumentsS3URL"}, " ",
             "-e api_subdomain=", {"Ref": "ApiSubdomain"}, " ",
             "-e api_url=", {"Ref": "ApiURL"}, " ",

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -4,6 +4,7 @@ server {
     error_page 400 401 402 403 404 = /404;
 
     set $documents_s3_url "{{ documents_s3_url }}";
+    set $g7_draft_documents_s3_url "{{ g7_draft_documents_s3_url }}";
     set $buyer_frontend_url "{{ buyer_frontend_url }}";
 
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
@@ -13,6 +14,13 @@ server {
         proxy_intercept_errors on;
 
         proxy_pass $documents_s3_url;
+    }
+
+    location /g-cloud-7 {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_intercept_errors on;
+
+        proxy_pass $g7_draft_documents_s3_url;
     }
 
     location /404 {

--- a/stacks.yml
+++ b/stacks.yml
@@ -353,6 +353,7 @@ supplier_frontend:
     EnvVarDmEnvironment: "{{ stage }}"
     EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
     EnvVarDmG7DraftDocumentsBucket: "{{ stacks.g7_draft_documents_s3.outputs.Name }}"
+    EnvVarDmG7DraftDocumentsUrl: "https://{% if stage != 'production' %}{{ stage }}-{% endif %}{% if stage != environment %}{{ environment }}-{% endif %}assets.{{root_domain}}"
     EnvVarDmSupplierFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmDataApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
@@ -392,6 +393,7 @@ nginx:
     LogGroupName: "{{ stacks.monitoring.outputs.LogGroupName }}"
     JSONLogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
 
+    G7DraftDocumentsS3URL: "{{stacks.g7_draft_documents_s3.outputs.URL}}"
     DocumentsS3URL: "{{stacks.documents_s3.outputs.URL}}"
     ApiURL: "{{stacks.api.outputs.URL}}"
     SearchApiURL: "{{stacks.search_api.outputs.URL}}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -49,4 +49,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-acf9addb
+  instance_image: ami-36f6a541


### PR DESCRIPTION
Maps assets /g-cloud-7 prefix to the G7 draft documents bucket.
This makes it possible to use the assets domain for draft documents
as well as any framework related files (eg supplier pack) as long as
the S3 object path starts with "g-cloud-7" prefix.