### PR TITLE
Bump Nginx AMI

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -49,4 +49,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-c5356fb2
+  instance_image: ami-3b87dd4c


### PR DESCRIPTION
This includes this change
https://github.com/alphagov/digitalmarketplace-aws/commit/6fd5554f3092220692044212bfec37f9f787fbe3

When rebasing I accidentally lost the AMI bump.