### PR TITLE
[#124089551] Add initial DMARC policy record to Route53 root domain

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -42,6 +42,19 @@
       }
     },
 
+    "DMARCRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": [".", ["_dmarc", {"Ref": "HostedZoneName"}]]},
+        "Type": "TXT",
+        "ResourceRecords": [
+          "\"v=DMARC1; p=none; rua=mailto:support+dmarc-reports@digitalmarketplace.service.gov.uk; fo=1\""
+        ],
+        "TTL": "300"
+      }
+    },
+
     "GoogleVerification": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {


### PR DESCRIPTION
Adds a 'none' DMARC policy to digitalmarketplace.service.gov.uk to collect reports without rejecting any emails that are currently being sent.

This sets `support+dmarc-reports@` to gather aggregate reports. Not setting up an email address to gather individual failure notifications since we don't know the volume yet.

Once we start receiving daily aggregate reports (first one should arrive after 24 hours) and verify they're ok we can change the policy to `p=reject` to match the service.gov.uk one. Ideally, we'd do this before October 1st, but `p=none` should override the service.gov.uk default either way.