### PR TITLE
Prune old versions

### DIFF
--- a/dmaws/commands/release.py
+++ b/dmaws/commands/release.py
@@ -60,6 +60,7 @@ def release_to_preview(ctx, repository_path):
     if build.tag_exists(repository_path, release_name):
         raise ValueError("Already have a tag for {}".format(release_name))
 
+    deploy.prune_old_versions(os.environ.get('DM_NUM_APPLICATIONS_TO_KEEP', 20))
     version, created = deploy.create_version(release_name)
     build.push_tag(repository_path, release_name)
 
@@ -83,6 +84,7 @@ def release_to_staging(ctx, repository_path, release_name, from_profile):
         source_deploy = source_plan.get_deploy(repository_path)
         package_path = source_deploy.download_package(release_name)
 
+        deploy.prune_old_versions(os.environ.get('DM_NUM_APPLICATIONS_TO_KEEP', 20))
         deploy.create_version(release_name, from_file=package_path)
 
     return deploy.deploy(release_name), release_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,12 @@ def beanstalk_conn(request):
     })
 
     set_boto_response(beanstalk_mock, 'describe_application_versions', {
-        'ApplicationVersions': ['test-version']
+        'ApplicationVersions': [
+            {
+                'ApplicationName': 'test-env',
+                'VersionLabel': 'test-version'
+            }
+        ]
     })
 
     return beanstalk_mock


### PR DESCRIPTION
## Add method to prune old Beanstalk app versions
There is a limit to the number of Beanstalk application versions that you can have, this limit is 500 per account and AWS refuses to increase it stating that we should be deleting old versions.

This adds a method to prune old Beanstalk application versions by listing them and deleting any above the number to keep.

## 	Prune old versions when releasing
When releasing to preview or staging (the only releases that create new versions) we need to prune the old versions before we create the version.

I have not added this to the `deploy` command because that is done manually and I don't think it should have unexpected side effects.