### PR TITLE
Add DB parameter group to enable slow query logging

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -36,6 +36,10 @@
     "DBSnapshotIdentifier": {
       "Type": "String",
       "Description": "The identifier for the DB snapshot to restore from."
+    },
+    "SlowQueryLogDurationMs": {
+      "Type": "Number",
+      "Description": "Log queries that take longer than X ms (-1 to disable)"
     }
   },
 
@@ -59,6 +63,17 @@
       }
     },
 
+    "DBParameterGroup": {
+      "Type": "AWS::RDS::DBParameterGroup",
+      "Properties": {
+        "Description": "Custom DB parameter group",
+        "Family": "postgres9.3",
+        "Parameters": {
+          "log_min_duration_statement": {"Ref": "SlowQueryLogDurationMs" }
+        }
+      }
+    },
+
     "DB": {
       "Type": "AWS::RDS::DBInstance",
       "DeletionPolicy": "Snapshot",
@@ -69,6 +84,7 @@
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
+        "DBParameterGroupName": {"Ref": "DBParameterGroup"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},

--- a/stacks.yml
+++ b/stacks.yml
@@ -70,6 +70,7 @@ database:
     DBInstanceType: "{{ database.instance_type }}"
     DBAllocatedStorage: "{{ database.allocated_storage }}"
     MultiAZ: "{{ database.multi_az }}"
+    SlowQueryLogDurationMs: "{{ database.slow_query_log_duration_ms }}"
     BackupRetentionPeriod: "{{ database.backup_retention_period }}"
     DBSnapshotIdentifier: "{{ database.snapshot_id }}"
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -9,6 +9,7 @@ monitoring:
 database:
   multi_az: "false"
   backup_retention_period: "1"
+  slow_query_log_duration_ms: 1000
   snapshot_id: "s2015-05-13t0953z"
 
 vpc_id: vpc-a29149c7

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -15,6 +15,7 @@ subnets:
 database:
   multi_az: "true"
   backup_retention_period: "30"
+  slow_query_log_duration_ms: -1
   instance_type: db.m3.medium
   snapshot_id: "production-2015-07-17t1204"
 

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -9,6 +9,7 @@ monitoring:
 database:
   multi_az: "true"
   backup_retention_period: "1"
+  slow_query_log_duration_ms: -1
   snapshot_id: "staging-2015-07-17t1003"
 
 vpc_id: vpc-70319115


### PR DESCRIPTION
Sets a Parameter Group on DB instances than can be used
to tweak database settings. Dynamic parameters can be
then changed without interruption.

Enables logging of queries >1000ms on preview by default.
Logging is disabled for staging and production.

**Note:** even though AWS docs state that 
> The parameter group name itself is changed immediately, but the actual parameter changes are not applied until you reboot the instance without failover. The db instance will NOT be rebooted automatically and the parameter changes will NOT be applied during the next maintenance window.
(http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html)

CloudFormation seems to have restarted the instance when this was applied to preview causing a <1 min downtime. If we decide to merge this and the same happens in staging we'll have to either revert or apply this to production when we can deal with a short service interruption 🔥
