### PR TITLE
Update jenkins box

### DIFF
--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -92,13 +92,12 @@
       }
     },
 
-    "JenkinsInstance": {
+    "Instance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
         "DisableApiTermination": false,
         "IamInstanceProfile": {"Ref": "InstanceProfile"},
         "ImageId": {"Ref": "InstanceImage"},
-        "InstanceInitiatedShutdownBehavior": "stop",
         "InstanceType": {"Ref": "InstanceType"},
         "KeyName": {"Ref": "KeyName"},
         "SecurityGroups": [{"Ref": "InstanceSecurityGroup"}],
@@ -118,7 +117,7 @@
     "ElasticIP": {
       "Type" : "AWS::EC2::EIP",
       "Properties" : {
-        "InstanceId" : {"Ref" : "JenkinsInstance"},
+        "InstanceId" : {"Ref" : "Instance"},
         "Domain" : "vpc"
       }
     },
@@ -145,7 +144,7 @@
     },
     "InstanceDomain": {
       "Description": "Instance public DNS",
-      "Value": {"Fn::GetAtt": ["JenkinsInstance", "PublicDnsName"]}
+      "Value": {"Fn::GetAtt": ["Instance", "PublicDnsName"]}
     },
     "URL": {
       "Description": "URL of the www server",

--- a/vars/ci.yml
+++ b/vars/ci.yml
@@ -3,7 +3,7 @@ root_domain: "beta.digitalmarketplace.service.gov.uk"
 
 jenkins:
   port: 443
-  instance_type: t2.micro
+  instance_type: t2.large
   instance_image: ami-838aabf4
 
 vpc_id: vpc-4077b925


### PR DESCRIPTION
## Make Jenkins instance bigger
We need more memory, the OOM killer keeps killing Jenkins.

## Remove Jenkins instance shutdown behaviour
This prevents the stack running again once you've terminated the instance (because CloudFormation cannot stop it anymore).