### PR TITLE
Upgrade bcrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ six==1.10.0
 requests==2.6.0
 
 # exportdata dependencies
-bcrypt==2.0.0
+bcrypt==3.1.1
 psycopg2==2.5.4


### PR DESCRIPTION
Running the migration was causing some warning in the output:
something about not explicitly casting the right thing for bcrypt.
(seen here: https://github.com/pyca/bcrypt/issues/82#issuecomment-247816431)

The solution seems to be to upgrade bcrypt, which _looks_ scary
because it goes up a major version but actually the changelog
doesn't seem too serious.

[Changelog](https://github.com/pyca/bcrypt#changelog)