### PR TITLE
Add Google DKIM record to digtalmarketplace.service.gov.uk DNS

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -82,6 +82,21 @@
       }
     },
 
+    "GoogleDKIMRecord": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "HostedZoneName": {"Ref": "HostedZoneName"},
+        "Name": {"Fn::Join": ["", [
+          "google._domainkey", ".", {"Ref": "HostedZoneName"}
+        ]]},
+        "Type": "TXT",
+        "ResourceRecords": [
+          "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3Wu3i6aNpaGGyUzkmtiyWCb+MfB1ezhpYt4iEHktjOQVk7zdKcJJGR4jZrdIZ7/2mgM1d1nXLmhthtHh5cQ3najni7Y2FFgLdvGsAt6dkV5guKYRBZO9fxafwWZG8lk/6ajBYQPjZBzE5rO8vzrq0XXLPPXWyGPTn028u41Dvv8Xp+YYNYSssfwhO7lrXyBhspH8yV+wumvx3Eagu4QAr96+SAyCUomGTE67l1eXjGF7Q9GCLPc/BTaiE7VkEVGr8TppCuptigean17xAAHK4jROrzHxFepMXiRe+/ddQ3Fz3KNW0Pu4wFH3lz81zQlKSlBcgUaTxOTB3wyhSvpW/wIDAQAB\""
+        ],
+        "TTL": "300"
+      }
+    },
+
     "DMARCRecord": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {


### PR DESCRIPTION
We're using GMail/Google Groups to send group emails from the support email address, so we need to validate them in order to pass DMARC checks.

The DKIM record is different for each account, so it needs to be generated through Google Apps administrator page.

https://support.google.com/a/answer/173535?hl=en&ref_topic=2752442