### PR TITLE
Update RDS database to PostgreSQL 9.4

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -7,6 +7,10 @@
       "Type": "String",
       "Description": "Database name"
     },
+    "DBVersion": {
+      "Type": "String",
+      "Description": "Database version number"
+    },
     "DBUser": {
       "NoEcho": "true",
       "Type": "String",
@@ -63,11 +67,11 @@
       }
     },
 
-    "DBParameterGroup": {
+    "DBParameterGroup94": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": "Custom DB parameter group",
-        "Family": "postgres9.3",
+        "Family": {"Fn::Join": ["", ["postgres", {"Ref": "DBVersion"}]]},
         "Parameters": {
           "log_min_duration_statement": {"Ref": "SlowQueryLogDurationMs" }
         }
@@ -79,12 +83,14 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "Engine": "postgres",
+        "EngineVersion": {"Ref": "DBVersion"},
+        "AllowMajorVersionUpgrade": true,
         "DBName": {"Fn::If": ["UseDbSnapshot", {"Ref": "AWS::NoValue"}, {"Ref": "DBName"}]},
         "MasterUsername": {"Ref": "DBUser"},
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "DBParameterGroupName": {"Ref": "DBParameterGroup"},
+        "DBParameterGroupName": {"Ref": "DBParameterGroup94"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},

--- a/stacks.yml
+++ b/stacks.yml
@@ -64,6 +64,7 @@ database:
   dependencies:
     - monitoring
   parameters:
+    DBVersion: "{{ database.version }}"
     DBName: "{{ database.name }}"
     DBUser: "{{ database.user }}"
     DBPassword: "{{ database.password }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -34,6 +34,7 @@ supplier_frontend:
   max_instance_count: 2
 
 database:
+  version: 9.4
   port: 5432
   user: "digitalmarketplace"
   name: "digitalmarketplace_api"


### PR DESCRIPTION
Changes the database engine version to 9.4. Major upgrades can only be done one at a time, so there's no way to move from 9.3 to 9.5 in one step. "allowMajorUpgrades" has to be set to true to apply the change.

Despite the description in the [AWS docs][1], there doesn't seem to be a way to change the DBParameterGroup Family parameter. AWS sets the resource status to 'UPDATE_COMPLETE', but the parameter group still has the old database version. And there doesn't seem to be a way to update the parameter group family using AWS CLI, so it's likely an error in the CloudFormation docs.

The updated database version however requires a matching parameter group family, so we rename the parameter group resource to force CloudFormation to replace the old group with a new one. This runs the expected update, removing the old group once the DB instance has finished updating, but requires a manual change to the template each time.

[1]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-dbparametergroup.html#cfn-rds-dbparametergroup-family