### PR TITLE
Add clarification_question_email variable

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -358,6 +358,7 @@ supplier_frontend:
     EnvVarDmDataApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ supplier_frontend.mandrill_key }}"
+    EnvVarDmClarificationQuestionEmail: "{{ supplier_frontend.clarification_question_email }}"
     EnvVarDmPasswordSecretKey: "{{ supplier_frontend.password_key }}"
     EnvVarDmSharedEmailKey: "{{ supplier_frontend.shared_email_key }}"
 


### PR DESCRIPTION
The supplier app uses [`DM_CLARIFICATION_QUESTION_EMAIL`](https://github.com/alphagov/digitalmarketplace-supplier-frontend/search?utf8=%E2%9C%93&q=DM_CLARIFICATION_QUESTION_EMAIL) to set an email address where to send clarification questions.