### PR TITLE
Delete less brief_users

### DIFF
--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -264,7 +264,7 @@ class RDSPostgresClient(object):
         self.log("  > Delete draft brief users")
         self.cursor.execute("""
             DELETE FROM brief_users WHERE brief_id IN (
-                SELECT brief_id FROM briefs WHERE published_at IS NULL
+                SELECT id FROM briefs WHERE published_at IS NULL
             )
             """)
         self.log("  > Delete draft briefs")


### PR DESCRIPTION
The way the query was written previously, all brief user rows were being deleted.

Seems weird because the `brief_id` column doesn't exist in the `briefs` table.

So, for example:

```sql
-- this does what we want
SELECT * FROM brief_users WHERE brief_id IN (
  SELECT id FROM briefs
)

-- this throws an error because the column name is wrong (and, presumably, nowhere else in the query)
SELECT * FROM brief_users WHERE brief_id IN (
  SELECT alligator FROM briefs
)

-- this selects all brief_users (which is arguably surprising/unexpected behaviour)
SELECT * FROM brief_users WHERE brief_id IN (
  SELECT brief_id FROM briefs
)

```



