### PR TITLE
Publish Jenkins releases to Github Deployments API

### DIFF
--- a/dmaws/cli.py
+++ b/dmaws/cli.py
@@ -26,6 +26,11 @@ def main(ctx, stage, environment):
     ctx.environment = environment
 
 
+@click.group()
+def base():
+    pass
+
+
 def cli_command(cmd_name, max_apps=-1):
     """Common options for deployment commands."""
 
@@ -74,5 +79,4 @@ def cli_command(cmd_name, max_apps=-1):
 from .commands import *  # noqa
 
 
-def cli():
-    main(auto_envvar_prefix='DM_AWS')
+cli = click.CommandCollection(sources=[main, base])

--- a/dmaws/commands/deploy.py
+++ b/dmaws/commands/deploy.py
@@ -1,10 +1,13 @@
 import sys
+import json
+from datetime import datetime
 
 import click
 
-from ..cli import cli_command
+from ..cli import cli_command, base
 from ..stacks import StackPlan
 from ..build import get_application_name
+from ..github import publish_deployment
 
 
 @click.argument('repository_path', nargs=1, type=click.Path(exists=True))
@@ -24,3 +27,26 @@ def deploy_cmd(ctx, repository_path):
         sys.exit(1)
 
     ctx.log("URL: http://%s/", url)
+
+
+@click.argument('deployments_json', nargs=1, type=click.File())
+@click.option('--github-token', help="Github API token", default=None)
+@base.command('publish-deployments')
+def publish_releases(deployments_json, github_token):
+    """Publishes Jenkins deployments JSON dump to Github Deployments API"""
+
+    releases = json.load(deployments_json)
+    return all(
+        publish_deployment(
+            token=github_token,
+            repo=release['repo'],
+            ref=release['release'],
+            environment=release['stage'],
+            build=release['build'],
+            created_at=datetime.utcfromtimestamp(release['timestamp'] / 1000.0),
+            ci_url=release['build_url'],
+            status=release['status'],
+            logger=click.echo
+        )
+        for release in releases
+    )

--- a/dmaws/github.py
+++ b/dmaws/github.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+
+import requests
+
+
+def create_github_deployment(token, repo, ref, environment, payload=None):
+    return requests.post(
+        'https://api.github.com/repos/{}/deployments'.format(repo),
+        headers={'Authorization': 'token {}'.format(token)} if token else None,
+        json={
+            'ref': ref,
+            'auto_merge': False,
+            'required_contexts': [],
+            'environment': environment,
+            'payload': payload
+        }
+    )
+
+
+def set_github_deployment_status(token, repo, deployment_id, state, target_url=None):
+    return requests.post(
+        'https://api.github.com/repos/{}/deployments/{}/statuses'.format(repo, deployment_id),
+        headers={'Authorization': 'token {}'.format(token)} if token else None,
+        json={
+            'state': state,
+            'target_url': target_url,
+        }
+    )
+
+
+def get_github_deployments(token, repo, ref=None, environment=None):
+    return requests.get(
+        'https://api.github.com/repos/{}/deployments'.format(repo),
+        headers={'Authorization': 'token {}'.format(token)} if token else None,
+        params={'ref': ref, 'environment': environment}
+    )
+
+
+def publish_deployment(token, repo, ref, environment, build, created_at, ci_url, status=None,
+                       logger=None):
+    log = logger or (lambda *args, **kwargs: None)
+
+    ref_deployments = get_github_deployments(token, repo, ref, environment)
+    if ref_deployments.status_code == 200 and ref_deployments.json():
+        log('Deployment for {}@{} to {} already exists'.format(repo, ref, environment))
+        return True
+
+    created_at = created_at.isoformat()[:-7] + 'Z'
+    deployment = create_github_deployment(
+        token, repo, ref, environment,
+        {
+            'ci_build_id': build,
+            'created_at': created_at,
+        }
+    )
+
+    if deployment.status_code // 100 != 2:
+        log(u'Failed to create deployment for {}@{}: {}'.format(
+            repo, ref,
+            deployment.json()
+        ))
+        return False
+
+    log('Created deployment for {}@{} to {}'.format(repo, ref, environment))
+
+    if status is not None:
+        deployment_status = set_github_deployment_status(
+            token, repo,
+            deployment.json()['id'],
+            status,
+            ci_url,
+        )
+
+        if deployment_status.status_code // 100 != 2:
+            log(u'Failed to set deployment status for {} {}: {}'.format(
+                repo, deployment.json()['id'],
+                deployment_status.json()
+            ))
+            return False
+
+        log('Set deployment status for {}@{} to {}'.format(repo, ref, status))
+
+    return True

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,3 +2,5 @@
 pytest==2.7.0
 pep8==1.5.7
 mock==1.0.1
