### PR TITLE
Enable gzip for css and javascript

### DIFF
--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -62,6 +62,7 @@ http {
 
     gzip on;
     gzip_disable "msie6";
+    gzip_types text/css application/javascript;
 
     # Virtual Host Configs
 


### PR DESCRIPTION
By default nginx only compresses text/html this change also compresses
css and javascript.