### PR TITLE
Increase kibana instance size

### DIFF
--- a/cloudformation_templates/aws_kibana.json
+++ b/cloudformation_templates/aws_kibana.json
@@ -6,6 +6,10 @@
       "Type": "String",
       "Description": "Domain name for AWS Elasticsearch service"
     },
+    "InstanceType": {
+      "Type": "String",
+      "Description": "AWS Elasticsearch instance type"
+    },
     "UserIPs": {
       "Type": "CommaDelimitedList",
       "Description": "List of IP addresses that can access the Elasticsearch domain"
@@ -19,11 +23,11 @@
         "DomainName": {"Ref": "DomainName"},
         "EBSOptions": {
           "EBSEnabled": true,
-          "VolumeSize": 15,
+          "VolumeSize": 50,
           "VolumeType": "gp2"
         },
         "ElasticsearchClusterConfig": {
-          "InstanceType": "t2.micro.elasticsearch",
+          "InstanceType": {"Ref": "InstanceType"},
           "InstanceCount": 1
         },
         "AccessPolicies": {

--- a/cloudformation_templates/aws_lambda.json
+++ b/cloudformation_templates/aws_lambda.json
@@ -57,7 +57,7 @@
         "MemorySize": 128,
         "Role": {"Fn::GetAtt" : ["LambdaExecutionRole", "Arn"]},
         "Runtime": "nodejs4.3",
-        "Timeout": 60
+        "Timeout": 5
       }
     }
   },

--- a/stacks.yml
+++ b/stacks.yml
@@ -509,6 +509,7 @@ kibana:
   parameters:
     DomainName: "kibana-{{ stage }}-{{ environment }}"
     UserIPs: "{{ jenkins_ips | join(',') }}"
+    InstanceType: "{{ kibana.instance_type }}"
 
 lambda_code_s3:
   name: "lambda-code-s3-{{ stage }}-{{ environment }}"

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -51,3 +51,6 @@ nginx:
   instance_type: t2.micro
   instance_count: 2
   instance_image: ami-e1d5b092
+
+kibana:
+  instance_type: m3.medium.elasticsearch


### PR DESCRIPTION
### Reduce lambda function timeout to 5s
When Kibana server is under heavy load it stops responding to lambda
requests, which makes the function wait until it's interrupted by
a timeout. Higher timeout value means the function will wait longer,
which increases the AWS bill.

Most successfull requests to Elasticsearch should complete within 5s,
so setting that as the timeout value. It could be adjusted if the
lambda monitoring shows a lot of functions being interrupted.

### Increase Kibana isntance size to m3.medium
It looks like micro instances aren't handling the load very well,
both preview and production instances stopped processing requests
after being up for a month. Increasing the instance size to see if
it solves the problem.

Also increasing the disk size. EBS is pretty cheap for the volumes
we're using, and log indexes take up around 400Mb per day in preview
and production.
