### PR TITLE
Upgrade to 10GB of storage on DB instance

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -39,7 +39,7 @@ database:
   user: "digitalmarketplace"
   name: "digitalmarketplace_api"
   instance_type: db.t2.micro
-  allocated_storage: 5
+  allocated_storage: 10
 
 elasticsearch:
   port: 9200


### PR DESCRIPTION
Preview DB is out of space.  Let's bump it up to 10GB.