### PR TITLE
Change Jenkins Route53 record to A

### DIFF
--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -130,7 +130,7 @@
         "Name": {"Fn::Join": ["",[
           {"Ref": "Subdomain"}, ".", {"Ref": "RootDomain"}, "."
          ]]},
-        "Type": "CNAME",
+        "Type": "A",
         "ResourceRecords": [
           {"Ref": "ElasticIP"}
         ],


### PR DESCRIPTION
The ElasticIP is an IP address and therefore the DNS record should be an
A record rather than a CNAME.