### PR TITLE
Set server tokens to off to hide version

### DIFF
--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -23,6 +23,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    server_tokens off;
 
     # Raise bucket size for long domain names
     server_names_hash_bucket_size 128;


### PR DESCRIPTION
server tokens set to off to hide nginx verison.

Required for pen test