### PR TITLE
Continue to use existing G7 draft bucket

### DIFF
--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -26,6 +26,14 @@ server {
         proxy_pass $agreements_s3_url;
     }
 
+    # Hack to force g7 communications to the old bucket to preserve upload times
+    location ^~ /g-cloud-7-updates/communications {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_intercept_errors on;
+
+        proxy_pass $g7_draft_documents_s3_url;
+    }
+
     location ~ ^/[^/]+/communications/ {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -49,4 +49,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-62c41a11
+  instance_image: ami-4a1fc639


### PR DESCRIPTION
We need to preserve the update times for when we list and they cannot be
manually edited.