### PR TITLE
Fix 5xx alarm to catch all errors

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -307,7 +307,7 @@
                     period=60,
                     evaluation_periods=1,
                     threshold=1,
-                    comparison_operator="GreaterThanThreshold",
+                    comparison_operator="GreaterThanOrEqualToThreshold",
                     depends_on=[
                       "HTTP5xxMetricFilter",
                       "HTTPNon5xxMetricFilter"


### PR DESCRIPTION
This alarm was only emailing us if there was more than one 5xx in a 1 minute period.