### PR TITLE
Upgrade app EB solution stacks to v2.0.1

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -139,7 +139,7 @@
       "Properties": {
         "ApplicationName": {"Ref": "ApplicationName"},
         "Description": "Elastic Beanstalk Configuration",
-        "SolutionStackName": "{% block solution_stack %}64bit Amazon Linux 2015.03 v1.4.3 running Python 2.7{% endblock %}",
+        "SolutionStackName": "{% block solution_stack %}64bit Amazon Linux 2015.03 v2.0.1 running Python 2.7{% endblock %}",
         "OptionSettings": [
           {
             "Namespace": "aws:autoscaling:asg",


### PR DESCRIPTION
Smoke tests running on the hour are failing with 504 errors. This
turned out to be an issue in the current EB Apache log rotation:

> The root cause of this is that EB rotates the logs once an hour
> BUT when rotating the logs, they do a "reload" on apache rather
> than a 'graceful'. This causes connections to be dropped.

¯\_(ツ)_/¯

and should be fixed in the newer (v1.4.6 and later) stack versions.

(https://forums.aws.amazon.com/thread.jspa?messageID=625900)