### PR TITLE
Upgrade to Postgres 9.4 (again)

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -7,6 +7,10 @@
       "Type": "String",
       "Description": "Database name"
     },
+    "DBVersion": {
+      "Type": "String",
+      "Description": "Database version number"
+    },
     "DBUser": {
       "NoEcho": "true",
       "Type": "String",
@@ -63,11 +67,11 @@
       }
     },
 
-    "DBParameterGroup": {
+    "DBParameterGroup94": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": "Custom DB parameter group",
-        "Family": "postgres9.3",
+        "Family": {"Fn::Join": ["", ["postgres", {"Ref": "DBVersion"}]]},
         "Parameters": {
           "log_min_duration_statement": {"Ref": "SlowQueryLogDurationMs" }
         }
@@ -79,12 +83,14 @@
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "Engine": "postgres",
+        "EngineVersion": {"Ref": "DBVersion"},
+        "AllowMajorVersionUpgrade": true,
         "DBName": {"Fn::If": ["UseDbSnapshot", {"Ref": "AWS::NoValue"}, {"Ref": "DBName"}]},
         "MasterUsername": {"Ref": "DBUser"},
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "DBParameterGroupName": {"Ref": "DBParameterGroup"},
+        "DBParameterGroupName": {"Ref": "DBParameterGroup94"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},

--- a/stacks.yml
+++ b/stacks.yml
@@ -64,6 +64,7 @@ database:
   dependencies:
     - monitoring
   parameters:
+    DBVersion: "{{ database.version }}"
     DBName: "{{ database.name }}"
     DBUser: "{{ database.user }}"
     DBPassword: "{{ database.password }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -34,6 +34,7 @@ supplier_frontend:
   max_instance_count: 2
 
 database:
+  version: 9.4
   port: 5432
   user: "digitalmarketplace"
   name: "digitalmarketplace_api"


### PR DESCRIPTION
This re-reverts the changes made in https://github.com/alphagov/digitalmarketplace-aws/commit/6efd5d1d2748a44446e692969f47981da085395c

This upgrade has already been run on Preview and Staging.  Once the G-Cloud 8 submissions window closes we need to pick a good time to run it on Production.