### PR TITLE
always set nginx proxy headers

### DIFF
--- a/playbooks/roles/nginx/templates/api.j2
+++ b/playbooks/roles/nginx/templates/api.j2
@@ -10,11 +10,6 @@ server {
     deny all;
 
     location / {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
-        proxy_set_header DM-Request-ID "";
-
         proxy_redirect http:// https://;
 
         proxy_pass $api_url;
@@ -35,11 +30,6 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
     location / {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
-        proxy_set_header DM-Request-ID "";
-
         proxy_redirect http:// https://;
 
         proxy_pass $search_api_url;

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -15,21 +15,18 @@ server {
     }
 
     location / {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $documents_s3_url;
     }
 
     location ~ ^/[^/]+/documents/ {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $documents_s3_url;
     }
 
     location ~ ^/[^/]+/agreements/ {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $agreements_s3_url;
@@ -37,28 +34,24 @@ server {
 
     # Hack to force g7 communications to the old bucket to preserve upload times
     location ^~ /g-cloud-7-updates/communications {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $g7_draft_documents_s3_url;
     }
 
     location ~ ^/[^/]+/communications/ {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $communications_s3_url;
     }
 
     location ~ ^/[^/]+/submissions/ {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $submissions_s3_url;
     }
 
     location /g-cloud-7 {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_intercept_errors on;
 
         proxy_pass $g7_draft_documents_s3_url;

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -17,8 +17,13 @@ http {
     # coming from the default VPC (ie ELB)
     set_real_ip_from 172.31.0.0/16;
 
-    # ignore X-Forwarded-Host to prevent malicious 302s
+    # set proxy headers here. proxy_set_header *only* looks at the deepest nested invocation, so if any
+    # additional headers are set further down the conf stack these will need to be duplicated there as well
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_set_header X-Forwarded-Host "";
+    proxy_set_header Host $http_host;
+    proxy_set_header DM-Request-ID "";
 
     # a few good practice security headers
     add_header X-Content-Type-Options nosniff;

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -11,11 +11,6 @@ server {
     }
 
     location / {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
-        proxy_set_header DM-Request-ID "";
-
         proxy_redirect http:// https://;
 
         proxy_pass $buyer_frontend_url;
@@ -27,22 +22,12 @@ server {
         {% endfor %}
         deny all;
 
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
-        proxy_set_header DM-Request-ID "";
-
         proxy_redirect http:// https://;
 
         proxy_pass $admin_frontend_url;
     }
 
     location ~ ^/suppliers(/|$) {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Host $http_host;
-        proxy_set_header DM-Request-ID "";
-
         proxy_redirect http:// https://;
 
         proxy_pass $supplier_frontend_url;


### PR DESCRIPTION
proxy_set_header directives are only considered at the most deeply nested
level, so remove them all from everywhere and only define them in nginx.conf.j2