### PR TITLE
Delete database instance if one exists already

### DIFF
--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -152,9 +152,11 @@ class RDS(object):
         if not instance:
             return
 
-        self.log("Found leftover RDS instance: {}:{}".format(
-            instance.id, instance.DBName
-        ))
+        log_msg = "Found leftover RDS instance: {}".format(instance.id)
+        if hasattr(instance, 'DBName'):
+            log_msg += ":{}".format(instance.DBName)
+
+        self.log(log_msg)
         self.delete_instance(instance_id)
 
     def _wait_for_available(self, target, name, action, sleep=5):

--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -121,6 +121,8 @@ class RDS(object):
         return instance
 
     def restore_instance_from_snapshot(self, snapshot_id, instance_id, dev_user_ips, vpc_id):
+        self.delete_instance_if_found(instance_id)
+
         instance = self.conn.restore_dbinstance_from_dbsnapshot(
             snapshot_id, instance_id,
             "db.t2.micro",
@@ -137,6 +139,23 @@ class RDS(object):
     def delete_instance(self, instance_id):
         instance = self.conn.delete_dbinstance(instance_id, skip_final_snapshot=True)
         self._wait_for_delete(instance, "RDS instance")
+
+    def delete_instance_if_found(self, instance_id):
+        instance = None
+
+        try:
+            instance = self.conn.get_all_dbinstances(instance_id)[0]
+        except boto.exception.BotoServerError as e:
+            if e.status != 404:
+                raise
+
+        if not instance:
+            return
+
+        self.log("Found leftover RDS instance: {}:{}".format(
+            instance.id, instance.DBName
+        ))
+        self.delete_instance(instance_id)
 
     def _wait_for_available(self, target, name, action, sleep=5):
         self.log(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ six==1.10.0
 requests==2.6.0
 
 # exportdata dependencies
-bcrypt==2.0.0
+bcrypt==3.1.1
 psycopg2==2.5.4


### PR DESCRIPTION
- Start trying to any leftover database instances before creating a new one.  If the script failed before and didn't delete its old database instance, then it would be impossible to run the migration again without manually deleting it.  

- Also upgrades `bcrypt` to get rid of a warning message.