### PR TITLE
Delete draft services for open frameworks

### DIFF
--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -248,8 +248,13 @@ class RDSPostgresClient(object):
         )
 
         open_framework_ids = self.get_open_framework_ids()
-        self.log("Delete draft services")
-        self.cursor.execute("DELETE FROM draft_services")
+        self.log("Delete draft services for open frameworks")
+        self.cursor.execute("""
+            DELETE FROM draft_services WHERE framework_id IN (
+                SELECT id FROM frameworks WHERE status='open'
+            )
+            """)
+
         self.log("Delete supplier frameworks for open frameworks")
         if len(open_framework_ids):
             self.cursor.execute(


### PR DESCRIPTION
Once a framework is no longer open, we're allowed to see the draft services that were submitted.

<sup>(small change)</sup>