### PR TITLE
Increase production nginx instance size to t2.medium

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -38,3 +38,6 @@ supplier_frontend:
   instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
+
+nginx:
+  instance_type: t2.medium


### PR DESCRIPTION
Similar to supplier frontend and API, since nginx is on the request
route for service submission, raising the instance size.

There's one "backend connection errors" spike in nginx ELB monitoring
in the last 7 days.