### PR TITLE
[#137354029] Enable CloudTrail logging to S3 and CloudWatch

### DIFF
--- a/cloudformation_templates/aws_cloudtrail.json
+++ b/cloudformation_templates/aws_cloudtrail.json
@@ -1,0 +1,67 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+  "Parameters" : {
+    "S3BucketName": {
+      "Description": "S3 Bucket to store CloudTrail logs",
+      "Type": "String"
+    }
+  },
+  "Resources" : {
+    "LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "cloudtrail",
+        "RetentionInDays": 90
+      }
+    },
+
+    "IAMRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }]
+        },
+        "Policies": [{
+          "PolicyName": "cloudtrail-cloudwatch-policy",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": ["logs:CreateLogStream"],
+                "Resource": [{"Fn::GetAtt": ["LogGroup", "Arn"]}]
+              },
+              {
+                "Effect": "Allow",
+                "Action": ["logs:PutLogEvents"],
+                "Resource": [{"Fn::GetAtt": ["LogGroup", "Arn"]}]
+              }
+            ]
+          }
+        }]
+      }
+    },
+
+    "CloudTrail" : {
+      "Type" : "AWS::CloudTrail::Trail",
+      "Properties" : {
+        "IsLogging" : true,
+        "IsMultiRegionTrail": true,
+        "IncludeGlobalServiceEvents": true,
+        "EnableLogFileValidation": true,
+        "CloudWatchLogsLogGroupArn": {"Fn::GetAtt": ["LogGroup", "Arn"]},
+        "CloudWatchLogsRoleArn": {"Fn::GetAtt": ["IAMRole", "Arn"]},
+        "S3BucketName" : {"Ref": "S3BucketName"},
+        "S3KeyPrefix" : {"Ref": "AWS::AccountId"}
+      }
+    }
+  }
+}

--- a/stacks.yml
+++ b/stacks.yml
@@ -150,10 +150,18 @@ g7_draft_documents_s3:
 monitoring:
   name: "monitoring-{{ stage }}-{{ environment }}"
   template: cloudformation_templates/aws_monitoring.json
+  dependencies:
+    - cloudtrail
   parameters:
     LogGroupName: "{{ stage }}-{{ environment }}"
     RetentionInDays: 3653
     Email: "{{ monitoring.email }}"
+
+cloudtrail:
+  name: "cloudtrail"
+  template: cloudformation_templates/aws_cloudtrail.json
+  parameters:
+    S3BucketName: "gds-audit-cloudtrails"
 
 api_app:
   name: "digitalmarketplace-api-app"
@@ -516,6 +524,7 @@ jenkins:
   template: cloudformation_templates/aws_jenkins.json
   dependencies:
     - route53zone
+    - cloudtrail
   parameters:
     UserIPs: "{{ dev_user_ips | join(',') }}"
 


### PR DESCRIPTION
Sets up CloudTrail to store logs in S3 bucket and creates a separate CloudWatch log group to send logs to.

gds-audit-cloudtrails S3 bucket is controlled by GDS Security Team, and they've asked us to use AWS account ID as key prefix.

CloudWatch is setup in the same AWS account as the CloudTrail, so we have access to view the history of events and can create CloudWatch alerts in the future.

There's only one CloudTrail per AWS account, so the stack name doesn't include stage or environment names (similar to Route53 stacks).

IAM policies and CloudTrail settings are taken from https://github.com/alphagov/aws-security-alarms/blob/master/terraform/main.tf

From AWS docs:

> AWS CloudTrail is a web service that records AWS API calls for your
> account and delivers log files to you. The recorded information includes
> the identity of the API caller, the time of the API call, the source IP
> address of the API caller, the request parameters, and the response
> elements returned by the AWS service.

> With CloudTrail, you can get a history of AWS API calls for your
> account, including API calls made via the AWS Management Console, AWS
> SDKs, command line tools, and higher-level AWS services (such as AWS
> CloudFormation). The AWS API call history produced by CloudTrail enables
> security analysis, resource change tracking, and compliance auditing.