### PR TITLE
Allow robots to crawl search results

### DIFF
--- a/playbooks/roles/nginx/files/robots.txt
+++ b/playbooks/roles/nginx/files/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Disallow: /admin
 Disallow: /suppliers
-Disallow: /g-cloud/search?


### PR DESCRIPTION
The search results pages will be prevented from being indexed by a meta
tag on the pages themselves.

See:
- https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/189
- https://github.com/alphagov/digitalmarketplace-aws/pull/162