### PR TITLE
unset Host on s3 requests

### DIFF
--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -10,6 +10,12 @@ server {
     set $communications_s3_url "{{ communications_s3_url }}";
     set $submissions_s3_url "{{ submissions_s3_url }}";
 
+    # host must be set to S3's domain for S3 requests
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-Host "";
+
     location /robots.txt {
         alias {{ static_files_root }}/robots_assets.txt;
     }


### PR DESCRIPTION
as S3 documentation says (http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonRequestHeaders.html):
Host
> For path-style requests, the value is s3.amazonaws.com. For virtual-style
> requests, the value is BucketName.s3.amazonaws.com. For more information,
> go to Virtual Hosting in the Amazon Simple Storage Service Developer Guide.

We're setting it to $http_host in the nginx base config, which is causing S3 to
reject all our requests. So lets unset it here. Because of proxy_set_header's
silly no-inheritance rule we have to redefine the other proxy headers for
all assets endpoints.