### PR TITLE
Split Google DKIM record to meet TXT length limit

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -91,7 +91,8 @@
         ]]},
         "Type": "TXT",
         "ResourceRecords": [
-          "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3Wu3i6aNpaGGyUzkmtiyWCb+MfB1ezhpYt4iEHktjOQVk7zdKcJJGR4jZrdIZ7/2mgM1d1nXLmhthtHh5cQ3najni7Y2FFgLdvGsAt6dkV5guKYRBZO9fxafwWZG8lk/6ajBYQPjZBzE5rO8vzrq0XXLPPXWyGPTn028u41Dvv8Xp+YYNYSssfwhO7lrXyBhspH8yV+wumvx3Eagu4QAr96+SAyCUomGTE67l1eXjGF7Q9GCLPc/BTaiE7VkEVGr8TppCuptigean17xAAHK4jROrzHxFepMXiRe+/ddQ3Fz3KNW0Pu4wFH3lz81zQlKSlBcgUaTxOTB3wyhSvpW/wIDAQAB\""
+          "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3Wu3i6aNpaGGyUzkmtiyWCb+MfB1ezhpYt4iEHktjOQVk7zdKcJJGR4jZrdIZ7/2mgM1d1nXLmhthtHh5cQ3najni7Y2FFgLdvGsAt6dkV5guKYRBZO9fxafwWZG8lk/6ajBYQPjZBzE5rO8vzrq0XXLPPXWyGPTn028\"",
+          "\"u41Dvv8Xp+YYNYSssfwhO7lrXyBhspH8yV+wumvx3Eagu4QAr96+SAyCUomGTE67l1eXjGF7Q9GCLPc/BTaiE7VkEVGr8TppCuptigean17xAAHK4jROrzHxFepMXiRe+/ddQ3Fz3KNW0Pu4wFH3lz81zQlKSlBcgUaTxOTB3wyhSvpW/wIDAQAB\""
         ],
         "TTL": "300"
       }


### PR DESCRIPTION
Route53 limits TXT records to 255 characters, so we need to split Google DKIM record into two quoted strings.

https://support.google.com/a/answer/173535?hl=en&ref_topic=2752442