### PR TITLE
Kibana log streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Packer and cloudformation won't automatically remove old AMI versions, so this h
 done manually. AMIs can be deleted from the EC2 console by deregestering the AMI and
 deleting the related EBS snapshot.
 
+## Deploying AWS Lambda functions
+
+Lambda functions are created by the CloudFormation stack, but rerunning the stack won't updated
+the function code. Instead, functions can be updating using the `lambda-release` command:
+
+```
+dmaws preview preview lambda-release cloudwatch_logs_lambda
+```
+
+This will package function code from `lambdas/cloudwatch_logs`, upload the archive to S3 and update
+the function code in AWS Lambda.
+
+This command can also be used to upload the initial function code archive to S3 before running the
+function stack for the first time. In this case, updating the function code will fail, since the
+function doesn't exist yet, but an archive will be uploaded to S3 and CloudFormation will use it
+when creating the function stack.
+
 ## SSHing into instances
 
 You can SSH onto instaces using the private key set up previously (SSH key pair).

--- a/cloudformation_templates/aws_jenkins.json
+++ b/cloudformation_templates/aws_jenkins.json
@@ -17,7 +17,11 @@
     },
     "Subdomain": {
       "Type": "String",
-      "Description": "Subdomain to use"
+      "Description": "Jenkins subdomain"
+    },
+    "LogsSubdomain": {
+      "Type": "String",
+      "Description": "Kibana proxy subdomain"
     },
     "HostedZoneName": {
       "Type": "String",
@@ -122,13 +126,24 @@
       }
     },
 
-    "Route53RecordSet": {
+    "CIRoute53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
         "HostedZoneName": {"Ref": "HostedZoneName"},
-        "Name": {"Fn::Join": ["",[
-          {"Ref": "Subdomain"}, ".", {"Ref": "RootDomain"}, "."
-         ]]},
+        "Name": {"Fn::Join": [".", [{"Ref": "Subdomain"}, {"Ref": "HostedZoneName"}]]},
+        "Type": "A",
+        "ResourceRecords": [
+          {"Ref": "ElasticIP"}
+        ],
+        "TTL": "300"
+      }
+    },
+
+    "LogsRoute53RecordSet": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": [".", ["*", {"Ref": "LogsSubdomain"}, {"Ref": "HostedZoneName"}]]},
         "Type": "A",
         "ResourceRecords": [
           {"Ref": "ElasticIP"}

--- a/cloudformation_templates/aws_kibana.json
+++ b/cloudformation_templates/aws_kibana.json
@@ -1,0 +1,63 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Kibana AWS Elasticsearch domain with CloudWatch streaming",
+  "Parameters": {
+    "DomainName": {
+      "Type": "String",
+      "Description": "Domain name for AWS Elasticsearch service"
+    },
+    "UserIPs": {
+      "Type": "CommaDelimitedList",
+      "Description": "List of IP addresses that can access the Elasticsearch domain"
+    }
+  },
+
+  "Resources": {
+    "ElasticsearchDomain": {
+      "Type": "AWS::Elasticsearch::Domain",
+      "Properties": {
+        "DomainName": {"Ref": "DomainName"},
+        "EBSOptions": {
+          "EBSEnabled": true,
+          "VolumeSize": 15,
+          "VolumeType": "gp2"
+        },
+        "ElasticsearchClusterConfig": {
+          "InstanceType": "t2.micro.elasticsearch",
+          "InstanceCount": 1
+        },
+        "AccessPolicies": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {"AWS": "*"},
+            "Action": "es:*",
+            "Resource": "arn:aws:es:*",
+            "Condition": {
+              "IpAddress": {
+                "aws:SourceIp": {"Ref": "UserIPs"}
+              }
+            }
+          }]
+        }
+      }
+    }
+  },
+  "Outputs": {
+    "Name": {
+      "Description": "Elasticsearch domain name",
+      "Value": {"Ref": "ElasticsearchDomain"}
+    },
+    "Domain": {
+      "Description": "Elasticsearch domain endpoint",
+      "Value": {"Fn::GetAtt": ["ElasticsearchDomain", "DomainEndpoint"]}
+    },
+    "URL" : {
+      "Value" : {"Fn::Join": ["", [
+        "https://", {"Fn::GetAtt": ["ElasticsearchDomain", "DomainEndpoint"]}
+      ]]},
+      "Description" : "Elasticsearch domain URL"
+    }
+  }
+}

