### PR TITLE
Add configuration for a Jenkins instance on AWS 

### DIFF
--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -128,6 +128,14 @@
         ],
         "TTL": "300"
       }
+    },
+
+    "ElasticIP": {
+      "Type" : "AWS::EC2::EIP",
+      "Properties" : {
+        "InstanceId" : {"Ref" : "JenkinsInstance"},
+        "Domain" : "vpc"
+      }
     }
   },
   "Outputs": {
@@ -149,6 +157,10 @@
           {"Ref" :"RootDomain"}
         ]]
       }
+    },
+    "ElasticIP": {
+      "Description": "Elastic IP address for Jenkins",
+      "Value": {"Ref": "ElasticIP"}
     }
   }
 }

--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -3,6 +3,14 @@
   "Description": "Jenkins instance",
 
   "Parameters": {
+    "UserIPs": {
+      "Type": "String",
+      "Description": "Comma-separated list of CIDRs for instance ingress rule"
+    },
+    "Port": {
+      "Type": "Number",
+      "Description": "External port for the instance ingress rule"
+    },
     "GroupTag": {
       "Type": "String",
       "Description": "Group Tag"
@@ -25,7 +33,13 @@
     "InstanceSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
-        "GroupDescription": "Main instance security group"
+        "GroupDescription": "Main instance security group",
+        "SecurityGroupIngress": [
+{% for user_ip in parameters.UserIPs.split(",") %}
+          {"IpProtocol": "tcp", "CidrIp": "{{ user_ip }}", "FromPort": {"Ref": "Port"}, "ToPort": {"Ref": "Port"}}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+        ]
       }
     },
 

--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -1,0 +1,99 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Jenkins instance",
+
+  "Parameters": {
+    "GroupTag": {
+      "Type": "String",
+      "Description": "Group Tag"
+    },
+    "KeyName": {
+      "Type": "AWS::EC2::KeyPair::KeyName",
+      "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the server"
+    },
+    "InstanceImage" : {
+      "Description" : "EC2 instance image",
+      "Type" : "String"
+    },
+    "InstanceType" : {
+      "Description" : "EC2 instance type",
+      "Type" : "String"
+    }
+  },
+
+  "Resources": {
+    "InstanceSecurityGroup": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "Main instance security group"
+      }
+    },
+
+    "IAMRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version" : "2012-10-17",
+          "Statement": [ {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": [ "ec2.amazonaws.com" ]
+            },
+            "Action": [ "sts:AssumeRole" ]
+          } ]
+        },
+        "Path": "/",
+        "Policies": []
+      }
+    },
+    "InstanceProfile": {
+      "Type": "AWS::IAM::InstanceProfile",
+      "Properties": {
+        "Path": "/",
+        "Roles": [{"Ref": "IAMRole"}]
+      }
+    },
+    "DataVolume": {
+      "Type": "AWS::EC2::Volume",
+      "Properties": {
+        "Size": "100",
+      "AvailabilityZone" : {
+        "Fn::Select": [0, {"Fn::GetAZs": ""}]
+      },
+      "VolumeType": "gp2"
+      }
+    },
+    "JenkinsInstance": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "DisableApiTermination": false,
+        "IamInstanceProfile": {"Ref": "InstanceProfile"},
+        "ImageId": {"Ref": "InstanceImage"},
+        "InstanceInitiatedShutdownBehavior": "stop",
+        "InstanceType": {"Ref": "InstanceType"},
+        "KeyName": {"Ref": "KeyName"},
+        "SecurityGroups": [{"Ref": "InstanceSecurityGroup"}],
+        "Tags": [
+          {"Key": "Name", "Value": {"Ref": "GroupTag"}}
+        ],
+        "AvailabilityZone" : {
+          "Fn::Select": [0, {"Fn::GetAZs": ""}]
+        },
+        "Volumes": [{
+          "Device" : "/dev/xvdf",
+          "VolumeId" : {"Ref": "DataVolume"}
+          }]
+      }
+    }
+  },
+  "Outputs": {
+    "InstanceSecurityGroup": {
+      "Description": "Jenkins instances security group",
+      "Value": {"Ref": "InstanceSecurityGroup"}
+    },
+    "Domain": {
+      "Description": "Load balancer endpoint CNAME",
+      "Value": {"Fn::GetAtt": ["JenkinsInstance", "PublicDnsName"]}
+    }
+  }
+}

--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -11,6 +11,18 @@
       "Type": "Number",
       "Description": "External port for the instance ingress rule"
     },
