### PR TITLE
Fix Google DKIM record split

### DIFF
--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -91,8 +91,7 @@
         ]]},
         "Type": "TXT",
         "ResourceRecords": [
-          "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3Wu3i6aNpaGGyUzkmtiyWCb+MfB1ezhpYt4iEHktjOQVk7zdKcJJGR4jZrdIZ7/2mgM1d1nXLmhthtHh5cQ3najni7Y2FFgLdvGsAt6dkV5guKYRBZO9fxafwWZG8lk/6ajBYQPjZBzE5rO8vzrq0XXLPPXWyGPTn028\"",
-          "\"u41Dvv8Xp+YYNYSssfwhO7lrXyBhspH8yV+wumvx3Eagu4QAr96+SAyCUomGTE67l1eXjGF7Q9GCLPc/BTaiE7VkEVGr8TppCuptigean17xAAHK4jROrzHxFepMXiRe+/ddQ3Fz3KNW0Pu4wFH3lz81zQlKSlBcgUaTxOTB3wyhSvpW/wIDAQAB\""
+          "\"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3Wu3i6aNpaGGyUzkmtiyWCb+MfB1ezhpYt4iEHktjOQVk7zdKcJJGR4jZrdIZ7/2mgM1d1nXLmhthtHh5cQ3najni7Y2FFgLdvGsAt6dkV5guKYRBZO9fxafwWZG8lk/6ajBYQPjZBzE5rO8vzrq0XXLPPXWyGPTn028\" \"u41Dvv8Xp+YYNYSssfwhO7lrXyBhspH8yV+wumvx3Eagu4QAr96+SAyCUomGTE67l1eXjGF7Q9GCLPc/BTaiE7VkEVGr8TppCuptigean17xAAHK4jROrzHxFepMXiRe+/ddQ3Fz3KNW0Pu4wFH3lz81zQlKSlBcgUaTxOTB3wyhSvpW/wIDAQAB\""
         ],
         "TTL": "300"
       }


### PR DESCRIPTION
Splitting the record in two stops it from being recognized by DKIM checkers. After some investigation it looks like the way to do it is to use 👉 a single space between two quoted strings 👈 instead of a newline. This is accepted by Route53 despite being longer than 255 characters and seems to be recognized by DKIM checking tools.

https://stelfox.net/blog/2014/07/spf-and-dkim-records-in-route-53/