### PR TITLE
Switch to AWS Certificate Manager certificate for DM and DSS domains

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,6 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2017-05-24"
+ssl_certificate_id: "arn:aws:acm:eu-west-1:050019655025:certificate/a0eb63fa-fdf8-4598-bae5-17d082966e0b"
 
 monitoring:
   email: "support+production-production@digitalmarketplace.service.gov.uk"

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,6 +1,6 @@
 ---
 root_domain: "digitalmarketplace.service.gov.uk"
-ssl_certificate_id: "arn:aws:iam::050019655025:server-certificate/star-digitalmarketplace-2017-05-24"
+ssl_certificate_id: "arn:aws:acm:eu-west-1:050019655025:certificate/a0eb63fa-fdf8-4598-bae5-17d082966e0b"
 
 monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION

![screen shot 2016-07-04 at 15 32 54](https://cloud.githubusercontent.com/assets/246664/16563929/aa2a22b0-41fc-11e6-89c0-6da80b28cb60.png)


Setting up a redirect for DSS means we need to have a valid
TLS certificate for the digitalservicesstore.service.gov.uk domain.
Since we're using our existing nginx instances and HTTP listeners
on the nginx ELB we can only set up one certificate per listener -
so we need a single certificate for both digitalmarketplace and DSS
domains. The added benefit of this approach is that we don't have
any SNI issues with old OS and browsers since all requests are covered
by the same certificate.

We've requested a new certificate through ACM, which allows us to
connect it with ELB listeners using our existing template.