### PR TITLE
Provide SECRET_KEY env var for apps

### DIFF
--- a/stacks.yml
+++ b/stacks.yml
@@ -289,6 +289,7 @@ admin_frontend:
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ shared_tokens.mandrill_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
+    EnvVarSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
     EnvVarDmAdminFrontendCookieSecret: "{{ admin_frontend.cookie_secret }}"
     EnvVarSecretKey: "{{ admin_frontend.cookie_secret }}"
 
@@ -343,6 +344,7 @@ buyer_frontend:
     EnvVarDmPasswordSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
+    EnvVarSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
 
     KeyName: "{{ key_name }}"
     InstanceType: "{{ buyer_frontend.instance_type }}"
@@ -403,6 +405,7 @@ supplier_frontend:
     EnvVarDmPasswordSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
+    EnvVarSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
 
     KeyName: "{{ key_name }}"
     InstanceType: "{{ supplier_frontend.instance_type }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -285,11 +285,12 @@ admin_frontend:
     EnvVarDmSubmissionsBucket: "{{ stacks.submissions_s3.outputs.Name }}"
     EnvVarDmAssetsUrl: "https://{% if stage != 'production' %}{{ stage }}-{% endif %}{% if stage != environment %}{{ environment }}-{% endif %}assets.{{root_domain}}"
     EnvVarDmAdminFrontendApiAuthToken: "{{ api.auth_tokens[0] }}"
-    EnvVarDmAdminFrontendCookieSecret: "{{ admin_frontend.cookie_secret }}"
     EnvVarDmDataApiUrl: "{{ stacks.api.outputs.URL }}"
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ shared_tokens.mandrill_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
+    EnvVarDmAdminFrontendCookieSecret: "{{ admin_frontend.cookie_secret }}"
+    EnvVarSecretKey: "{{ admin_frontend.cookie_secret }}"
 
     KeyName: "{{ key_name }}"
     InstanceType: "{{ admin_frontend.instance_type }}"
@@ -340,6 +341,7 @@ buyer_frontend:
     EnvVarDmDataApiAuthToken: "{{ api.auth_tokens[0] }}"
     EnvVarDmMandrillApiKey: "{{ shared_tokens.mandrill_key }}"
     EnvVarDmPasswordSecretKey: "{{ shared_tokens.password_key }}"
+    EnvVarSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
 
     KeyName: "{{ key_name }}"
@@ -399,6 +401,7 @@ supplier_frontend:
     EnvVarDmClarificationQuestionEmail: "{{ supplier_frontend.clarification_question_email }}"
     EnvVarDmFollowUpEmailTo: "{{ supplier_frontend.follow_up_email_to }}"
     EnvVarDmPasswordSecretKey: "{{ shared_tokens.password_key }}"
+    EnvVarSecretKey: "{{ shared_tokens.password_key }}"
     EnvVarDmSharedEmailKey: "{{ shared_tokens.shared_email_key }}"
 
     KeyName: "{{ key_name }}"


### PR DESCRIPTION
Currently we use different environment variable names for the Flask secret key and then override it with `os.environ` in the [root Config class](https://github.com/alphagov/digitalmarketplace-supplier-frontend/blob/master/config.py#L52).

This is problematic for a few reasons:

1. `SECRET_KEY` is a Flask thing and naming it something different (even
   if it is more descriptive) obfuscates what it's being used for.
2. Setting it from the environment in the base class means that we
   cannot set a default for it in one of the environment specific child
   classes.

If we think that it is more helpful to have more descriptive names rather than stay consistent with Flask's naming than we should map the name we use to `SECRET_KEY` in `init_app`.