### PR TITLE
Dump exportdata into a local directory

### DIFF
--- a/dmaws/build.py
+++ b/dmaws/build.py
@@ -28,7 +28,7 @@ def clone_or_update(repo_url):
     repository_path = os.path.join(REPOS_PATH,
                                    'digitalmarketplace-{}'.format(app_name))
     if not os.path.exists(REPOS_PATH):
-        os.mkdir(REPOS_PATH)
+        utils.mkdir_p(REPOS_PATH)
     if not os.path.exists(repository_path):
         run_git_cmd(['clone', repo_url], REPOS_PATH)
     else:

--- a/dmaws/commands/migratedata.py
+++ b/dmaws/commands/migratedata.py
@@ -72,7 +72,7 @@ def dump_to_target(target_ctx, src_pg_client, export_file=None):
 
     StackPlan.from_ctx(target_ctx, apps=['database_dev_access'], profile_name=target_ctx.stage).create()
 
-    pg_client = RDSPostgresClient.from_boto(
+    target_pg_client = RDSPostgresClient.from_boto(
         instance,
         target_ctx.variables['database']['name'],
         target_ctx.variables['database']['user'],
@@ -83,10 +83,10 @@ def dump_to_target(target_ctx, src_pg_client, export_file=None):
         if not os.path.exists(os.path.dirname(EXPORT_FILE_PATH)):
             raise Exception("Path not found: {}".format(os.path.dirname(EXPORT_FILE_PATH)))
         src_pg_client.dump(EXPORT_FILE_PATH)
-        pg_client.load(EXPORT_FILE_PATH)
+        target_pg_client.load(EXPORT_FILE_PATH)
     else:
-        src_pg_client.dump_to(pg_client)
+        src_pg_client.dump_to(target_pg_client)
 
-    pg_client.close()
+    target_pg_client.close()
 
     StackPlan.from_ctx(target_ctx, apps=['database_dev_access'], profile_name=target_ctx.stage).delete()

--- a/dmaws/commands/migratedata.py
+++ b/dmaws/commands/migratedata.py
@@ -17,7 +17,7 @@ IMPORT_SECURITY_GROUP_NAME = "importdata-sg"
 @click.argument('target_stage', nargs=1, type=click.Choice(STAGES))
 @click.argument('target_environment', nargs=1)
 @click.argument('target_vars_file', nargs=1)
-@click.argument('exportdata_path', nargs=1, type=click.Path(writable=True))
+@click.argument('exportdata_path', nargs=1, type=click.Path(writable=True), required=False)
 def migratedata_cmd(ctx, target_stage, target_environment, target_vars_file, exportdata_path):
     if target_stage not in ['development', 'preview', 'staging']:
         raise Exception("Invalid target stage [{}]".format(target_stage))

--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -223,7 +223,7 @@ class RDSPostgresClient(object):
 
     def load(self, export_path):
         utils.run_cmd([
-            'psql', '-d', self.db_path, 'f', export_path
+            'psql', '-d', self.db_path, '-f', export_path
         ], logger=self.log, ignore_errors=True)
 
     def dump_to(self, target_pg_client):

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -211,3 +211,11 @@ def param_to_env(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
     return s2.upper().replace('ENV_VAR_', '')
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError:
+        if not os.path.isdir(path):
+            raise

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -214,6 +214,10 @@ def param_to_env(name):
 
 
 def mkdir_p(path):
+    """
+    Creates a nested directory structure (does nothing if the path already exists)
+    http://stackoverflow.com/a/14364249
+    """
     try:
         os.makedirs(path)
     except OSError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,25 @@ def path_exists(request):
 
 
 @pytest.fixture()
+def isdir(request):
+    isdir_patch = mock.patch('os.path.isdir')
+    request.addfinalizer(isdir_patch.stop)
+
+    isdir = isdir_patch.start()
+    isdir.return_value = True
+
+    return isdir
+
+
+@pytest.fixture()
+def makedirs(request):
+    makedirs_patch = mock.patch('os.makedirs')
+    request.addfinalizer(makedirs_patch.stop)
+
+    return makedirs_patch.start()
+
+
+@pytest.fixture()
 def mkdir_p(request):
     mkdir_p_patch = mock.patch('dmaws.utils.mkdir_p', wraps=mkdir_p_orig)
     request.addfinalizer(mkdir_p_patch.stop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from boto.rds import RDSConnection
 from boto.ec2 import EC2Connection
 
 from dmaws.utils import run_cmd as run_cmd_orig
+from dmaws.utils import mkdir_p as mkdir_p_orig
 from dmaws.build import get_repo_url, get_current_sha, get_current_ref
 
 
@@ -178,12 +179,12 @@ def path_exists(request):
     return path_exists
 
 
-@pytest.fixture(autouse=True)
-def mkdir(request):
-    mkdir_patch = mock.patch('os.mkdir')
-    request.addfinalizer(mkdir_patch.stop)
+@pytest.fixture()
+def mkdir_p(request):
+    mkdir_p_patch = mock.patch('dmaws.utils.mkdir_p', wraps=mkdir_p_orig)
+    request.addfinalizer(mkdir_p_patch.stop)
 
-    return mkdir_patch.start()
+    return mkdir_p_patch.start()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -47,11 +47,11 @@ class TestGetApplicationName(object):
 class TestCloneOrUpdate(object):
     example_repo = 'git@github.com:alphagov/digitalmarketplace-aws.git'
 
-    def test_no_folder(self, run_cmd, mkdir, path_exists):
+    def test_no_folder(self, run_cmd, mkdir_p, path_exists):
         path_exists.return_value = False
         clone_or_update(self.example_repo)
 
-        mkdir.assert_called_with(REPOS_PATH)
+        mkdir_p.assert_called_with(REPOS_PATH)
 
     def test_clone(self, run_cmd):
         clone_or_update(self.example_repo)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from dmaws.utils import safe_path_join
 from dmaws.utils import dict_from_path, merge_dicts
 from dmaws.utils import DEFAULT_TEMPLATES_PATH
 from dmaws.utils import template, template_string, LazyTemplateMapping
+from dmaws.utils import mkdir_p
 
 
 class TestRunCmd(object):
@@ -279,3 +280,25 @@ class TestLazyTemplateMapping(object):
         mapping = LazyTemplateMapping({"a": "{{ var }}a", "b": "{{ var }}b"},
                                       {"var": "a"})
         assert set(mapping.items()) == set([("a", "aa"), ("b", "ab")])
+
+
+class TestMkdirP(object):
+
+    def test_directories_created(self, makedirs):
+        mkdir_p('path/to/create')
+        makedirs.assert_called_with('path/to/create')
+
+    @pytest.mark.parametrize("path_exists", [
+        True, False
+    ])
+    def test_directories_created_if_they_exist(self, makedirs, isdir, path_exists):
+        makedirs.side_effect = OSError()
+        isdir.return_value = path_exists
+
+        if path_exists:
+            mkdir_p('path/to/create')
+            makedirs.assert_called_with('path/to/create')
+
+        else:
+            with pytest.raises(OSError):
+                mkdir_p('path/to/create')


### PR DESCRIPTION
Instead of streaming our `pg_dump` output straight into the target database, this code creates an intermediary `exportdata.sql` file in a particular directory.

The (relative) filepath is a new parameter passed into the `migratedata` command, and then the python code will create the directory structure and dump the .sql file into it before importing it into our target database.
We're relying on [the migratadata `-jenkins` job](https://github.gds/gds/digitalmarketplace-jenkins/pull/73) to do the sync, and then do the cleanup.

We can decide either to do or not do the 'export to a file' part of this based on whether or not we pass in a filepath. Tested locally and both work.