### PR TITLE
Prevent API from autoscaling in preview during functional tests run

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -11,7 +11,7 @@ dev_user_ips:
 api:
   instance_type: t2.micro
   min_instance_count: 1
-  max_instance_count: 2
+  max_instance_count: 1
 
 search_api:
   instance_type: t2.micro


### PR DESCRIPTION
![screen shot 2016-09-26 at 10 25 26](https://cloud.githubusercontent.com/assets/246664/18829325/a5623f92-83d3-11e6-8327-9390ac8ddffe.png)


Sets the API max instance count in preview and staging to 1 to stop AWS from creating a new API instance every time functional tests run.

Functional tests create enough load to trigger the scaling policy, but the newly created instance only exists for a few minutes. Setting max instances to 1 will prevent this. Initially, we set max instances to 2 for all apps expecting Elastic Beanstalk to do a zero time deploy by replacing a running instance with a new one, but that doesn't seem to be happening.

Note: this is the simplest solution I could think of. Ideally, we'd change the autoscaling triggers to stop this from happening, but that requires a bit more digging into the CloudFormation templates and essentially achieves the same thing.