### PR TITLE
Move 5xx metric filters and alarms to dmaws

### DIFF
--- a/cloudformation_templates/alarms/CloudWatchHTTP5xxCountAlarm.j2
+++ b/cloudformation_templates/alarms/CloudWatchHTTP5xxCountAlarm.j2
@@ -1,0 +1,14 @@
+{
+  "Fn::Join": [
+    "",
+    [
+      "Too many 5xx\n",
+      "Stage and environment: ", {"Ref": "LogGroupName"}, "\n",
+      "Application: ", {"Ref": "ApplicationName"}, "\n",
+      "Manual: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate\n",
+      "\n",
+      "MetricNamespace: ", {"Ref": "EnvVarDmMetricsNamespace"}, "\n",
+      "LogGroupName: ", {"Ref": "LogGroupName"}, "\n"
+    ]
+  ]
+}

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -1,3 +1,4 @@
+{% import "metrics.j2" as metrics %}
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Digital Marketplace Elastic Beanstalk Environment",
@@ -280,6 +281,28 @@
         "Description": "Digital Marketplace EB Environment"
       }
     },
+
+    {{ metrics.metric_filter("CloudWatchHTTP5xxMetricFilter",
+                             pattern="{ $.logType = apache-access && $.application = api && $.status = 5* }",
+                             metric_name="HTTP5xx",
+                             metric_value=1) }}
+
+    {{ metrics.metric_filter("CloudWatchHTTPNon5xxMetricFilter",
+                             pattern="{ $.logType = apache-access && $.application = api && $.status != 5* }",
+                             metric_name="HTTP5xx",
+                             metric_value=0) }}
+
+    {{ metrics.alarm("CloudWatchHTTP5xxCountAlarm",
+                    metric_name="HTTP5xx",
+                    statistic="Sum",
+                    period=60,
+                    evaluation_period=1,
+                    threshold=10,
+                    comparison_operator="GreaterThanThreshold",
+                    depends_on=[
+                      "CloudWatchHTTP5xxMetricFilter",
+                      "CloudWatchHTTPNon5xxMetricFilter"
+                    ]) }}
 
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",

--- a/cloudformation_templates/metrics.j2
+++ b/cloudformation_templates/metrics.j2
@@ -1,0 +1,36 @@
+{% macro metric_filter(name, pattern, metric_name, metric_value) -%}
+  "{{ name }}": {
+    "Type": "AWS::Logs::MetricFilter",
+    "Properties": {
+      "LogGroupName": {"Ref": "JSONLogGroupName"},
+      "FilterPattern": "{{ pattern }}",
+      "MetricTransformations": [
+        {
+          "MetricValue": {{ metric_value }},
+          "MetricNamespace": {"Ref": "EnvVarDmMetricsNamespace"},
+          "MetricName": "{{ metric_name }}"
+        }
+      ]
+    }
+  },
+{%- endmacro %}
+
+{% macro alarm(name, metric_name, statistic, period, evaluation_period, threshold, comparison_operator, depends_on) -%}
+  "{{ name }}": {
+    "Type": "AWS::CloudWatch::Alarm",
+    "DependsOn": ["{% if depends_on is sequence and depends_on is not string %}{{ depends_on|join('", "') }}{% else %}{{ depends_on }}{% endif %}"],
+    "Properties": {
+      "Namespace": {"Ref": "EnvVarDmMetricsNamespace"},
+      "MetricName": "{{ metric_name }}",
+      "AlarmDescription": {% include "alarms/%s.j2" % name %},
+      "Statistic": "{{ statistic }}",
+      "Period": {{ period }},
+      "EvaluationPeriods": {{ evaluation_period }},
+      "Threshold": {{ threshold }},
+      "ComparisonOperator": "{{ comparison_operator }}",
+      "AlarmActions": [
+        {"Ref": "MonitoringSNSTopic"}
+      ]
+    }
+  },
+{%- endmacro %}

--- a/dmaws/cloudformation.py
+++ b/dmaws/cloudformation.py
@@ -120,6 +120,7 @@ class Cloudformation(object):
             elif info.get('status') in ['ROLLBACK_COMPLETE',
                                         'ROLLBACK_FAILED',
                                         '%s_ROLLBACK_COMPLETE' % operation,
+                                        '%s_ROLLBACK_FAILED' % operation,
                                         '%s_FAILED' % operation]:
                 self.log('==> Stack [%s] is now %s', stack.name,
                          info['status'], color='red')

--- a/stacks.yml
+++ b/stacks.yml
@@ -120,7 +120,7 @@ api:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarSqlalchemyDatabaseUri: "postgres://{{ database.user }}:{{ database.password}}@{{ stacks.database.outputs.URL }}"
     EnvVarDmApiAuthTokens: "{{ api.auth_tokens | join(':') }}"
     EnvVarDmSearchApiUrl: "{{ stacks.search_api.outputs.URL }}"
@@ -212,7 +212,7 @@ search_api:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.search_api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmElasticsearchUrl: "{{ stacks.elasticsearch.outputs.URL }}"
     EnvVarDmSearchApiAuthTokens: "{{ search_api.auth_tokens | join(':') }}"
 
@@ -255,7 +255,7 @@ admin_frontend:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.admin_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmS3DocumentBucket: "{{ stacks.documents_s3.outputs.Name }}"
     EnvVarDmAdminFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
@@ -304,7 +304,7 @@ buyer_frontend:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.buyer_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmBuyerFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmBuyerFrontendSearchApiAuthToken: "{{ search_api.auth_tokens[0] }}"
@@ -351,7 +351,7 @@ supplier_frontend:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.supplier_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmG7DraftDocumentsBucket: "{{ stacks.g7_draft_documents_s3.outputs.Name }}"
     EnvVarDmG7DraftDocumentsUrl: "https://{% if stage != 'production' %}{{ stage }}-{% endif %}{% if stage != environment %}{{ environment }}-{% endif %}assets.{{root_domain}}"
     EnvVarDmSupplierFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"


### PR DESCRIPTION
Move the 5xx metric filters and alarms into dmaws from the applications .ebextensions.

A short version of the application name has been added to the DM_METRICS_NAMESPACE to match the namespace used for Nginx logs and be easier to search for than making the metric names themselves really long. This is the AWS recommended way of organising metrics.

Metric filters and alarms have been pulled out into macros to avoid mistakes in boilerplate such as log group name, alarm actions and namespace.

Alarm descriptions are implemented in separate templates so that they can be easily managed and more easily made uniform (eg. extending from a base template).

After discussion we have decided not to port over the 4xx and related alarms unless they can be shown to be useful. Instead favouring more specific alarms where needed.