### PR TITLE
S3 versioning and EB IAM delete permission

### DIFF
--- a/cloudformation_templates/app_base.j2
+++ b/cloudformation_templates/app_base.j2
@@ -102,6 +102,7 @@
                 "s3:Get*",
                 "s3:List*",
                 "s3:Put*",
+                "s3:DeleteObject",
                 "cloudwatch:PutMetricData"
               ],
               "Resource": "*"

--- a/cloudformation_templates/aws_s3.json
+++ b/cloudformation_templates/aws_s3.json
@@ -13,6 +13,9 @@
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "Private",
+        "VersioningConfiguration": {
+          "Status": "Enabled"
+        },
         "BucketName": {"Ref": "BucketName"}
       }
     }


### PR DESCRIPTION
### Enable Object Versioning for S3 buckets
Object versioning will automatically keep old file versions so
that there's less need for us to do manual copies and backups
of modified or removed documents.

### Add s3:Delete* permission for EB InstanceProfile
Admin app sends delete requests to remove countersigned agreements,
so we need to add a permission to EB instance profile policy.