### PR TITLE
Move stage argument after the command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Lambda functions are created by the CloudFormation stack, but rerunning the stac
 the function code. Instead, functions can be updating using the `lambda-release` command:
 
 ```
-dmaws preview preview lambda-release cloudwatch_logs_lambda
+dmaws lambda-release preview cloudwatch_logs_lambda
 ```
 
 This will package function code from `lambdas/cloudwatch_logs`, upload the archive to S3 and update

--- a/dmaws/cli.py
+++ b/dmaws/cli.py
@@ -1,5 +1,4 @@
 from functools import wraps
-import os
 import sys
 
 import click
@@ -18,16 +17,8 @@ STAGES = [
 
 
 @click.group()
-@click.argument('stage', nargs=1, type=click.Choice(STAGES))
-@click.argument('environment', nargs=1)
 @pass_context
-def main(ctx, stage, environment):
-    ctx.stage = stage
-    ctx.environment = environment
-
-
-@click.group()
-def base():
+def main(ctx):
     pass
 
 
@@ -51,10 +42,12 @@ def cli_command(cmd_name, max_apps=-1):
             '--dry-run', is_flag=True, default=False,
             help="List tasks that would run without executing any of them"
         )
+        @click.argument('stage', nargs=1, type=click.Choice(STAGES))
         @pass_context
         @wraps(cmd)
         def wrapped(ctx, vars_file, var, stacks_file, load_default_files,
-                    dry_run, app=None, *args, **kwargs):
+                    dry_run, stage, app=None, *args, **kwargs):
+            ctx.stage = ctx.environment = stage
             ctx.load_variables(
                 files=ctx.get_variables_files(load_default_files, vars_file),
                 pairs=[v.split('=') for v in var])
@@ -79,4 +72,5 @@ def cli_command(cmd_name, max_apps=-1):
 from .commands import *  # noqa
 
 
-cli = click.CommandCollection(sources=[main, base])
+def cli():
+    main(auto_envvar_prefix='DM_AWS')

--- a/dmaws/commands/deploy.py
+++ b/dmaws/commands/deploy.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import click
 
-from ..cli import cli_command, base
+from ..cli import cli_command, main
 from ..stacks import StackPlan
 from ..build import get_application_name
 from ..github import publish_deployment
@@ -31,7 +31,7 @@ def deploy_cmd(ctx, repository_path):
 
 @click.argument('deployments_json', nargs=1, type=click.File())
 @click.option('--github-token', help="Github API token", default=None)
-@base.command('publish-deployments')
+@main.command('publish-deployments')
 def publish_releases(deployments_json, github_token):
     """Publishes Jenkins deployments JSON dump to Github Deployments API"""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto==2.36.0
 boto3==1.3.1
 
-click==4.0
+click==6.6
 Jinja2==2.8
 PyYAML==3.11
 toposort==1.1

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -20,4 +20,4 @@ if [ "$STAGE" = "staging" ]; then
 fi
 
 rm release_properties.out
-AWS_PROFILE="$STAGE" dmaws $STAGE $STAGE release $APPLICATION_NAME $OPTIONS 1>release_properties.out
+AWS_PROFILE="$STAGE" dmaws release $STAGE $APPLICATION_NAME $OPTIONS 1>release_properties.out


### PR DESCRIPTION
There doesn't seem to be a way to organize commands with and without arguments before the command name in a single CLI, so in order to support the helper commands I'm moving the STAGE argument after the command name.

This also removes ENVIRONMENT argument. We haven't used environment names that don't match the stage name until now, and we don't have any plans to at the moment, so I'm hiding the separate argument and making sure that environment is always the same as stage.