### PR TITLE
Add a CloudWatch metric for Nginx requestTime

### DIFF
--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -55,6 +55,21 @@
         "SnsTopicArn": {"Ref": "MonitoringSNSTopic"},
         "SourceType": "db-instance"
       }
+    },
+
+    "CloudWatchMetricNginxRequestTime": {
+      "Type": "AWS::Logs::MetricFilter",
+      "Properties": {
+        "LogGroupName": {"Fn::Join": ["", [{"Ref": "LogGroupName"}, "-json"]]},
+        "FilterPattern": "{ $.logType = nginx-access }",
+        "MetricTransformations": [
+          {
+            "MetricName": "requestTime",
+            "MetricNamespace": {"Fn::Join": ["/", [{"Ref": "LogGroupName"}, "Nginx"]]},
+            "MetricValue": "$.requestTime"
+          }
+        ]
+      }
     }
   },
 


### PR DESCRIPTION
This will create a CloudWatch metric filter that takes the requestTime from Nginx JSON logs and puts it into a CloudWatch metric. In preview the metric will have a namespace preview-preview/Nginx and a name of requestTime. This doesn't match metric naming convention we've used to date because we don't have access to the ElasticBeanstalk environment name. This may actually turn out to be a more flexible naming convention.

This has been tested on preview

![screen shot 2015-08-27 at 16 01 34](https://cloud.githubusercontent.com/assets/14287/9524136/28dc6da2-4cd5-11e5-9bce-575bc8d28e8e.png)
