### PR TITLE
Rollback staging database to this morning's version

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -9,7 +9,7 @@ database:
   multi_az: "true"
   backup_retention_period: "1"
   slow_query_log_duration_ms: -1
-  snapshot_id: "staging-2016-08-08t1459"
+  snapshot_id: "staging-2016-12-20t1037"
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
DOS-2 is closed and we need some preset data to check that the scripts determining who is on the framework do the right thing.