### PR TITLE
Update nginx AMI with nginx 1.8.1

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -49,4 +49,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-d42886a7
+  instance_image: ami-f100b482


### PR DESCRIPTION
There's a new stable nginx release with some security fixes related
to the resolver (which we're using to connect to application ELBs)

http://nginx.org/en/CHANGES-1.8