### PR TITLE
DSS domain redirect

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -373,6 +373,14 @@
       "Description": "ELB security group",
       "Value": {"Ref": "LoadBalancerSecurityGroup"}
     },
+    "LoadBalancerDNS": {
+      "Description": "Load Balancer DSN name",
+      "Value": {"Fn::GetAtt": ["LoadBalancer", "DNSName"]}
+    },
+    "LoadBalancerHostedZoneID": {
+      "Description": "Load Balancer hosted zone",
+      "Value": {"Fn::GetAtt": ["LoadBalancer", "CanonicalHostedZoneNameID"]}
+    },
     "AssetsURL": {
       "Description": "URL of the assets server",
       "Value": {

--- a/cloudformation_templates/aws_route53_digital_services_store.json
+++ b/cloudformation_templates/aws_route53_digital_services_store.json
@@ -1,0 +1,61 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "A public hosted zone for the given root domain.",
+
+  "Parameters": {
+    "Domain": {
+      "Type": "String",
+      "Description": "Route53 hosted zone root domain"
+    },
+    "LoadBalancerDNS": {
+      "Type": "String",
+      "Description": "DNS name for the target load balancer"
+    },
+    "LoadBalancerHostedZoneID": {
+      "Type": "String",
+      "Description": "Hosted zone ID for the target load balancer"
+    }
+  },
+
+  "Resources": {
+    "HostedZone": {
+      "Type": "AWS::Route53::HostedZone",
+      "Properties": {
+        "Name": {"Fn::Join": ["", [{"Ref": "Domain"}, "."]]}
+      }
+    },
+
+    "RootRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneId": {"Ref": "HostedZone"},
+        "Name": {"Fn::Join": ["", [{"Ref": "Domain"}, "."]]},
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": {"Ref": "LoadBalancerHostedZoneID"},
+          "DNSName": {"Ref": "LoadBalancerDNS"}
+        }
+      }
+    },
+
+    "WWWRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneId": {"Ref": "HostedZone"},
+        "Name": {"Fn::Join": ["", ["www.", {"Ref": "Domain"}, "."]]},
+        "Type": "A",
+        "AliasTarget": {
+          "HostedZoneId": {"Ref": "LoadBalancerHostedZoneID"},
+          "DNSName": {"Ref": "LoadBalancerDNS"}
+        }
+      }
+    }
+  },
+
+  "Outputs": {
+    "HostedZoneName": {
+      "Description": "Hosted zone name",
+      "Value": {"Ref": "HostedZone"}
+    }
+  }
+}

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -4,5 +4,6 @@ nginx_configs:
   - api
   - assets
   - healthcheck
+  - digitalservicesstore
 
 static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/templates/digitalservicesstore.j2
+++ b/playbooks/roles/nginx/templates/digitalservicesstore.j2
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name www.digitalservicesstore.service.gov.uk digitalservicesstore.service.gov.uk;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
+    location / {
+        return 301 https://www.digitalmarketplace.service.gov.uk;
+    }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -58,6 +58,16 @@ route53rootrecords:
   parameters:
     HostedZoneName: "{{ stacks.route53zone.outputs.HostedZoneName }}"
 
+route53digitalservicesstore:
+  name: "route53-digital-services-store"
+  template: cloudformation_templates/aws_route53_digital_services_store.json
+  dependencies:
+    - nginx
+  parameters:
+    Domain: '{% if stage == "production" %}digitalservicesstore.service.gov.uk{% endif %}'
+    LoadBalancerDNS: "{{ stacks.nginx.outputs.LoadBalancerDNS }}"
+    LoadBalancerHostedZoneID: "{{ stacks.nginx.outputs.LoadBalancerHostedZoneID }}"
+
 database:
   name: "rds-database-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_rds_database.json

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -50,4 +50,4 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-45991d36
+  instance_image: ami-e1d5b092


### PR DESCRIPTION
### Add a stack to create DSS Route53 records
Points [www.]digitalservicesstore.service.gov.uk to the nginx ELB
using Route53 alias records.

There's a stage check for hosted zone domain value that will make
stack creation fail on non-production environments. This is making
sure that records don't get accidentally changed to staging ELB.

#### Add nginx config to redirect DSS domain to digitalmarketplace
#### Update nginx AMI with new digitalservicesstore config
