### PR TITLE
Add current production instance sizes to vars file

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -39,5 +39,11 @@ supplier_frontend:
   min_instance_count: 3
   max_instance_count: 10
 
+database:
+  instance_type: db.m3.medium
+
+elasticsearch:
+  instance_type: t2.medium
+
 nginx:
   instance_type: t2.medium


### PR DESCRIPTION
Instance sizes for elasticsearch and RDS were set in the credentials
repo. Moving them to aws since they're not supposed to be secret and
keeping them near the default makes it easier to understand what types
of instances we have for different parts of the environment.