### PR TITLE
Move cloudwatch to dmaws

### DIFF
--- a/cloudformation_templates/alarms/CloudWatchHTTP5xxCountAlarm.j2
+++ b/cloudformation_templates/alarms/CloudWatchHTTP5xxCountAlarm.j2
@@ -1,0 +1,14 @@
+{
+  "Fn::Join": [
+    "",
+    [
+      "Too many 5xx\n",
+      "Stage and environment: ", {"Ref": "LogGroupName"}, "\n",
+      "Application: ", {"Ref": "ApplicationName"}, "\n",
+      "Manual: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate\n",
+      "\n",
+      "MetricNamespace: ", {"Ref": "EnvVarDmMetricsNamespace"}, "\n",
+      "LogGroupName: ", {"Ref": "LogGroupName"}, "\n"
+    ]
+  ]
+}

--- a/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
+++ b/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
@@ -1,5 +1,5 @@
 {% extends "alarms/base_alarm.j2" %}
 
-{% block description %}Login failure rate too high{% endblock %}
+{% block description %}Too many 5xx{% endblock %}
 
-{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failure-rate{% endblock %}
+{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-errors{% endblock %}

--- a/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
+++ b/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
@@ -1,0 +1,5 @@
+{% extends "alarms/base_alarm.j2" %}
+
+{% block description %}Login failure rate too high{% endblock %}
+
+{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failure-rate{% endblock %}

--- a/cloudformation_templates/alarms/LoginFailurePercentAlarm.j2
+++ b/cloudformation_templates/alarms/LoginFailurePercentAlarm.j2
@@ -1,0 +1,5 @@
+{% extends "alarms/base_alarm.j2" %}
+
+{% block description %}Too many 5xx{% endblock %}
+
+{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-errors{% endblock %}

--- a/cloudformation_templates/alarms/LoginFailurePercentAlarm.j2
+++ b/cloudformation_templates/alarms/LoginFailurePercentAlarm.j2
@@ -1,5 +1,5 @@
 {% extends "alarms/base_alarm.j2" %}
 
-{% block description %}Too many 5xx{% endblock %}
+{% block description %}Login failure rate too high{% endblock %}
 
-{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-errors{% endblock %}
+{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#login-failure-rate{% endblock %}

--- a/cloudformation_templates/alarms/base_alarm.j2
+++ b/cloudformation_templates/alarms/base_alarm.j2
@@ -2,10 +2,10 @@
   "Fn::Join": [
     "",
     [
-      "Too many 5xx\n",
+      "{% block description %}{% endblock %}\n",
       "Stage and environment: ", {"Ref": "LogGroupName"}, "\n",
       "Application: ", {"Ref": "ApplicationName"}, "\n",
-      "Manual: https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-error-rate\n",
+      "Manual: {% block manual_url %}{% endblock %}\n",
       "\n",
       "MetricNamespace: ", {"Ref": "EnvVarDmMetricsNamespace"}, "\n",
       "LogGroupName: ", {"Ref": "LogGroupName"}, "\n"

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -297,7 +297,7 @@
                     statistic="Sum",
                     period=60,
                     evaluation_periods=1,
-                    threshold=10,
+                    threshold=1,
                     comparison_operator="GreaterThanThreshold",
                     depends_on=[
                       "HTTP5xxMetricFilter",

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -1,3 +1,4 @@
+{% import "metrics.j2" as metrics %}
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Digital Marketplace Elastic Beanstalk Environment",
@@ -280,6 +281,28 @@
         "Description": "Digital Marketplace EB Environment"
       }
     },
+
+    {{ metrics.metric_filter("HTTP5xxMetricFilter",
+                             pattern="$.logType = apache-access && $.status = 5*",
+                             metric_name="HTTP5xx",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("HTTPNon5xxMetricFilter",
+                             pattern="$.logType = apache-access && $.status != 5*",
+                             metric_name="HTTP5xx",
+                             metric_value=0) }},
+
+    {{ metrics.alarm("HTTP5xxCountAlarm",
+                    metric_name="HTTP5xx",
+                    statistic="Sum",
+                    period=60,
+                    evaluation_period=1,
+                    threshold=10,
+                    comparison_operator="GreaterThanThreshold",
+                    depends_on=[
+                      "HTTP5xxMetricFilter",
+                      "HTTPNon5xxMetricFilter"
+                    ]) }},
 
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -296,7 +296,7 @@
                     metric_name="HTTP5xx",
                     statistic="Sum",
                     period=60,
-                    evaluation_period=1,
+                    evaluation_periods=1,
                     threshold=10,
                     comparison_operator="GreaterThanThreshold",
                     depends_on=[

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -309,6 +309,47 @@
                              metric_name="ApacheRequestTime",
                              metric_value="\"$.requestTimeMicro\"") }},
 
+    {# 4xx related experimental metric filters #}
+    {{ metrics.metric_filter("HTTP4xxMetricFilter",
+                             pattern="$.logType = apache-access && $.status = 4*",
+                             metric_name="HTTP4xx",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("HTTPNon4xxMetricFilter",
+                             pattern="$.logType = apache-access && $.status != 4*",
+                             metric_name="HTTP4xx",
+                             metric_value=0) }},
+
+    {{ metrics.metric_filter("HTTPBadRequestMetricFilter",
+                             pattern="$.logType = apache-access && ($.status = 400 || $.status = 405)",
+                             metric_name="BadRequest",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("HTTPNonBadRequestMetricFilter",
+                             pattern="$.logType = apache-access && $.status != 400 && $.status != 405",
+                             metric_name="BadRequest",
+                             metric_value=0) }},
+
+    {{ metrics.metric_filter("HTTPBadAuthMetricFilter",
+                             pattern="$.logType = apache-access && ($.status >= 401 && $.status <= 403)",
+                             metric_name="BadAuth",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("HTTPNonBadAuthMetricFilter",
+                             pattern="$.logType = apache-access && ($.status < 401 || $.status > 403)",
+                             metric_name="BadAuth",
+                             metric_value=0) }},
+
+    {{ metrics.metric_filter("HTTPWhatThe4xxMetricFilter",
+                             pattern="$.logType = apache-access && ($.status >= 406 && $.status <= 499)",
+                             metric_name="WhatThe4xx",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("HTTPNonWhatThe4xxMetricFilter",
+                             pattern="$.logType = apache-access && ($.status < 406 || $.status > 499)",
+                             metric_name="WhatThe4xx",
+                             metric_value=0) }},
+
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {

--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -304,6 +304,11 @@
                       "HTTPNon5xxMetricFilter"
                     ]) }},
 
+    {{ metrics.metric_filter("ApacheRequestTimeFilter",
+                             pattern="$.logType = apache-access",
+                             metric_name="ApacheRequestTime",
+                             metric_value="\"$.requestTimeMicro\"") }},
+
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {

--- a/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
@@ -7,12 +7,12 @@
     {{ metrics.metric_filter("LoginFailureMetricFilter",
                              pattern="$.logType = application && $.message = *login.fail*",
                              metric_name="LoginFailure",
-                             metric_value=1) }}
+                             metric_value=1) }},
 
     {{ metrics.metric_filter("LoginSuccessMetricFilter",
                              pattern="$.logType = application && $.message = *login.success*",
                              metric_name="LoginFailure",
-                             metric_value=0) }}
+                             metric_value=0) }},
 
     {{ metrics.alarm("LoginFailurePercentAlarm",
                      metric_name="LoginFailure",

--- a/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_supplier_frontend.json
@@ -1,3 +1,28 @@
 {% extends "app_base.j2" %}
+{% import "metrics.j2" as metrics %}
 
 {% block url_prefix %}/suppliers/{% endblock %}
+
+{% block resources %}
+    {{ metrics.metric_filter("LoginFailureMetricFilter",
+                             pattern="$.logType = application && $.message = *login.fail*",
+                             metric_name="LoginFailure",
+                             metric_value=1) }}
+
+    {{ metrics.metric_filter("LoginSuccessMetricFilter",
+                             pattern="$.logType = application && $.message = *login.success*",
+                             metric_name="LoginFailure",
+                             metric_value=0) }}
+
+    {{ metrics.alarm("LoginFailurePercentAlarm",
+                     metric_name="LoginFailure",
+                     statistic="Average",
+                     period=60,
+                     evaluation_periods=5,
+                     threshold=0.20,
+                     comparison_operator="GreaterThanThreshold",
+                     depends_on=[
+                       "LoginFailureMetricFilter",
+                       "LoginSuccessMetricFilter"
+                    ]) }}
+{% endblock %}

--- a/cloudformation_templates/metrics.j2
+++ b/cloudformation_templates/metrics.j2
@@ -1,0 +1,38 @@
+{% macro metric_filter(name, pattern, metric_name, metric_value) -%}
+  "{{ name }}": {
+    "Type": "AWS::Logs::MetricFilter",
+    "Properties": {
+      "LogGroupName": {"Ref": "JSONLogGroupName"},
+      "FilterPattern": {"Fn::Join": ["",
+                       ["{ $.application = ", {"Ref": "EnvVarDmAppName"}, " && (", "{{ pattern }}", ") }"]
+                       ]},
+      "MetricTransformations": [
+        {
+          "MetricValue": {{ metric_value }},
+          "MetricNamespace": {"Ref": "EnvVarDmMetricsNamespace"},
+          "MetricName": "{{ metric_name }}"
+        }
+      ]
+    }
+  }
+{%- endmacro %}
+
+{% macro alarm(name, metric_name, statistic, period, evaluation_period, threshold, comparison_operator, depends_on) -%}
+  "{{ name }}": {
+    "Type": "AWS::CloudWatch::Alarm",
+    "DependsOn": ["{% if depends_on is sequence and depends_on is not string %}{{ depends_on|join('", "') }}{% else %}{{ depends_on }}{% endif %}"],
+    "Properties": {
+      "Namespace": {"Ref": "EnvVarDmMetricsNamespace"},
+      "MetricName": "{{ metric_name }}",
+      "AlarmDescription": {% include "alarms/%s.j2" % name %},
+      "Statistic": "{{ statistic }}",
+      "Period": {{ period }},
+      "EvaluationPeriods": {{ evaluation_period }},
+      "Threshold": {{ threshold }},
+      "ComparisonOperator": "{{ comparison_operator }}",
+      "AlarmActions": [
+        {"Ref": "MonitoringSNSTopic"}
+      ]
+    }
+  }
+{%- endmacro %}

--- a/cloudformation_templates/metrics.j2
+++ b/cloudformation_templates/metrics.j2
@@ -17,7 +17,7 @@
   }
 {%- endmacro %}
 
-{% macro alarm(name, metric_name, statistic, period, evaluation_period, threshold, comparison_operator, depends_on) -%}
+{% macro alarm(name, metric_name, statistic, period, evaluation_periods, threshold, comparison_operator, depends_on) -%}
   "{{ name }}": {
     "Type": "AWS::CloudWatch::Alarm",
     "DependsOn": ["{% if depends_on is sequence and depends_on is not string %}{{ depends_on|join('", "') }}{% else %}{{ depends_on }}{% endif %}"],
@@ -27,7 +27,7 @@
       "AlarmDescription": {% include "alarms/%s.j2" % name %},
       "Statistic": "{{ statistic }}",
       "Period": {{ period }},
-      "EvaluationPeriods": {{ evaluation_period }},
+      "EvaluationPeriods": {{ evaluation_periods }},
       "Threshold": {{ threshold }},
       "ComparisonOperator": "{{ comparison_operator }}",
       "AlarmActions": [

--- a/dmaws/cloudformation.py
+++ b/dmaws/cloudformation.py
@@ -120,6 +120,7 @@ class Cloudformation(object):
             elif info.get('status') in ['ROLLBACK_COMPLETE',
                                         'ROLLBACK_FAILED',
                                         '%s_ROLLBACK_COMPLETE' % operation,
+                                        '%s_ROLLBACK_FAILED' % operation,
                                         '%s_FAILED' % operation]:
                 self.log('==> Stack [%s] is now %s', stack.name,
                          info['status'], color='red')

--- a/stacks.yml
+++ b/stacks.yml
@@ -120,7 +120,8 @@ api:
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmAppName: "{{ stacks.api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarSqlalchemyDatabaseUri: "postgres://{{ database.user }}:{{ database.password}}@{{ stacks.database.outputs.URL }}"
     EnvVarDmApiAuthTokens: "{{ api.auth_tokens | join(':') }}"
     EnvVarDmSearchApiUrl: "{{ stacks.search_api.outputs.URL }}"
@@ -211,8 +212,9 @@ search_api:
 
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmAppName: "{{ stacks.search_api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.search_api_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmElasticsearchUrl: "{{ stacks.elasticsearch.outputs.URL }}"
     EnvVarDmSearchApiAuthTokens: "{{ search_api.auth_tokens | join(':') }}"
 
@@ -254,8 +256,9 @@ admin_frontend:
 
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmAppName: "{{ stacks.admin_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.admin_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmS3DocumentBucket: "{{ stacks.documents_s3.outputs.Name }}"
     EnvVarDmAdminFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
@@ -303,8 +306,9 @@ buyer_frontend:
 
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmAppName: "{{ stacks.buyer_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.buyer_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmBuyerFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmBuyerFrontendSearchApiAuthToken: "{{ search_api.auth_tokens[0] }}"
@@ -350,8 +354,9 @@ supplier_frontend:
 
     # EnvVar* variables are written to Elastic Beanstalk environment
     # as EnvVarDmVarName -> DM_VAR_NAME
+    EnvVarDmAppName: "{{ stacks.supplier_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmEnvironment: "{{ stage }}"
-    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}"
+    EnvVarDmMetricsNamespace: "{{ stage }}-{{ environment }}/{{ stacks.supplier_frontend_app.parameters.ApplicationName|replace('digitalmarketplace-', '') }}"
     EnvVarDmG7DraftDocumentsBucket: "{{ stacks.g7_draft_documents_s3.outputs.Name }}"
     EnvVarDmG7DraftDocumentsUrl: "https://{% if stage != 'production' %}{{ stage }}-{% endif %}{% if stage != environment %}{{ environment }}-{% endif %}assets.{{root_domain}}"
     EnvVarDmSupplierFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"


### PR DESCRIPTION
This has been tested on preview and can be seen in the CloudWatch console. Select the `preview-preview/api` metric in the Custom Metrics drop down on the left.

## Move 5xx metric filters and alarms to dmaws
Move the 5xx metric filters and alarms into dmaws from the applications .ebextensions.

A short version of the application name has been added to the `DM_METRICS_NAMESPACE` to match the namespace used for Nginx logs and be easier to search for than making the metric names themselves really long. This is the AWS recommended way of organising metrics. For example, the metrics namespace for the supplier app in preview would be `preview-preview/supplier-frontend`.

Metric filters and alarms have been pulled out into macros to avoid mistakes in boilerplate such as log group name, alarm actions and namespace.

The metric filter macro accepts a sub-part of the patter which it wraps and adds the application filter to automatically. For example, giving the metric filter `$.foo = bar` to the macro will result in a metric
filter of `{ $.application = api && ($.foo = bar) }` on the api app.

Alarm descriptions are implemented in separate templates so that they can be easily managed and more easily made uniform (eg. extending from a base template).

After discussion we have decided not to port over the 4xx and related alarms unless they can be shown to be useful. Instead favouring more specific alarms where needed.

## Add {ACTION}_ROLLBACK_FAILED as complete condition
This was seen when a CloudFormation internal failure happened during a rollback.

## Add apache request time metric filter
Add a CloudWatch metric filter for Apache requestTimeMicro so that we can graph individual application performance.

## Add metrics and alarm for supplier login failure
Adds metric filters for login failure and success and an alarm that fires if more than 20% of login attempts fail.

## 	Add 4xx metric filters
Add a variety of 4xx related metric filters to gain a better idea of what kind of errors we get here. There are no alarms set on these filters as yet as the intention right now is just to get a better idea of what's going on.