### PR TITLE
DKIM records for Zendesk and Mailchimp

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -42,6 +42,21 @@
       }
     },
 
+    "MailchimpDKIMRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["", [
+          "k1._domainkey", ".", {"Ref": "HostedZoneName"}
+        ]]},
+        "Type": "CNAME",
+        "ResourceRecords": [
+          "dkim.mcsv.net"
+        ],
+        "TTL": "300"
+      }
+    },
+
     "ZendeskDKIMRecord": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -88,7 +103,7 @@
         "Type": "TXT",
         "ResourceRecords": [
           "\"google-site-verification=wCZPbaSgAFuIlzK2CpzwiOYwgCUJP_ZUOhHTYCGs7aQ\"",
-          "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com include:mail.zendesk.com ~all\""
+          "\"v=spf1 include:_spf.google.com include:spf.mandrillapp.com include:mail.zendesk.com include:servers.mcsv.net ~all\""
         ],
         "TTL": "300"
       }

--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -42,6 +42,31 @@
       }
     },
 
+    "ZendeskDKIMRecord": {
+      "Type": "AWS::Route53::RecordSetGroup",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "RecordSets": [
+          {
+            "Name": {"Fn::Join": [".", [
+              "zendesk1._domainkey", {"Ref": "HostedZoneName"}
+            ]]},
+            "Type" : "CNAME",
+            "TTL" : "900",
+            "ResourceRecords" : ["zendesk1._domainkey.zendesk.com"]
+          },
+          {
+            "Name": {"Fn::Join": [".", [
+              "zendesk2._domainkey", {"Ref": "HostedZoneName"}
+            ]]},
+            "Type" : "CNAME",
+            "TTL" : "900",
+            "ResourceRecords" : ["zendesk2._domainkey.zendesk.com"]
+          }
+        ]
+      }
+    },
+
     "DMARCRecord": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {


### PR DESCRIPTION
### Add Zendesk DKIM records
Zendesk uses CNAME records for DKIM authentication and requires two
separate records to be set up.

https://support.zendesk.com/hc/en-us/articles/203663326-Digitally-signing-your-email-with-DKIM-or-DMARC

This might require a change in Zendesk configuration to enable signing

### Add Mailchimp DKIM and SPF records
We're still using Mailchimp for non-transactional emails to buyers
and suppliers, so we need to set up email authentication for it.

http://kb.mailchimp.com/accounts/email-authentication/set-up-custom-domain-authentication-dkim-and-spf