--- a/cloudformation_templates/aws_lambda.json
+++ b/cloudformation_templates/aws_lambda.json
@@ -1,0 +1,68 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "AWS Lambda function",
+  "Parameters": {
+    "FunctionName": {
+      "Type": "String",
+      "Description": "AWS Lambda function name"
+    },
+    "S3Bucket": {
+      "Type": "String",
+      "Description": "Name of S3 bucket with lambda function code"
+    },
+    "S3Key": {
+      "Type": "String",
+      "Description": "S3 key with lambda function code"
+    }
+  },
+
+  "Resources": {
+    "LambdaExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{"Effect": "Allow", "Principal": {"Service": ["lambda.amazonaws.com"]}, "Action": ["sts:AssumeRole"]}]
+        },
+        "Path": "/",
+        "Policies": [{
+          "PolicyName": "root",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {"Effect": "Allow", "Action": ["logs:*"], "Resource": "arn:aws:logs:*:*:*"},
+              {"Effect": "Allow", "Action": "es:ESHttpPost", "Resource": "arn:aws:es:*:*:*"}
+            ]
+          }
+        }]
+      }
+    },
+
+    "LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {"Ref": "S3Bucket"},
+          "S3Key": {"Ref": "S3Key"}
+        },
+        "FunctionName": {"Ref": "FunctionName"},
+        "Handler": "main.handler",
+        "MemorySize": 128,
+        "Role": {"Fn::GetAtt" : ["LambdaExecutionRole", "Arn"]},
+        "Runtime": "nodejs4.3",
+        "Timeout": 60
+      }
+    }
+  },
+
+  "Outputs": {
+    "Name": {
+      "Description": "Lambda function name",
+      "Value": {"Ref": "LambdaFunction"}
+    },
+    "Arn": {
+      "Description": "Lambda function Arn",
+      "Value": {"Fn::GetAtt": ["LambdaFunction", "Arn"]}
+    }
+  }
+}

--- a/cloudformation_templates/aws_lambda.json
+++ b/cloudformation_templates/aws_lambda.json
@@ -2,6 +2,13 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AWS Lambda function",
   "Parameters": {
+{% for variable in environment_variables %}
+    "{{ variable }}": {
+        "Type": "String",
+        "Description": "Lambda function environment variable",
+        "NoEcho": "true"
+    },
+{% endfor %}
     "FunctionName": {
       "Type": "String",
       "Description": "AWS Lambda function name"

--- a/cloudformation_templates/aws_log_subscription.json
+++ b/cloudformation_templates/aws_log_subscription.json
@@ -1,0 +1,47 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "CloudWatch Logs subscription to stream logs to AWS Lambda",
+  "Parameters": {
+    "Lambda": {
+      "Type": "String",
+      "Description": "Destination lambda function ARN"
+    },
+    "LogGroupName": {
+      "Type": "String",
+      "Description": "Source CloudWatch log group"
+    },
+    "FilterPattern": {
+      "Type": "String",
+      "Description": "CloudWatch filter expression restricting what gets streamed"
+    }
+  },
+
+  "Resources": {
+    "LambdaInvokePermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "FunctionName" : {"Ref": "Lambda"},
+        "Action": "lambda:InvokeFunction",
+        "Principal": {"Fn::Join": [".", ["logs", {"Ref": "AWS::Region"}, "amazonaws.com"]]},
+        "SourceAccount": { "Ref" : "AWS::AccountId" }
+      }
+    },
+
+    "SubscriptionFilter" : {
+      "Type" : "AWS::Logs::SubscriptionFilter",
+      "DependsOn": "LambdaInvokePermission",
+      "Properties" : {
+        "DestinationArn" : {"Ref": "Lambda"},
+        "LogGroupName" : {"Ref" : "LogGroupName"},
+        "FilterPattern" : {"Ref": "FilterPattern"}
+      }
+    }
+  },
+
+  "Outputs": {
+    "Name": {
+      "Description": "Subscription filter name",
+      "Value": {"Ref": "SubscriptionFilter"}
+    }
+  }
+}

