### PR TITLE
Add bucket env variables to admin frontend

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -260,6 +260,8 @@ admin_frontend:
   template: cloudformation_templates/aws_digitalmarketplace_admin_frontend.json
   dependencies:
     - documents_s3
+    - communications_s3
+    - submissions_s3
     - agreements_s3
     - api
     - admin_frontend_app
@@ -277,6 +279,9 @@ admin_frontend:
     EnvVarDmApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmS3DocumentBucket: "{{ stacks.documents_s3.outputs.Name }}"
     EnvVarDmAgreementsBucket: "{{ stacks.agreements_s3.outputs.Name }}"
+    EnvVarDmCommunicationsBucket: "{{ stacks.communications_s3.outputs.Name }}"
+    EnvVarDmDocumentsBucket: "{{ stacks.documents_s3.outputs.Name }}"
+    EnvVarDmSubmissionsBucket: "{{ stacks.submissions_s3.outputs.Name }}"
     EnvVarDmAssetsUrl: "https://{% if stage != 'production' %}{{ stage }}-{% endif %}{% if stage != environment %}{{ environment }}-{% endif %}assets.{{root_domain}}"
     EnvVarDmAdminFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmAdminFrontendCookieSecret: "{{ admin_frontend.cookie_secret }}"


### PR DESCRIPTION
The communications bucket is required uploading communications. The
others have been added now as they will be useful soon and it's a bit
confusing to debug when it's not available.