### PR TITLE
Update staging and production TLS certificate

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,6 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2016-05-13"
+ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2017-05-24"
 
 monitoring:
   email: "support+production-production@digitalmarketplace.service.gov.uk"

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,6 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2016-05-13"
+ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2017-05-24"
 
 monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
New certificate is uploaded to IAM so we can update the nginx ELBs to use it instead of the expiring one.