--- a/cloudformation_templates/aws_monitoring.json
+++ b/cloudformation_templates/aws_monitoring.json
@@ -60,7 +60,7 @@
     "CloudWatchMetricNginxRequestTime": {
       "Type": "AWS::Logs::MetricFilter",
       "Properties": {
-        "LogGroupName": {"Fn::Join": ["", [{"Ref": "LogGroupName"}, "-json"]]},
+        "LogGroupName": {"Ref": "JSONLogGroup"},
         "FilterPattern": "{ $.logType = nginx-access }",
         "MetricTransformations": [
           {

--- a/dmaws/commands/lambda.py
+++ b/dmaws/commands/lambda.py
@@ -1,0 +1,85 @@
+import os
+import sys
+import json
+import tempfile
+import zipfile
+
+import boto3
+import boto.s3
+
+from ..cli import cli_command
+from ..stacks import StackPlan
+from ..utils import param_to_env
+
+
+@cli_command('lambda-release', max_apps=1)
+def lambda_release_cmd(ctx, release_name=None, from_profile=None):
+    """Release new AWS Lambda function versions."""
+
+    app = ctx.apps[0]
+    plan = StackPlan.from_ctx(ctx, apps=[app])
+    plan.info(with_aws=True)
+
+    parameters = dict(plan.get_value('stacks.%s.parameters' % app))
+    environment_variables = {
+        param_to_env(key): p for key, p in parameters.items() if key.startswith('EnvVar')
+    }
+
+    ctx.log('==> Creating an archive for %s', app)
+    archive_path = create_zip_archive(ctx.home, app, environment_variables)
+    ctx.log('==> Uploading %s to %s/%s', archive_path, parameters['S3Bucket'], parameters['S3Key'])
+    upload_archive(ctx.variables['aws_region'], parameters['S3Bucket'], parameters['S3Key'], archive_path)
+    os.remove(archive_path)
+
+    ctx.log('==> Updating %s function', parameters['FunctionName'])
+    status = update_lambda_function(
+        ctx.variables['aws_region'],
+        parameters['FunctionName'],
+        parameters['S3Bucket'],
+        parameters['S3Key']
+    )
+
+    if not status:
+        sys.exit(1)
+
+
+def create_zip_archive(cwd, app, env):
+    lambda_path = os.path.join(cwd, 'lambdas', app.replace('_lambda', ''))
+
+    package_file, archive_path = tempfile.mkstemp()
+    os.close(package_file)
+
+    with zipfile.ZipFile(archive_path, 'a') as archive:
+        for root, dirs, files in os.walk(lambda_path):
+            for f in dirs + files:
+                file_path = os.path.join(root, f)
+                archive.write(os.path.join(root, f), arcname=os.path.relpath(file_path, lambda_path))
+
+        # Write stack environment variables to 'env' archive file,
+        # so it can be used by the lambda function
+        env_file = zipfile.ZipInfo('env')
+        env_file.external_attr = 0644 << 16L  # give full read access to env file
+        archive.writestr(env_file, json.dumps(env))
+
+    return archive_path
+
+
+def upload_archive(region, s3_bucket, s3_key, archive_path):
+    s3 = boto.s3.connect_to_region(region)
+    bucket = s3.get_bucket(s3_bucket)
+    key = bucket.new_key(s3_key)
+    key.set_contents_from_filename(archive_path)
+
+
+def update_lambda_function(region, function_name, s3_bucket, s3_key):
+    client = boto3.client('lambda', region_name=region)
+    response = client.update_function_code(
+        FunctionName=function_name,
+        S3Bucket=s3_bucket,
+        S3Key=s3_key,
+    )
+
+    if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+        return False
+
+    return True

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -149,10 +149,10 @@ class StackPlan(object):
                 stack_info = self.cfn.create_stack(built_stack)
             else:
                 stack_info = self.cfn.describe_stack(built_stack)
-                if not stack_info:
-                    self.log("Dependency %s doesn't exists, can't continue",
-                             built_stack.name, color='red')
-                    return False
+
+            if not stack_info or stack_info.get('failed', False):
+                self.log("%s doesn't exist or can't be created, can't continue", built_stack.name, color='red')
+                return False
 
             failure = failure or stack_info.get('failed', False)
             self.stack_context['stacks'][name].update_info(stack_info)

--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -1,9 +1,7 @@
-import re
-
 from toposort import toposort_flatten
 
 from .cloudformation import Cloudformation
-from .utils import template, load_file, LazyTemplateMapping
+from .utils import template, load_file, LazyTemplateMapping, param_to_env
 from .deploy import Deploy
 
 
@@ -59,11 +57,6 @@ class BuiltStack(Stack):
         environment_variables = [
             p for p in self.parameters.keys() if p.startswith('EnvVar')
         ]
-
-        def param_to_env(name):
-            s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-            s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
-            return s2.upper().replace('ENV_VAR_', '')
 
         return template(template_body, {
             "parameters": self.parameters,

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import collections
 import subprocess
 from subprocess import CalledProcessError
@@ -204,3 +205,9 @@ def template_string(string, variables, templates_path=None):
         return template.render(variables)
     except jinja2.exceptions.UndefinedError as e:
         raise ValueError(u"Variable {} in '{}'".format(e, string))
+
+
+def param_to_env(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
+    return s2.upper().replace('ENV_VAR_', '')

--- a/lambdas/cloudwatch_logs/main.js
+++ b/lambdas/cloudwatch_logs/main.js
@@ -1,0 +1,239 @@
+// Based on AWS Cloudwatch "Stream to Amazon Elasticsearch Service" funcion v1.1.2
+// Required stack parameters:
+// * EnvVarElasticsearchEndpoint - Amazon Elasticsearch Service domain endpoint
+
+var https = require('https');
+var zlib = require('zlib');
+var crypto = require('crypto');
+
+var environment = JSON.parse(require('fs').readFileSync('env', 'utf8'));
+var endpoint = environment['ELASTICSEARCH_ENDPOINT'];
+
+exports.handler = function(input, context) {
+    // decode input from base64
+    var zippedInput = new Buffer(input.awslogs.data, 'base64');
+
+    // decompress the input
+    zlib.gunzip(zippedInput, function(error, buffer) {
+        if (error) { context.fail(error); return; }
+
+        // parse the input from JSON
+        var awslogsData = JSON.parse(buffer.toString('utf8'));
+
+        // transform the input to Elasticsearch documents
+        var elasticsearchBulkData = transform(awslogsData);
+
+        // skip control messages
+        if (!elasticsearchBulkData) {
+            console.log('Received a control message');
+            context.succeed('Control message handled successfully');
+            return;
+        }
+
+        // post documents to the Amazon Elasticsearch Service
+        post(elasticsearchBulkData, function(error, success, statusCode, failedItems) {
+            console.log('Response: ' + JSON.stringify({
+                "statusCode": statusCode
+            }));
+
+            if (error) {
+                console.log('Error: ' + JSON.stringify(error, null, 2));
+
+                if (failedItems && failedItems.length > 0) {
+                    console.log("Failed Items: " +
+                        JSON.stringify(failedItems, null, 2));
+                }
+
+                context.fail(JSON.stringify(error));
+            } else {
+                console.log('Success: ' + JSON.stringify(success));
+                context.succeed('Success');
+            }
+        });
+    });
+};
+
+function transform(payload) {
+    if (payload.messageType === 'CONTROL_MESSAGE') {
+        return null;
+    }
+
+    var bulkRequestBody = '';
+
+    payload.logEvents.forEach(function(logEvent) {
+        var timestamp = new Date(1 * logEvent.timestamp);
+
+        // index name format: cwl-YYYY.MM.DD
+        var indexName = [
+            'cwl-' + timestamp.getUTCFullYear(),              // year
+            ('0' + (timestamp.getUTCMonth() + 1)).slice(-2),  // month
+            ('0' + timestamp.getUTCDate()).slice(-2)          // day
+        ].join('.');
+
+        var source = buildSource(logEvent.message);
+        source['@id'] = logEvent.id;
+        source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+        source['@message'] = logEvent.message;
+        source['@owner'] = payload.owner;
+        source['@log_group'] = payload.logGroup;
+        source['@log_stream'] = payload.logStream;
+
+        var action = { "index": {} };
+        action.index._index = indexName;
+        action.index._type = payload.logGroup;
+        action.index._id = logEvent.id;
+
+        bulkRequestBody += [
+            JSON.stringify(action),
+            JSON.stringify(source),
+        ].join('\n') + '\n';
+    });
+    return bulkRequestBody;
+}
+
+
+function buildSource(message) {
+    var jsonSubString = extractJson(message);
+    if (jsonSubString === null) {
+        return {};
+    }
+
+    var source = JSON.parse(jsonSubString);
+
+    ['time', 'remoteLogname', 'user'].forEach(function (key) {
+        delete source[key];
+    });
+
+    // Rewrite Apache logs request time to match nginx
+    if (source['requestTimeMicro']) {
+        source['requestTime'] = source['requestTimeMicro'] / 1000000;
+        delete source['requestTimeMicro'];
+    }
+
+    return source;
+}
+
+function extractJson(message) {
+    var jsonStart = message.indexOf('{');
+    if (jsonStart < 0) return null;
+    var jsonSubString = message.substring(jsonStart);
+    return isValidJson(jsonSubString) ? jsonSubString : null;
+}
+
+function isValidJson(message) {
+    try {
+        JSON.parse(message);
+    } catch (e) { return false; }
+    return true;
+}
+
+function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+function post(body, callback) {
+    var requestParams = buildRequest(endpoint, body);
+
+    var request = https.request(requestParams, function(response) {
+        var responseBody = '';
+        response.on('data', function(chunk) {
+            responseBody += chunk;
+        });
+        response.on('end', function() {
+            var info = JSON.parse(responseBody);
+            var failedItems;
+            var success;
+
+            if (response.statusCode >= 200 && response.statusCode < 299) {
+                failedItems = info.items.filter(function(x) {
+                    return x.index.status >= 300;
+                });
+
+                success = {
+                    "attemptedItems": info.items.length,
+                    "successfulItems": info.items.length - failedItems.length,
+                    "failedItems": failedItems.length
+                };
+            }
+
+            var error = response.statusCode !== 200 || info.errors === true ? {
+                "statusCode": response.statusCode,
+                "responseBody": responseBody
+            } : null;
+
+            callback(error, success, response.statusCode, failedItems);
+        });
+    }).on('error', function(e) {
+        callback(e);
+    });
+    request.end(requestParams.body);
+}
+
+function buildRequest(endpoint, body) {
+    var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
+    var region = endpointParts[2];
+    var service = endpointParts[3];
+    var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
+    var date = datetime.substr(0, 8);
+    var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
+    var kRegion = hmac(kDate, region);
+    var kService = hmac(kRegion, service);
+    var kSigning = hmac(kService, 'aws4_request');
+
+    var request = {
+        host: endpoint,
+        method: 'POST',
+        path: '/_bulk',
+        body: body,
+        headers: {
+            'Content-Type': 'application/json',
+            'Host': endpoint,
+            'Content-Length': Buffer.byteLength(body),
+            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
+            'X-Amz-Date': datetime
+        }
+    };
+
+    var canonicalHeaders = Object.keys(request.headers)
+        .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
+        .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
+        .join('\n');
+
+    var signedHeaders = Object.keys(request.headers)
+        .map(function(k) { return k.toLowerCase(); })
+        .sort()
+        .join(';');
+
+    var canonicalString = [
+        request.method,
+        request.path, '',
+        canonicalHeaders, '',
+        signedHeaders,
+        hash(request.body, 'hex'),
+    ].join('\n');
+
+    var credentialString = [ date, region, service, 'aws4_request' ].join('/');
+
+    var stringToSign = [
+        'AWS4-HMAC-SHA256',
+        datetime,
+        credentialString,
+        hash(canonicalString, 'hex')
+    ] .join('\n');
+
+    request.headers.Authorization = [
+        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
+        'SignedHeaders=' + signedHeaders,
+        'Signature=' + hmac(kSigning, stringToSign, 'hex')
+    ].join(', ');
+
+    return request;
+}
+
+function hmac(key, str, encoding) {
+    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
+}
+
+function hash(str, encoding) {
+    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 boto==2.36.0
+boto3==1.3.1
 
 click==4.0
-Jinja2==2.7.3
+Jinja2==2.8
 PyYAML==3.11
 toposort==1.1
 
-six==1.9.0
+six==1.10.0
 
 # loaddata dependencies
 requests==2.6.0

--- a/stacks.yml
+++ b/stacks.yml
@@ -493,6 +493,7 @@ jenkins:
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
     RootDomain: "{{ root_domain }}"
     Subdomain: "ci"
+    LogsSubdomain: "logs"
     Port: "{{ jenkins.port }}"
 
     KeyName: "{{ key_name }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -71,8 +71,6 @@ route53digitalservicesstore:
 database:
   name: "rds-database-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_rds_database.json
-  dependencies:
-    - monitoring
   parameters:
     DBVersion: "{{ database.version }}"
     DBName: "{{ database.name }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -539,7 +539,7 @@ lambda_logs_subscription:
     - cloudwatch_logs_lambda
   parameters:
     Lambda: "{{ stacks.cloudwatch_logs_lambda.outputs.Arn }}"
-    FilterPattern: ''
+    FilterPattern: '{ $.request != "*/_status?ignore-dependencies *" || $.url != "*/_status?ignore-dependencies" }'
     LogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
 
 jenkins_ssh_access:

--- a/stacks.yml
+++ b/stacks.yml
@@ -525,6 +525,12 @@ cloudwatch_logs_lambda:
     S3Bucket: "digitalmarketplace-lambda-code-{{ stage }}-{{ environment }}"
     S3Key: "cloudwatch-logs-{{ stage }}-{{ environment }}.zip"
 
+    # Additional parameters used by the function code. Names match
+    # the ElasticBeanstalk environment variable convention since
+    # we need to autogenerate the matching parameter declaration
+    # in the cloudformation template
+    EnvVarElasticsearchEndpoint: "{{ stacks.kibana.outputs.Domain }}"
+
 jenkins_ssh_access:
   name: "jenkins-{{ stage }}-ssh-access"
   template: cloudformation_templates/aws_dev_access.json

--- a/stacks.yml
+++ b/stacks.yml
@@ -4,6 +4,7 @@ all:
   - apps
   - dev_access
   - data_storage
+  - kibana
 
 apps:
   - api
@@ -493,6 +494,15 @@ jenkins:
     GroupTag: "jenkins-{{ stage }}"
     InstanceType: "{{ jenkins.instance_type }}"
     InstanceImage: "{{ jenkins.instance_image }}"
+
+kibana:
+  name: "kibana-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_kibana.json
+  dependencies:
+    - monitoring
+  parameters:
+    DomainName: "kibana-{{ stage }}-{{ environment }}"
+    UserIPs: "{{ dev_user_ips | join(',') }}"
 
 jenkins_ssh_access:
   name: "jenkins-{{ stage }}-ssh-access"

--- a/stacks.yml
+++ b/stacks.yml
@@ -508,7 +508,7 @@ kibana:
     - monitoring
   parameters:
     DomainName: "kibana-{{ stage }}-{{ environment }}"
-    UserIPs: "{{ dev_user_ips | join(',') }}"
+    UserIPs: "{{ jenkins_ips | join(',') }}"
 
 lambda_code_s3:
   name: "lambda-code-s3-{{ stage }}-{{ environment }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -553,6 +553,17 @@ jenkins_ssh_access:
     ToPort: 22
     SecurityGroup: "{{ stacks.jenkins.outputs.InstanceSecurityGroup }}"
 
+jenkins_letsencrypt_access:
+  name: "jenkins-{{ stage }}-letsencrypt-access"
+  template: cloudformation_templates/aws_dev_access.json
+  dependencies:
+    - jenkins
+  parameters:
+    CidrIPs: "0.0.0.0/0"
+    FromPort: 80
+    ToPort: 80
+    SecurityGroup: "{{ stacks.jenkins.outputs.InstanceSecurityGroup }}"
+
 nginx_ssh_access:
   name: "nginx-{{ stage }}-{{ environment }}-ssh-access"
   template: cloudformation_templates/aws_dev_access.json

--- a/stacks.yml
+++ b/stacks.yml
@@ -531,6 +531,16 @@ cloudwatch_logs_lambda:
     # in the cloudformation template
     EnvVarElasticsearchEndpoint: "{{ stacks.kibana.outputs.Domain }}"
 
+lambda_logs_subscription:
+  name: "lambda-logs-subscription-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_log_subscription.json
+  dependencies:
+    - cloudwatch_logs_lambda
+  parameters:
+    Lambda: "{{ stacks.cloudwatch_logs_lambda.outputs.Arn }}"
+    FilterPattern: ''
+    LogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
+
 jenkins_ssh_access:
   name: "jenkins-{{ stage }}-ssh-access"
   template: cloudformation_templates/aws_dev_access.json

--- a/stacks.yml
+++ b/stacks.yml
@@ -5,6 +5,7 @@ all:
   - dev_access
   - data_storage
   - kibana
+  - lambda_functions
 
 apps:
   - api
@@ -29,8 +30,12 @@ data_storage:
   - communications_s3
   - submissions_s3
   - agreements_s3
+  - lambda_code_s3
   - elasticsearch
   - monitoring
+
+lambda_functions:
+  - cloudwatch_logs_lambda
 
 dev_access:
   - database_dev_access
@@ -503,6 +508,22 @@ kibana:
   parameters:
     DomainName: "kibana-{{ stage }}-{{ environment }}"
     UserIPs: "{{ dev_user_ips | join(',') }}"
+
+lambda_code_s3:
+  name: "lambda-code-s3-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_s3.json
+  parameters:
+    BucketName: "digitalmarketplace-lambda-code-{{ stage }}-{{ environment }}"
+
+cloudwatch_logs_lambda:
+  name: "cloudwatch-logs-lambda-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_lambda.json
+  dependencies:
+    - kibana
+  parameters:
+    FunctionName: "dm-cloudwatch-logs-{{ stage }}-{{ environment }}"
+    S3Bucket: "digitalmarketplace-lambda-code-{{ stage }}-{{ environment }}"
+    S3Key: "cloudwatch-logs-{{ stage }}-{{ environment }}.zip"
 
 jenkins_ssh_access:
   name: "jenkins-{{ stage }}-ssh-access"


### PR DESCRIPTION
## General improvements
### Remove dependency on monitoring from database stack
Database stack doesn't reference the monitoring output, so there's no reason to have an explicit dependency. The only connection between RDS and monitoring is the notification when a DB instance is deleted, but there's little value in them for standalone databases.

Monitoring is still required for apps, so there's no risk of accidentally skipping the stack update.

### Abort create process if one of the dependent stack fails to create

Stops the creation process if a stack fails to create. This is similar to how we stopped when a dependant stack didn't exist, but for some reason there was no similar check for creating dependencies.

### Fix a race condition when creating monitoring metrics

Using JSONLogGroup reference to get the log group name instead of creating the name string forces cloudformation to wait until the log group resource has finished creating. Without the dependency both log group and metric creation are started at the same time and metric fails since the log group name doesn't exist yet.

### Move param_to_env to utils
param_to_env captures our naming convention for parameter name transformation, so it could be used by other methods/commands.

## Cloudwatch log streaming

![screen shot 2016-06-30 at 17 12 04](https://cloud.githubusercontent.com/assets/246664/16495527/d40091c4-3ee5-11e6-8137-5b9a91613c1c.png)


### Add kibana stack to create AWS Elasticsearch service for logs
Creates an AWS Elasticsearch instance with IP access restriction for developers.

### Add AWS Lambda CloudFormation template and stacks
There are two ways to create a Lambda function using CloudFormation:
* by inlining the code into the template directly, which is limited to 4096 bytes
* from an S3 object containing a ZIP archive with the function code

Since the inline size is quite restrictive we're going with the S3 route. The stacks will create an S3 bucket and then attempt to create a Lambda function using the `S3Key` object that should be stored in that bucket. Since there's no way to upload a file to S3 using CloudFormation that file has to be uploaded manually (after the bucket stack was created, but before the Lambda one) when the stack is run for the first time.

Rerunning the stack if the S3 file was changed won't update the Lambda code, since CloudFormation considers the template to be unchanged. There's a way to add S3 object version to the resource (or use manual versioning by changing the file name for each version) forcing CloudFormation to apply the update, but that requires changing the variable for each new function version (similar to how packer AMI
flow works right now). Instead, since code archive creation will require additional steps anyway, we're going to add a command to release and apply a new lambda version.

### Add lambda-release dmaws command to push lambda code updates
Since there's no convenient way to upload Lambda function code with CloudFormation we need a separate command to create the code archive, upload it to S3 and update the Lambda.

`lambda-release` command takes the name of the lambda function stack and:
1. Looks for the function code in `lambdas/<lambda_name>`. `lambda_name` is the name of the stack with `"_lambda"` part removed. The folder should contain a main.js file (since this is what our runtime and handler parameters in aws_lambda template are set to).
2. Create the environment file with all `EnvVar` parameters stored in JSON.
3. Archive the code and upload it to `S3Bucket/S3Key`
4. Update the Lambda function code with the new file from S3

Environment variables are taken from the stack parameters matching the `EnvVar` naming convention. Parameter names are rewritten using `param_to_env`, similar to how we do it with ElasticBeanstalk app environment variables. The file is stored as `'env'` and added to the code package, so that it can be loaded by the function code.

Since all CloudFormation parameters need to be declared by the template, even though they're not used by any of the resources, we have to generate the EnvVar declarations using Jinja, same as in the app_base template.

We could update function code directly instead of uploading to S3 first, but this approach makes it possible to recreate CloudFormation stack without losing the function code. Since CloudFormation references the same S3 object it will recreate the stack with the latest function code.
The downside of this approach is that we need to upload a file to S3 before the first lambda stack run. The alternative would be to use an empty function code block in the CloudFormation template and then upload the actual code using the new command.

### Add cloudwatch_logs Lambda function source code
Based on the function created when setting up streaming to Amazon Elasticsearch service.

Code is modified to read Elasticsearch endpoint from the environment file and adds some field changes specific to our log format in `buildSource` (rewriting request times so that apache and nginx formats match and dropping time fields that confused Kibana).

### Add log streaming from CloudWatch to Lambda function
Creates a log subscription for json log group. There can be only one subscription per log group, which we set up with an empty filter, so that all log streams are sent to the lambda function, which will then store them in Elasticsearch. This is not ideal, since our log group contains both apache and application logs
and with one subscription the only way to split them is inside the lambda function itself. And there's no way to set up separate functions for more granular filters (eg notifying on exceptions).

## Proxy ES through Jenkins nginx

### Point *.logs.beta domains to Jenkins instance IP
Allows proxying Elasticsearch instances through Jenkins nginx with more useful domain names and added authentication.

### Don't stream ELB health check request logs to Kibana
Filters out /_status?ignore-dependencies logs from streaming to the AWS Lambda function. Health check logs aren't really useful since they're mostly the same and removing them makes it easier to see actual user requests.

### Make Kibana Elasticsearch cluster only accessible from Jenkins
Since there's no way to set up user authentication on AWS ES service we make the Elasticsearch server accessible only from the Jenkins IP and set up a proxy with authorization on the Jenkins instance. This way ES is protected both by an IP restriction applied to the Jenkins nginx port and the authorization set up in nginx.

### Add a stack to open Jenkins port for letsencrypt checks
When verifying the domain ownership letsencrypt CA needs to be able to make a request to the domain server. Since the source IP address can change often we open the HTTP port for all IPs and change nginx config on Jenkins instance to only listen on 443, which means our proxy is still restricted to our developer IPs and port 80 is free to be used by letsencrypt standalone server when required.

The stack can be safely removed when unsused since it's only needed for the verification when requesting the certificate.