### PR TITLE
Update environment variable name to the one used in the application

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -389,7 +389,7 @@ supplier_frontend:
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ supplier_frontend.mandrill_key }}"
     EnvVarDmClarificationQuestionEmail: "{{ supplier_frontend.clarification_question_email }}"
-    EnvVarDmG7FollowUpEmailTo: "{{ supplier_frontend.g7_follow_up_email_to }}"
+    EnvVarDmFollowUpEmailTo: "{{ supplier_frontend.follow_up_email_to }}"
     EnvVarDmPasswordSecretKey: "{{ supplier_frontend.password_key }}"
     EnvVarDmSharedEmailKey: "{{ supplier_frontend.shared_email_key }}"
 


### PR DESCRIPTION
This updates the environment variable to be the one used in the supplier app here:
https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/config.py#L49
and here:
https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/app/main/views/frameworks.py#L400

Depends on new variable name in:
 - [x] https://github.gds/gds/digitalmarketplace-credentials/pull/54/files