### PR TITLE
Upgrade PostgreSQL to 9.5

### DIFF
--- a/cloudformation_templates/aws_rds_database.json
+++ b/cloudformation_templates/aws_rds_database.json
@@ -67,7 +67,7 @@
       }
     },
 
-    "DBParameterGroup94": {
+    "DBParameterGroup95": {
       "Type": "AWS::RDS::DBParameterGroup",
       "Properties": {
         "Description": "Custom DB parameter group",
@@ -90,7 +90,7 @@
         "DBInstanceClass": {"Ref": "DBInstanceType"},
         "AllocatedStorage": {"Ref": "DBAllocatedStorage"},
         "MasterUserPassword": {"Ref": "DBPassword"},
-        "DBParameterGroupName": {"Ref": "DBParameterGroup94"},
+        "DBParameterGroupName": {"Ref": "DBParameterGroup95"},
         "VPCSecurityGroups": [{"Fn::GetAtt": ["SecurityGroup", "GroupId"]}],
         "MultiAZ": {"Ref": "MultiAZ"},
         "BackupRetentionPeriod": {"Ref": "BackupRetentionPeriod"},

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -34,7 +34,7 @@ supplier_frontend:
   max_instance_count: 2
 
 database:
-  version: 9.4
+  version: 9.5
   port: 5432
   user: "digitalmarketplace"
   name: "digitalmarketplace_api"


### PR DESCRIPTION
Now that 9.4 is in production we can start testing 9.5 in preview
and staging.

Version change still requires a new parameter group resource, since
CloudFormation can't change the parameter group version in-place.