### PR TITLE
Update nginx AMI

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -50,7 +50,7 @@ elasticsearch:
 nginx:
   instance_type: t2.micro
   instance_count: 2
-  instance_image: ami-e6297495
+  instance_image: ami-87adf0f4
 
 kibana:
   instance_type: m3.medium.elasticsearch


### PR DESCRIPTION
Fixes proxy_set_header issue with X-Forwarded-Host not being removed from the forwarded headers.