### PR TITLE
Mandrill DNS records

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -35,7 +35,22 @@
         "ResourceRecords": [
           "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com ~all\""
         ],
-        "TTL": "3600"
+        "TTL": "300"
+      }
+    },
+
+    "MandrillDKIMRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["", [
+          "mandrill._domainkey", ".", {"Ref": "HostedZoneName"}
+        ]]},
+        "Type": "TXT",
+        "ResourceRecords": [
+          "\"v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCrLHiExVd55zd/IQ/J/mRwSRMAocV/hMB3jXwaHH36d9NaVynQFYV8NaWi69c1veUtRzGt7yAioXqLj7Z4TeEUoOLgrKsn8YnckGs9i3B3tVFB+Ch/4mPhXWiNfNdynHWBcPcbJ8kjEQ2U8y78dHZj1YeRXXVvWob2OaKynO8/lQIDAQAB;\""
+        ],
+        "TTL": "300"
       }
     },
 

--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -31,7 +31,7 @@
       "Properties": {
         "HostedZoneName": {"Ref": "HostedZoneName"},
         "Name": {"Ref": "HostedZoneName"},
-        "Type": "SPF",
+        "Type": "TXT",
         "ResourceRecords": [
           "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com ~all\""
         ],


### PR DESCRIPTION
### Use TXT record instead of SPF record type
Mandrill SPF verification doesn't recognize current SPF value.

From Route 53 docs:

> ... we no longer recommend that you create resource record sets for
> which the record type is SPF ... its use is no longer appropriate for
> SPF version 1; implementations are not to use it ... Instead of an
> SPF record, we recommend that you create a TXT record

(http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#SPFFormat)

### Add mandrill DKIM record and change SPF/DKIM TTL to 300
Setting a short TTL in case we need to revert the records. DKIM
value copied from Mandrill setup instructions page:
https://mandrillapp.com/settings/sending-domains?q=digitalmarketplace