### PR TITLE
Set DMARC policy to quarantine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
   - "3.4"
 install:
-  - pip install -r requirements_for_test.txt
+  - pip install --no-use-wheel -r requirements_for_test.txt
 script:
   - ./scripts/run_tests.sh
 notifications:

--- a/cloudformation_templates/aws_route53_root_records.json
+++ b/cloudformation_templates/aws_route53_root_records.json
@@ -104,7 +104,7 @@
         "Name": {"Fn::Join": [".", ["_dmarc", {"Ref": "HostedZoneName"}]]},
         "Type": "TXT",
         "ResourceRecords": [
-          "\"v=DMARC1; p=none; rua=mailto:support+dmarc-reports@digitalmarketplace.service.gov.uk; fo=1\""
+          "\"v=DMARC1; p=quarantine; rua=mailto:support+dmarc-reports@digitalmarketplace.service.gov.uk; fo=1\""
         ],
         "TTL": "300"
       }


### PR DESCRIPTION
From dmarc.org FAQ:

> Given the real-world, non-technical use of the term, quarantine means "set aside for additional processing". The definition is at the appreciation of the manager of the receiving email infrastructure. It may mean deliver to the "junk folder" but it may also mean hold in a database for further review by dedicated personnel, or simply add a specific tag to the message before delivery.

https://dmarc.org/wiki/FAQ#What_does_a_.22quarantine.22_policy_mean_in_a_DMARC_record.3F

We're going to 'quarantine' instead of 'reject' to check that Google forwarding policy changes with a strict DMARC policy.