### PR TITLE
Update preview TSL certificate ARN

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,7 +1,6 @@
 ---
 root_domain: "development.digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/cloudfront/star-development-digitalmarketplace/star-development-digitalmarketplace"
-iam_certificate_id: "ASCAIJITQ6F5D5P4NWJZS"
+ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/nginx-preview-preview"
 
 monitoring:
   email: "support+development-preview@digitalmarketplace.service.gov.uk"

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,7 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2016-05-13"
-iam_certificate_id: "ASCAJG65ZXOA7JBRVORN6"
 
 monitoring:
   email: "support+production-production@digitalmarketplace.service.gov.uk"

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,7 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2016-05-13"
-iam_certificate_id: "ASCAJG65ZXOA7JBRVORN6"
 
 monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
Updates certificate name to match the new letsencryp certificate.
Letsencrypt update job will always rename the new certificate to
keep the current name, so future renewals should require no more
changes.

Removes iam_certificate_id since it appears to be unused now.