### PR TITLE
set/unset some security related headers in nginx

### DIFF
--- a/playbooks/roles/nginx/templates/api.j2
+++ b/playbooks/roles/nginx/templates/api.j2
@@ -4,8 +4,6 @@ server {
 
     set $api_url "{{ api_url }}";
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -10,8 +10,6 @@ server {
     set $communications_s3_url "{{ communications_s3_url }}";
     set $submissions_s3_url "{{ submissions_s3_url }}";
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-
     location /robots.txt {
         alias {{ static_files_root }}/robots_assets.txt;
     }

--- a/playbooks/roles/nginx/templates/digitalservicesstore.j2
+++ b/playbooks/roles/nginx/templates/digitalservicesstore.j2
@@ -2,8 +2,6 @@ server {
     listen 80;
     server_name www.digitalservicesstore.service.gov.uk digitalservicesstore.service.gov.uk;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-
     location / {
         return 301 https://www.digitalmarketplace.service.gov.uk;
     }

--- a/playbooks/roles/nginx/templates/healthcheck.j2
+++ b/playbooks/roles/nginx/templates/healthcheck.j2
@@ -1,6 +1,9 @@
 server {
     listen 80 default_server;
 
+    # unset HSTS header
+    add_header Strict-Transport-Security "";
+
     location /_status {
         access_log off;
         return 200 'nginx healthcheck status ok\n';

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -20,9 +20,10 @@ http {
     # ignore X-Forwarded-Host to prevent malicious 302s
     proxy_set_header X-Forwarded-Host "";
 
-    # couple of good practice security headers
+    # a few good practice security headers
     add_header X-Content-Type-Options nosniff;
     add_header X-Xss-Protection "1; mode=block" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
     # Basic Settings
     sendfile on;

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -17,6 +17,13 @@ http {
     # coming from the default VPC (ie ELB)
     set_real_ip_from 172.31.0.0/16;
 
+    # ignore X-Forwarded-Host to prevent malicious 302s
+    proxy_set_header X-Forwarded-Host "";
+
+    # couple of good practice security headers
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Xss-Protection "1; mode=block" always;
+
     # Basic Settings
     sendfile on;
     tcp_nopush on;

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -6,8 +6,6 @@ server {
     set $admin_frontend_url "{{ admin_frontend_url }}";
     set $supplier_frontend_url "{{ supplier_frontend_url }}";
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-
     location /robots.txt {
         alias {{ static_files_root }}/robots_www.txt;
     }


### PR DESCRIPTION
clear X-Forwarded-Host: if it was set to www.evil.com, and we 302 to /foo,
the browser would redirect to www.evil.com/foo

add X-Content-Type-Options nosniff: stop browsers inferring MIME types, which
is bad and stuff.

set X-Xss-Protection, which is enabled by default in most browsers and
completely stops rendering if XSS is detected

for more information on the headers, have a look at all the useful links in
https://gist.github.com/plentz/6737338

we've already got Strict-Transport-Security enabled everywhere other than the healthcheck conf (https://github.com/alphagov/digitalmarketplace-aws/blob/master/playbooks/roles/nginx/templates/healthcheck.j2)


![](http://i1.kym-cdn.com/photos/images/facebook/000/234/739/fa5.jpg)