### PR TITLE
Clean production data for other environments

### DIFF
--- a/dmaws/commands/migratedata.py
+++ b/dmaws/commands/migratedata.py
@@ -56,9 +56,7 @@ def create_scrubbed_instance(ctx, target_stage):
         logger=ctx.log
     )
 
-    pg_client.clean_database_for_staging()
-    if target_stage != 'staging':
-        pg_client.clean_database_for_preview()
+    pg_client.clean_database()
 
     return rds, pg_client
 

--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -256,17 +256,14 @@ class RDSPostgresClient(object):
                 "DELETE FROM supplier_frameworks WHERE framework_id IN %s",
                 (open_framework_ids,))
 
+        # We can't tell if a procurement is ongoing, so delete all of them
+        self.log("Delete brief_responses")
+        self.cursor.execute("DELETE FROM brief_responses")
+
         self.log("Delete draft briefs")
         self.log("  > Delete draft brief users")
         self.cursor.execute("""
             DELETE FROM brief_users WHERE brief_id IN (
-                SELECT brief_id FROM briefs WHERE published_at IS NULL
-            )
-            """)
-        # somehow, we still have brief responses attached a draft brief
-        self.log("  > Delete draft brief responses")
-        self.cursor.execute("""
-            DELETE FROM brief_responses WHERE brief_id IN (
                 SELECT brief_id FROM briefs WHERE published_at IS NULL
             )
             """)

--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -301,6 +301,9 @@ class RDSPostgresClient(object):
         self.log("Delete audit events")
         self.cursor.execute("DELETE FROM audit_events")
 
+        self.log("Delete framework agreements")
+        self.cursor.execute("DELETE FROM framework_agreements")
+
         self.log("Blank out declarations")
         self.cursor.execute("""
             UPDATE supplier_frameworks

--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -305,9 +305,13 @@ class RDSPostgresClient(object):
         self.cursor.execute("""
             UPDATE supplier_frameworks
             SET declaration = (CASE
-                WHEN (declaration->'status') IS NULL
+                WHEN (declaration->'status') IS NULL OR (declaration->'nameOfOrganisation') IS NULL
                 THEN '{}'
-                ELSE '{"status": "' || (declaration->>'status') || '"}'
+                ELSE '{
+                   "status": "' || (declaration->>'status') || '",
+                   "nameOfOrganisation": "' || replace((declaration->>'nameOfOrganisation'), '"', '') || '",
+                   "primaryContactEmail": "supplier-user@example.com"
+                }'
             END)::json
             WHERE declaration IS NOT NULL AND declaration::varchar != 'null';
         """)


### PR DESCRIPTION
The data we collect has changed (grown, mostly) since this data migration logic was last used, and so we aren't removing all the real personal data that we should.  

We delete all draft things because they've never been made public and we try to remove real names and email addresses where we've asked for them:

- Draft briefs are deleted
- All framework agreements are deleted
- All brief responses are deleted
- Two more fields are added to the declaration because we need them for the updated signing flow