### PR TITLE
Revert "Increase instance size for API and supplier app"

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,7 +19,6 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
-  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 
@@ -36,7 +35,6 @@ buyer_frontend:
   max_instance_count: 5
 
 supplier_frontend:
-  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 


### PR DESCRIPTION
Service submissions are closed and the request spike is over, so we can scale down the instance sizes. We've reached the 10 instance autoscaling limit yesterday, but it's back to 3 instances for API and supplier frontend now.