+
+requests-mock==0.6.0

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -28,11 +28,18 @@ def test_publish_deployment_without_status(rmock):
         ref='release-1',
         environment='production',
         build=1,
-        created_at=datetime.utcnow(),
+        created_at=datetime(2016, 1, 1, 2, 3, 4, 5),
         ci_url='/1',
     )
 
     assert status
+    assert rmock.last_request.json() == {
+        u'auto_merge': False,
+        u'environment': u'production',
+        u'payload': {u'ci_build_id': 1, u'created_at': u'2016-01-01T02:03:04Z'},
+        u'ref': u'release-1',
+        u'required_contexts': []
+    }
 
 
 def test_publish_deployment_with_status(rmock):
@@ -61,6 +68,10 @@ def test_publish_deployment_with_status(rmock):
     )
 
     assert status
+    assert rmock.last_request.json() == {
+        u'state': u'success',
+        u'target_url': u'/1'
+    }
 
 
 def test_dont_publish_if_ref_deployment_already_exists(rmock):

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,82 @@
+import pytest
+import requests_mock
+
+from datetime import datetime
+
+from dmaws.github import publish_deployment
+
+
+@pytest.yield_fixture
+def rmock():
+    with requests_mock.mock() as rmock:
+        yield rmock
+
+
+def test_publish_deployment_without_status(rmock):
+    rmock.request(
+        "GET", 'https://api.github.com/repos/org/repo/deployments',
+        json=[], status_code=200
+    )
+    rmock.request(
+        "POST", 'https://api.github.com/repos/org/repo/deployments',
+        json={"id": 1}, status_code=201
+    )
+
+    status = publish_deployment(
+        token='token',
+        repo='org/repo',
+        ref='release-1',
+        environment='production',
+        build=1,
+        created_at=datetime.utcnow(),
+        ci_url='/1',
+    )
+
+    assert status
+
+
+def test_publish_deployment_with_status(rmock):
+    rmock.request(
+        "GET", 'https://api.github.com/repos/org/repo/deployments',
+        json=[], status_code=200
+    )
+    rmock.request(
+        "POST", 'https://api.github.com/repos/org/repo/deployments',
+        json={"id": 1}, status_code=201
+    )
+    rmock.request(
+        "POST", 'https://api.github.com/repos/org/repo/deployments/1/statuses',
+        json={"id": 1}, status_code=201
+    )
+
+    status = publish_deployment(
+        token='token',
+        repo='org/repo',
+        ref='release-1',
+        environment='production',
+        build=1,
+        created_at=datetime.utcnow(),
+        ci_url='/1',
+        status='success'
+    )
+
+    assert status
+
+
+def test_dont_publish_if_ref_deployment_already_exists(rmock):
+    rmock.request(
+        "GET", 'https://api.github.com/repos/org/repo/deployments',
+        json=[{'id': 1}], status_code=200
+    )
+
+    status = publish_deployment(
+        token='token',
+        repo='org/repo',
+        ref='release-1',
+        environment='production',
+        build=1,
+        created_at=datetime.utcnow(),
+        ci_url='/1',
+    )
+
+    assert status


### PR DESCRIPTION
### Add a base CLI group to allow commands without stage/app
Not all CLI commands require stack information, so adding a separate `base` click group. Both groups are used for the `dmaws` command.

This drops the auto environment variable support that we're not using. Only explicit variables set for options will be picked up by click.

### Add dmaws.github to publish releases to Github Deployments API
Creates a github deployment for a given repository, ref and environment and sets the deployment status.

### Add a helper command to export Jenkins deployments to GitHub
Requires a JSON export of Jenkins deployments and creates a Github Deployment for each build.

### Publish a Github Deployment after each successful release
Adds a publish_deployment step to the release job. Requires a GITHUB_TOKEN and Jenkins build environment variables to be set.