### PR TITLE
Enable enhanced health reporting for EB environments

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -194,6 +194,11 @@
             "Value": "app/static/"
           },
           {
+            "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+            "OptionName": "SystemType",
+            "Value": "enhanced"
+          },
+          {
             "Namespace": "aws:elasticbeanstalk:hostmanager",
             "OptionName": "LogPublicationControl",
             "Value": "true"


### PR DESCRIPTION
> Enhanced health reporting is a feature that you can enable on your environment to allow AWS
> Elastic Beanstalk to gather additional information about resources in your environment. Elastic
> Beanstalk analyzes the information gathered to provide a better picture of overall environment
> health and aid in the identification of issues that can cause your application to become
> unavailable.

(http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/health-enhanced.html)