### PR TITLE
Restore staging database from a snapshot

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -9,7 +9,7 @@ database:
   multi_az: "true"
   backup_retention_period: "1"
   slow_query_log_duration_ms: -1
-  snapshot_id: "staging-2015-07-17t1003"
+  snapshot_id: "staging-2016-08-06t0529"
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
Unintentionally reset the staging database over the weekend, so
restoring from a snapshot taken this weekend to see if we get our
data back.
Our hypothesis is that we won't, but
- at least we'll know for sure
- it's an opportunity for me to try out our backup process, if
you want to call it a process

Also toyed with the idea of increasing the number of days we keep
around our backups, but that doesn't really seem like the problem
that we have.

(ie, I think the problem that we have is that we don't have an easy way for @andrewchong to create things on staging.  We shouldn't be worried about wiping out our staging database.)