+    "RootDomain": {
+      "Type": "String",
+      "Description": "Root domain for the public Route 53 records"
+    },
+    "Subdomain": {
+      "Type": "String",
+      "Description": "Subdomain to use"
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "Route53 hosted zone name"
+    },
     "GroupTag": {
       "Type": "String",
       "Description": "Group Tag"
@@ -60,6 +72,7 @@
         "Policies": []
       }
     },
+
     "InstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
@@ -67,6 +80,7 @@
         "Roles": [{"Ref": "IAMRole"}]
       }
     },
+
     "DataVolume": {
       "Type": "AWS::EC2::Volume",
       "Properties": {
@@ -77,6 +91,7 @@
       "VolumeType": "gp2"
       }
     },
+
     "JenkinsInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
@@ -98,6 +113,21 @@
           "VolumeId" : {"Ref": "DataVolume"}
           }]
       }
+    },
+
+    "Route53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["",[
+          {"Ref": "Subdomain"}, ".", {"Ref": "RootDomain"}, "."
+         ]]},
+        "Type": "CNAME",
+        "ResourceRecords": [
+          {"Fn::GetAtt": ["JenkinsInstance", "PublicDnsName"]}
+        ],
+        "TTL": "300"
+      }
     }
   },
   "Outputs": {
@@ -105,9 +135,20 @@
       "Description": "Jenkins instances security group",
       "Value": {"Ref": "InstanceSecurityGroup"}
     },
-    "Domain": {
-      "Description": "Load balancer endpoint CNAME",
+    "InstanceDomain": {
+      "Description": "Instance public DNS",
       "Value": {"Fn::GetAtt": ["JenkinsInstance", "PublicDnsName"]}
+    },
+    "URL": {
+      "Description": "URL of the www server",
+      "Value": {
+        "Fn::Join": ["", [
+          "https://",
+          {"Ref" :"Subdomain"},
+          ".",
+          {"Ref" :"RootDomain"}
+        ]]
+      }
     }
   }
 }

--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -115,6 +115,14 @@
       }
     },
 
+    "ElasticIP": {
+      "Type" : "AWS::EC2::EIP",
+      "Properties" : {
+        "InstanceId" : {"Ref" : "JenkinsInstance"},
+        "Domain" : "vpc"
+      }
+    },
+
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
@@ -124,17 +132,9 @@
          ]]},
         "Type": "CNAME",
         "ResourceRecords": [
-          {"Fn::GetAtt": ["JenkinsInstance", "PublicDnsName"]}
+          {"Ref": "ElasticIP"}
         ],
         "TTL": "300"
-      }
-    },
-
-    "ElasticIP": {
-      "Type" : "AWS::EC2::EIP",
-      "Properties" : {
-        "InstanceId" : {"Ref" : "JenkinsInstance"},
-        "Domain" : "vpc"
       }
     }
   },

--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -68,6 +68,24 @@
         ],
         "TTL": "3600"
       }
+    },
+
+    "CI": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["", [
+          "beta", ".", {"Ref": "HostedZoneName"}
+        ]]},
+        "Type": "NS",
+        "ResourceRecords": [
+          "ns-895.awsdns-47.net.",
+          "ns-1187.awsdns-20.org.",
+          "ns-505.awsdns-63.com.",
+          "ns-1661.awsdns-15.co.uk."
+        ],
+        "TTL": "3600"
+      }
     }
   }
 }

--- a/dmaws/cli.py
+++ b/dmaws/cli.py
@@ -13,6 +13,7 @@ STAGES = [
     'preview',
     'staging',
     'production',
+    'ci',
 ]
 
 

--- a/packer_templates/jenkins.json
+++ b/packer_templates/jenkins.json
@@ -15,10 +15,7 @@
         "volume_size": "20",
         "delete_on_termination": true
     }],
-    "ami_users": [
-      "050019655025",
-      "381494870249"
-    ]
+    "ami_users": []
   }],
   "provisioners": []
 }

--- a/packer_templates/jenkins.json
+++ b/packer_templates/jenkins.json
@@ -1,0 +1,24 @@
+{
+  "variables": {
+      "aws_region": "eu-west-1"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "region": "{{ user `aws_region` }}",
+    "source_ami": "ami-d9ba9eae",
+    "instance_type": "t2.micro",
+    "ssh_username": "ubuntu",
+    "ami_name": "jenkins-{{isotime | clean_ami_name}}",
+    "launch_block_device_mappings": [{
+        "device_name": "/dev/sda1",
+        "volume_type": "gp2",
+        "volume_size": "20",
+        "delete_on_termination": true
+    }],
+    "ami_users": [
+      "050019655025",
+      "381494870249"
+    ]
+  }],
+  "provisioners": []
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -419,9 +419,16 @@ nginx:
 jenkins:
   name: "jenkins-{{ stage }}"
   template: cloudformation_templates/aws_jenkins.json
