### PR TITLE
Restore t2.micro instance size for supplier-frontend and api

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,7 +19,6 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
-  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 
@@ -36,7 +35,6 @@ buyer_frontend:
   max_instance_count: 5
 
 supplier_frontend:
-  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 


### PR DESCRIPTION
Restoring the default instance size for supplier-frontend and Data
API apps after the close of G-Cloud 7 service submissions.

Keeping the autoscaling max instance counts and the medium nginx
instances, since nginx is not autoscaled.