### PR TITLE
Allow promoting preview to staging by setting empty release-name

### DIFF
--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -36,6 +36,8 @@ def release_cmd(ctx, release_name=None, from_profile=None):
 
     if not success:
         sys.exit(1)
+
+    ctx.out("RELEASE_NAME", release_name)
     build.push_deployed_to_tag(repository_path, ctx.stage, release_name)
 
 

--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -67,8 +67,9 @@ def release_to_preview(ctx, repository_path):
 
 
 def release_to_staging(ctx, repository_path, release_name, from_profile):
-    if release_name is None:
-        raise ValueError("Release name required for staging release")
+    if not release_name:
+        release_name = build.get_release_name_for_tag(repository_path, 'deployed-to-preview')
+        ctx.log("Deploying current preview version %s", release_name)
     if from_profile is None:
         raise ValueError("Source profile required for staging release")
 

--- a/dmaws/context.py
+++ b/dmaws/context.py
@@ -59,5 +59,9 @@ class Context(object):
             msg = click.style(msg, fg=kwargs['color'])
         click.echo(msg, err=True)
 
+    def out(self, key, value):
+        """Print a key=value pair to stdout"""
+        click.echo("{}={}".format(key, value), err=False)
+
 
 pass_context = click.make_pass_decorator(Context, ensure=True)

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -19,4 +19,5 @@ if [ "$STAGE" = "staging" ]; then
   OPTIONS="--from-profile=preview --release-name=$RELEASE_NAME"
 fi
 
-AWS_PROFILE="$STAGE" dmaws $STAGE $STAGE release $APPLICATION_NAME $OPTIONS
+rm release_properties.out
+AWS_PROFILE="$STAGE" dmaws $STAGE $STAGE release $APPLICATION_NAME $OPTIONS 1>release_properties.out

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 120


### PR DESCRIPTION
#### Allow promoting preview to staging by setting empty release-name
If release-name is not set when calling release to staging current
preview release version will be used. This should act similar to the
current production releases.

"release-name" is kept as a parameter and will be used when set. Staging
is the only stage that allows an explicit release name right now, so
this is required for rollbacks (rollbacks should start with staging and
can be promoted to production, preview can not be rolled back right
now).

"release-name" check is changed to `not release_name` to avoid adding
logic to the jenkins script, which will always pass `--release-name=`
for staging, but now an empty value is allowed.

#### Write a KEY=VALUE property file using release command output
Uses ctx.out to write KEY=VALUE pairs to stdout, which is redirected
by the jenkins script to a property file. Stdout is now reserved for
this output format, all other unstructured command output should be
written to stderr by `ctx.log`.

This allows us to communicate release information back to the caller
environment (e.g. Jenkins) to use in the following build steps and
notifications.