### PR TITLE
Change database names

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -9,7 +9,7 @@ database:
   multi_az: "false"
   backup_retention_period: "1"
   slow_query_log_duration_ms: 1000
-  snapshot_id: "s2015-05-13t0953z"
+  snapshot_id: ""
 
 vpc_id: vpc-a29149c7
 subnets:

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -6,6 +6,7 @@ monitoring:
   email: "support+development-preview@digitalmarketplace.service.gov.uk"
 
 database:
+  name: "digitalmarketplace_api_preview"
   multi_az: "false"
   backup_retention_period: "1"
   slow_query_log_duration_ms: 1000

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -6,6 +6,7 @@ monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"
 
 database:
+  name: "digitalmarketplace_api_staging"
   multi_az: "true"
   backup_retention_period: "1"
   slow_query_log_duration_ms: -1

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -9,7 +9,7 @@ database:
   multi_az: "true"
   backup_retention_period: "1"
   slow_query_log_duration_ms: -1
-  snapshot_id: "staging-2016-12-23t1115"
+  snapshot_id: ""
 
 vpc_id: vpc-70319115
 subnets:


### PR DESCRIPTION
- blanking out the snapshot id means that when we run the `create database` job, it will create a new, empty database for us. 

- changing the database name means that new databases will have new names.  this one is pretty self-explanatory.

Taken together, this means that next time we run a `create database` command (for example `dmaws create database staging`) we will create an new empty instance in its place with a new name.
And then we can ruin our beautiful new minimalist database with a bunch of cluttered data using the migrate data job.  Means we'll always have the latest data from production, although it also means we'll have an outage of about 30-40 minutes when we run this.