### PR TITLE
DM-Request-ID updates for Nginx logs

### DIFF
--- a/playbooks/roles/nginx/templates/api.j2
+++ b/playbooks/roles/nginx/templates/api.j2
@@ -10,6 +10,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;
+        proxy_set_header DM-Request-ID "";
 
         proxy_redirect http:// https://;
 
@@ -29,6 +30,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;
+        proxy_set_header DM-Request-ID "";
 
         proxy_redirect http:// https://;
 

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -35,13 +35,13 @@ http {
 
     # Logging Settings
 
-    log_format access_txt 'nginx-access "$http_dm_request_id" $remote_addr - '
+    log_format access_txt 'nginx-access "$upstream_http_dm_request_id" $remote_addr - '
                           '$remote_user [$time_local] "$request" $status '
                           '$body_bytes_sent "$http_referer" "$http_user_agent" '
                           '$request_time $http_host';
 
     log_format access_json '{"logType": "nginx-access", '
-                           ' "requestId": "$http_dm_request_id", '
+                           ' "requestId": "$upstream_http_dm_request_id", '
                            ' "remoteHost": "$remote_addr", '
                            ' "user": "$remote_user", '
                            ' "time": "$time_local", '

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -16,6 +16,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;
+        proxy_set_header DM-Request-ID "";
 
         proxy_redirect http:// https://;
 
@@ -31,6 +32,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;
+        proxy_set_header DM-Request-ID "";
 
         proxy_redirect http:// https://;
 
@@ -41,6 +43,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header Host $http_host;
+        proxy_set_header DM-Request-ID "";
 
         proxy_redirect http:// https://;
 

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -49,4 +49,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-fc09528b
+  instance_image: ami-c5356fb2


### PR DESCRIPTION
## Use upstream DM-Request-ID for Nginx logs

$http_dm_request_id takes the value from the request header however we
want to take it from the response of the upstream.

http://nginx.org/en/docs/http/ngx_http_upstream_module.html#var_upstream_http_

## Unset DM-Request-ID on initial requests

The way that we pass the DM-Request-ID around services is through the HTTP header. As a result, a client could set the DM-Request-ID themselves from outside. This strips that header on the way in so that one is generated internally.

There is no unset header directive, instead an empty value prevents the header being passed on to the proxied server.

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header