### PR TITLE
Add S3 logs bucket and enable S3 access logging

### DIFF
--- a/cloudformation_templates/aws_s3.json
+++ b/cloudformation_templates/aws_s3.json
@@ -5,6 +5,15 @@
     "BucketName": {
       "Type": "String",
       "Description": "S3 bucket name"
+    },
+    "AccessControl": {
+      "Type": "String",
+      "Description": "S3 bucket ACL",
+      "Default": "Private"
+    },
+    "LogsBucket": {
+      "Type": "String",
+      "Description": "S3 bucket name for storing access logs"
     }
   },
 
@@ -12,9 +21,13 @@
     "S3Bucket": {
       "Type": "AWS::S3::Bucket",
       "Properties": {
-        "AccessControl": "Private",
+        "AccessControl": {"Ref": "AccessControl"},
         "VersioningConfiguration": {
           "Status": "Enabled"
+        },
+        "LoggingConfiguration": {
+          "DestinationBucketName": {"Ref": "LogsBucket"},
+          "LogFilePrefix": {"Fn::Join": ["", [{"Ref": "BucketName"}, "/"]]}
         },
         "BucketName": {"Ref": "BucketName"}
       }

--- a/stacks.yml
+++ b/stacks.yml
@@ -89,35 +89,58 @@ database:
     BackupRetentionPeriod: "{{ database.backup_retention_period }}"
     DBSnapshotIdentifier: "{{ database.snapshot_id }}"
 
+logs_s3:
+  name: "logs-s3-{{ stage }}-{{ environment }}"
+  template: cloudformation_templates/aws_s3.json
+  parameters:
+    BucketName: "digitalmarketplace-logs-{{ stage }}-{{ environment }}"
+    LogsBucket: "digitalmarketplace-logs-{{ stage }}-{{ environment }}"
+    AccessControl: "LogDeliveryWrite"
+
 documents_s3:
   name: "documents-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 communications_s3:
   name: "communications-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-communications-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 submissions_s3:
   name: "submissions-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-submissions-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 agreements_s3:
   name: "agreements-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-agreements-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 g7_draft_documents_s3:
   name: "g7-draft-documents-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-g7-draft-documents-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 monitoring:
   name: "monitoring-{{ stage }}-{{ environment }}"
@@ -515,8 +538,11 @@ kibana:
 lambda_code_s3:
   name: "lambda-code-s3-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_s3.json
+  dependencies:
+    - logs_s3
   parameters:
     BucketName: "digitalmarketplace-lambda-code-{{ stage }}-{{ environment }}"
+    LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
 
 cloudwatch_logs_lambda:
   name: "cloudwatch-logs-lambda-{{ stage }}-{{ environment }}"

--- a/stacks.yml
+++ b/stacks.yml
@@ -105,6 +105,7 @@ documents_s3:
   parameters:
     BucketName: "digitalmarketplace-documents-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 communications_s3:
   name: "communications-s3-{{ stage }}-{{ environment }}"
@@ -114,6 +115,7 @@ communications_s3:
   parameters:
     BucketName: "digitalmarketplace-communications-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 submissions_s3:
   name: "submissions-s3-{{ stage }}-{{ environment }}"
@@ -123,6 +125,7 @@ submissions_s3:
   parameters:
     BucketName: "digitalmarketplace-submissions-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 agreements_s3:
   name: "agreements-s3-{{ stage }}-{{ environment }}"
@@ -132,6 +135,7 @@ agreements_s3:
   parameters:
     BucketName: "digitalmarketplace-agreements-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 g7_draft_documents_s3:
   name: "g7-draft-documents-s3-{{ stage }}-{{ environment }}"
@@ -141,6 +145,7 @@ g7_draft_documents_s3:
   parameters:
     BucketName: "digitalmarketplace-g7-draft-documents-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 monitoring:
   name: "monitoring-{{ stage }}-{{ environment }}"
@@ -543,6 +548,7 @@ lambda_code_s3:
   parameters:
     BucketName: "digitalmarketplace-lambda-code-{{ stage }}-{{ environment }}"
     LogsBucket: "{{ stacks.logs_s3.outputs.Name }}"
+    AccessControl: "Private"
 
 cloudwatch_logs_lambda:
   name: "cloudwatch-logs-lambda-{{ stage }}-{{ environment }}"


### PR DESCRIPTION
Enables access logging for all S3 buckets. Logs are stored in a separate logs bucket for each environment and logs from buckets are stored in separate folders. Log bucket access logs are stored in the same bucket (which thankfully doesn't create an infinite feedback loop).

Enabling logging was recommended by ITHC report. I'm not sure what the cost implications are since it seems to create a lot of small files, and S3 could get quite expensive for LIST/PUT operations, so we'll have to keep an eye on it.