+  dependencies:
+    - route53zone
   parameters:
     UserIPs: "{{ dev_user_ips | join(',') }}"
+
+    HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
+    RootDomain: "{{ root_domain }}"
+    Subdomain: "jenkins"
     Port: "{{ jenkins.port }}"
+
     KeyName: "{{ key_name }}"
     GroupTag: "jenkins-{{ stage }}"
     InstanceType: "{{ jenkins.instance_type }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -426,7 +426,7 @@ jenkins:
 
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     RootDomain: "{{ root_domain }}"
-    Subdomain: "jenkins"
+    Subdomain: "ci"
     Port: "{{ jenkins.port }}"
 
     KeyName: "{{ key_name }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -416,6 +416,26 @@ nginx:
     InstanceType: "{{ nginx.instance_type }}"
     InstanceImage: "{{ nginx.instance_image }}"
 
+jenkins:
+  name: "jenkins-{{ stage }}"
+  template: cloudformation_templates/aws_jenkins.json
+  parameters:
+    KeyName: "{{ key_name }}"
+    GroupTag: "jenkins-{{ stage }}"
+    InstanceType: "{{ jenkins.instance_type }}"
+    InstanceImage: "{{ jenkins.instance_image }}"
+
+jenkins_ssh_access:
+  name: "jenkins-{{ stage }}-ssh-access"
+  template: cloudformation_templates/aws_dev_access.json
+  dependencies:
+    - jenkins
+  parameters:
+    CidrIPs: "{{ dev_user_ips | join(',') }}"
+    FromPort: 22
+    ToPort: 22
+    SecurityGroup: "{{ stacks.jenkins.outputs.InstanceSecurityGroup }}"
+
 nginx_ssh_access:
   name: "nginx-{{ stage }}-{{ environment }}-ssh-access"
   template: cloudformation_templates/aws_dev_access.json

--- a/stacks.yml
+++ b/stacks.yml
@@ -420,6 +420,8 @@ jenkins:
   name: "jenkins-{{ stage }}"
   template: cloudformation_templates/aws_jenkins.json
   parameters:
+    UserIPs: "{{ dev_user_ips | join(',') }}"
+    Port: "{{ jenkins.port }}"
     KeyName: "{{ key_name }}"
     GroupTag: "jenkins-{{ stage }}"
     InstanceType: "{{ jenkins.instance_type }}"

--- a/vars/ci.yml
+++ b/vars/ci.yml
@@ -1,0 +1,13 @@
+---
+root_domain: "beta.digitalmarketplace.service.gov.uk"
+
+jenkins:
+  port: 443
+  instance_type: t2.micro
+  instance_image: ami-838aabf4
+
+vpc_id: vpc-4077b925
+subnets:
+  - subnet-acc565db
+  - subnet-c614d19f
+  - subnet-a2f54ec7

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -50,3 +50,7 @@ nginx:
   instance_type: t2.micro
   instance_count: 2
   instance_image: ami-3b87dd4c
+
+jenkins:
+  instance_type: t2.micro
+  instance_image: ami-d9ba9eae

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -52,5 +52,6 @@ nginx:
   instance_image: ami-3b87dd4c
 
 jenkins:
+  port: 8080
   instance_type: t2.micro
   instance_image: ami-d9ba9eae

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -54,4 +54,4 @@ nginx:
 jenkins:
   port: 8080
   instance_type: t2.micro
-  instance_image: ami-d9ba9eae
+  instance_image: ami-ab6046dc

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -50,8 +50,3 @@ nginx:
   instance_type: t2.micro
   instance_count: 2
   instance_image: ami-3b87dd4c
-
-jenkins:
-  port: 443
-  instance_type: t2.micro
-  instance_image: ami-ab6046dc

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -52,6 +52,6 @@ nginx:
   instance_image: ami-3b87dd4c
 
 jenkins:
-  port: 8080
+  port: 443
   instance_type: t2.micro
   instance_image: ami-ab6046dc


### PR DESCRIPTION
This pull request: 
- sets up a Jenkins instance with a 20Gb EBS drive on digitalmarketplace-development
- whitelists Aviation House IP addresses
- adds a DNS record at [https://jenkins.development.digitalmarketplace.service.gov.uk/](https://jenkins.development.digitalmarketplace.service.gov.uk/)
- assigns it an [Elastic IP address](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html)