### PR TITLE
Add G7 post-clarification email address

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -364,6 +364,7 @@ supplier_frontend:
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ supplier_frontend.mandrill_key }}"
     EnvVarDmClarificationQuestionEmail: "{{ supplier_frontend.clarification_question_email }}"
+    EnvVarDmG7FollowUpEmailTo: "{{ supplier_frontend.g7_follow_up_email_to }}"
     EnvVarDmPasswordSecretKey: "{{ supplier_frontend.password_key }}"
     EnvVarDmSharedEmailKey: "{{ supplier_frontend.shared_email_key }}"
 


### PR DESCRIPTION
Required for this to send things to the right email address: https://www.pivotaltracker.com/story/show/103088520

It's supposed to pull in this address from credentials: https://github.gds/gds/digitalmarketplace-credentials/blob/master/dmaws-vars-files/preview.yml#L47