### PR TITLE
Fix cloudwatch stream filter

### DIFF
--- a/lambdas/cloudwatch_logs/main.js
+++ b/lambdas/cloudwatch_logs/main.js
@@ -71,12 +71,7 @@ function transform(payload) {
         ].join('.');
 
         var source = buildSource(logEvent.message);
-        source['@id'] = logEvent.id;
         source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
-        source['@message'] = logEvent.message;
-        source['@owner'] = payload.owner;
-        source['@log_group'] = payload.logGroup;
-        source['@log_stream'] = payload.logStream;
 
         var action = { "index": {} };
         action.index._index = indexName;

--- a/stacks.yml
+++ b/stacks.yml
@@ -539,7 +539,7 @@ lambda_logs_subscription:
     - cloudwatch_logs_lambda
   parameters:
     Lambda: "{{ stacks.cloudwatch_logs_lambda.outputs.Arn }}"
-    FilterPattern: '{ $.request != "*/_status?ignore-dependencies *" || $.url != "*/_status?ignore-dependencies" }'
+    FilterPattern: '{ ($.request NOT EXISTS || $.request != "*/_status?ignore-dependencies *") && ($.url NOT EXISTS || $.url != "*/_status?ignore-dependencies") && ($.remoteHost NOT EXISTS || $.remoteHost != "::1") }'
     LogGroupName: "{{ stacks.monitoring.outputs.JSONLogGroupName }}"
 
 jenkins_ssh_access:


### PR DESCRIPTION
### Fix cloudwatch log streaming filter to not drop exceptions

Previous filter removed logs for health check requests by looking for log events that have either a wrong `request` or wrong `url`, but exception logs don't have any of these fields, so they got filtered out too.

Changing the filter to skip events that:
* Have `request` field and field value is matching health check
  URL - filters out apache-access health check logs
* Have `url` field and field value is matching health check URL -
  filters out application health check logs
* Have `remoteHost` field and field value is `::1` - filters out
  Apache mod_wsgi internal connection logs

### Drop redundant fields from Kibana log events
Removes duplicate `@id` field, `@message` source, account `@owner` and log group fields since they're all the same for all messages.
