### PR TITLE
Increase instance size and max limit for API and supplier app

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -18,8 +18,9 @@ subnets:
   - subnet-ad0894c8
 
 api:
+  instance_type: t2.medium
   min_instance_count: 3
-  max_instance_count: 5
+  max_instance_count: 10
 
 search_api:
   min_instance_count: 3
@@ -34,5 +35,6 @@ buyer_frontend:
   max_instance_count: 5
 
 supplier_frontend:
+  instance_type: t2.medium
   min_instance_count: 3
-  max_instance_count: 5
+  max_instance_count: 10


### PR DESCRIPTION
Supplier app reached the autoscaling limit of 5 instances.
Since we expect an increase in requests for the last days of the
G-Cloud 7 service submission, we raise the max limit and size of
EC2 instances for supplier frontend and Data API apps.

We can reduce these limits to the previous value  after the service
submission is closed.