### PR TITLE
Increase instance size for API and supplier app

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -7,10 +7,6 @@
       "Type": "String",
       "Description": "Database name"
     },
-    "DBVersion": {
-      "Type": "String",
-      "Description": "Database version number"
-    },
     "DBUser": {
       "NoEcho": "true",
       "Type": "String",
@@ -67,11 +63,11 @@
       }
     },
 
-    "DBParameterGroup94": {
+    "DBParameterGroup": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": "Custom DB parameter group",
-        "Family": {"Fn::Join": ["", ["postgres", {"Ref": "DBVersion"}]]},
+        "Family": "postgres9.3",
         "Parameters": {
           "log_min_duration_statement": {"Ref": "SlowQueryLogDurationMs" }
         }
@@ -83,14 +79,12 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "Engine": "postgres",
-        "EngineVersion": {"Ref": "DBVersion"},
-        "AllowMajorVersionUpgrade": true,
         "DBName": {"Fn::If": ["UseDbSnapshot", {"Ref": "AWS::NoValue"}, {"Ref": "DBName"}]},
         "MasterUsername": {"Ref": "DBUser"},
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "DBParameterGroupName": {"Ref": "DBParameterGroup94"},
+        "DBParameterGroupName": {"Ref": "DBParameterGroup"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},

--- a/stacks.yml
+++ b/stacks.yml
@@ -64,7 +64,6 @@ database:
   dependencies:
     - monitoring
   parameters:
-    DBVersion: "{{ database.version }}"
     DBName: "{{ database.name }}"
     DBUser: "{{ database.user }}"
     DBPassword: "{{ database.password }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -34,7 +34,6 @@ supplier_frontend:
   max_instance_count: 2
 
 database:
-  version: 9.4
   port: 5432
   user: "digitalmarketplace"
   name: "digitalmarketplace_api"

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,6 +19,7 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
+  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 
@@ -35,6 +36,7 @@ buyer_frontend:
   max_instance_count: 5
 
 supplier_frontend:
+  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 


### PR DESCRIPTION
Since we expect an increase in requests for the last days of the G-Cloud 8 service submission, we raise the size of EC2 instances for supplier frontend and Data API apps.

This is the same as we did for G7 and it was all good (see Alexey's commit here: https://github.com/alphagov/digitalmarketplace-aws/commit/df1f1effc792f5d7211896e1dcd8ea8ae1609dcc)
We can reduce these to the previous value after the service submission is closed.