### PR TITLE
Pass in correct profile to the StackPlan + open `database_dev_access` for target stage

### DIFF
--- a/dmaws/stacks.py
+++ b/dmaws/stacks.py
@@ -123,7 +123,10 @@ class StackPlan(object):
                 if stack_info:
                     self.stack_context['stacks'][name].update_info(stack_info)
                 else:
-                    self.log('Stack [%s] does not exist', name)
+                    self.log('Stack [{} ({})] does not exist'.format(
+                        name,
+                        built_stack.name
+                    ))
 
         return self.stack_context['stacks']
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -125,6 +125,32 @@ class TestStackPlan(object):
 
         assert plan.stack_context == {'aws_region': AWS_REGION, 'stacks': {}}
 
+    @pytest.mark.parametrize('from_ctx_kwargs', [
+        {},
+        {'profile_name': 'stage'},
+    ])
+    def test_stackplan_from_ctx(self, from_ctx_kwargs):
+        # stage will always be set in the context,
+        # but it should only be applied if passed in explicitly
+        mock_ctx = mock.Mock(
+            stacks={},
+            stage='stage',
+            environment='environment',
+            variables={'aws_region': AWS_REGION},
+            apps=[],
+            log=None
+        )
+
+        plan = StackPlan.from_ctx(mock_ctx, **from_ctx_kwargs)
+
+        assert plan._stacks == {}
+        assert plan.stage == 'stage'
+        assert plan.environment == 'environment'
+        assert plan.stack_context == {'aws_region': AWS_REGION, 'stacks': {}}
+        assert plan.apps == []
+        assert plan.log() is None
+        assert plan.profile_name is None if not from_ctx_kwargs else from_ctx_kwargs['profile_name']
+
     def test_stacks_variable_is_reserved(self):
         with pytest.raises(ValueError):
             StackPlan({


### PR DESCRIPTION
####	Set the profile correctly for StackPlan

 The `ctx.stage` value is passed in as a `profile_name` to the `RDS` initialisation, but [it doesn't get passed properly to the `StackPlan`](https://github.com/alphagov/digitalmarketplace-aws/blob/master/dmaws/commands/migratedata.py#L38-L39).  Added an extra bit to the `from_ctx()` method that fixes this.


#### Open `database_dev_access` to target stage

The way I understand it, we've been creating a security group for our new `exportdata` instance (which lets Jenkins connect to the database) and then attaching it to the target stage (where we're going to import the data) as well so that Jenkins can pg_dump to the target database.

Reusing our new security group this way has occasionally meant -- if the script fails to clean up everything -- we leave open access to our target database which then never gets cleaned up.

Opening `database_dev_access` on the target stage gives jenkins access (so the migration script works like it did before) and it also gets closed nightly, so there's less potential for security holes.