### PR TITLE
More metric filter fixes

### DIFF
--- a/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
+++ b/cloudformation_templates/alarms/HTTP5xxCountAlarm.j2
@@ -2,4 +2,4 @@
 
 {% block description %}Too many 5xx{% endblock %}
 
-{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#5xx-errors{% endblock %}
+{% block manual_url %}https://github.gds/pages/gds/digitalmarketplace-manual/alerts.html#fivexx-errors{% endblock %}

--- a/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
+++ b/cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
@@ -1,3 +1,27 @@
 {% extends "app_base.j2" %}
 
 {% block url_prefix %}/admin/{% endblock %}
+
+{% block resources %}
+    {{ metrics.metric_filter("LoginFailureMetricFilter",
+                             pattern="$.logType = application && $.message = *login.fail*",
+                             metric_name="LoginFailure",
+                             metric_value=1) }},
+
+    {{ metrics.metric_filter("LoginSuccessMetricFilter",
+                             pattern="$.logType = application && $.message = *login.success*",
+                             metric_name="LoginFailure",
+                             metric_value=0) }},
+
+    {{ metrics.alarm("LoginFailurePercentAlarm",
+                     metric_name="LoginFailure",
+                     statistic="Average",
+                     period=60,
+                     evaluation_periods=5,
+                     threshold=0.20,
+                     comparison_operator="GreaterThanThreshold",
+                     depends_on=[
+                       "LoginFailureMetricFilter",
+                       "LoginSuccessMetricFilter"
+                    ]) }}
+{% endblock %}


### PR DESCRIPTION
## Fix 5xx link to manual
Sphinx doesn't support anchors starting with digits for some reason.

## Add admin frontend login failure metric
This is a direct copy of the login failure metric and alarm used for supplier frontend.