### PR TITLE
Add SPF DNS record to allow sending emails from Zendesk

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -50,7 +50,7 @@
         "Type": "TXT",
         "ResourceRecords": [
           "\"google-site-verification=wCZPbaSgAFuIlzK2CpzwiOYwgCUJP_ZUOhHTYCGs7aQ\"",
-          "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com ~all\""
+          "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com include:mail.zendesk.com ~all\""
         ],
         "TTL": "300"
       }


### PR DESCRIPTION
Adding to existing Google and Mandrill SPF records.
(https://support.zendesk.com/hc/en-us/articles/203683886-SPF-Learn-More)