### PR TITLE
Update Google site verification code

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -46,9 +46,9 @@
         "Name": {"Ref": "HostedZoneName"},
         "Type": "TXT",
         "ResourceRecords": [
-          "\"google-site-verification=j6RvC0_ipOIvcyTR0WBAwa8C5SPblqFaJOS8QByISGI\""
+          "\"google-site-verification=wCZPbaSgAFuIlzK2CpzwiOYwgCUJP_ZUOhHTYCGs7aQ\""
         ],
-        "TTL": "3600"
+        "TTL": "300"
       }
     },
 


### PR DESCRIPTION
Our access to Google Webmaster Tools is no longer working. After speaking with Ash we have decided to replacing the verification code.

We are reducing the TTL to 5 minutes in case there is any problem with replacing the old verification code.

See:
- https://github.com/alphagov/digitalmarketplace-aws/pull/163
- https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/189