### PR TITLE
[preview] Add paas-manifest command to dmaws for generating PaaS manifest files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 *.pyc
 user.yml
 venv
+/tmp
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ paas-deploy: ## Deploys the app to PaaS
 .PHONY: paas-rollback
 paas-rollback: ## Rollbacks the app to the previous release on PaaS
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
+	@[ $$(cf curl /v2/apps/`cf app --guid ${APPLICATION_NAME}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${APPLICATION_NAME}-rollback is not in a started state" && exit 1)
 	cd ${DEPLOYMENT_DIR} && \
 		cf app --guid notify-admin-rollback && \
 		cf delete -f notify-admin && \

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,3 @@ paas-push: ## Pushes the app to PaaS
 .PHONY: paas-clean
 paas-clean: ## Cleans up all files created for the PaaS deployment
 	rm -rf ${DEPLOYMENT_DIR}
-
-build-app:
-	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || echo ${VIRTUAL_ENV})
+
+PAAS_API ?= api.cloud.service.gov.uk
+PAAS_ORG ?= digitalmarketplace
+PAAS_SPACE ?= ${STAGE}
+
+DEPLOYMENT_DIR := ${CURDIR}/tmp
+CF_HOME ?= ${DEPLOYMENT_DIR}
+$(eval export CF_HOME)
+
+.PHONY: help
+help:
+	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: requirements
+requirements: ## Install requirements
+	${VIRTUALENV_ROOT}/bin/pip install -e .
+
+.PHONY: virtualenv
+virtualenv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
+
+${VIRTUALENV_ROOT}/activate:
+	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv venv || true
+
+.PHONY: build
+build: requirements ## Build project
+
+.PHONY: preview
+preview: ## Set stage to preview
+	$(eval export STAGE=preview)
+	@true
+
+.PHONY: staging
+staging: ## Set stage to staging
+	$(eval export STAGE=staging)
+	@true
+
+.PHONY: production
+production: ## Set stage to production
+	$(eval export STAGE=production)
+	@true
+
+download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
+	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
+	$(if ${RELEASE_NUMBER},,$(error Must specify RELEASE_NUMBER))
+	rm -rf ${DEPLOYMENT_DIR}
+	mkdir ${DEPLOYMENT_DIR}
+	${VIRTUALENV_ROOT}/bin/aws s3 cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/deployment.zip
+	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/deployment.zip
+	rm ${DEPLOYMENT_DIR}/deployment.zip
+
+.PHONY: paas-generate-manifest
+paas-generate-manifest: virtualenv ## Generate manifest file for PaaS
+	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
+	$(if ${STAGE},,$(error Must specify STAGE))
+	mkdir -p ${DEPLOYMENT_DIR}
+	${VIRTUALENV_ROOT}/bin/dmaws paas-manifest preview api -o ${DEPLOYMENT_DIR}/manifest.yml
+
+.PHONY: paas-login
+paas-login: ## Log in to PaaS
+	$(if ${PAAS_USERNAME},,$(error Must specify PAAS_USERNAME))
+	$(if ${PAAS_PASSWORD},,$(error Must specify PAAS_PASSWORD))
+	$(if ${PAAS_SPACE},,$(error Must specify PAAS_SPACE))
+	mkdir -p ${CF_HOME}
+	@cf login -a "${PAAS_API}" -u ${PAAS_USERNAME} -p "${PAAS_PASSWORD}" -o "${PAAS_ORG}" -s "${PAAS_SPACE}"
+
+.PHONY: paas-deploy
+paas-deploy: ## Deploys the app to PaaS
+	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
+	$(eval export PAAS_INSTANCE_COUNT=$(shell cf curl /v2/apps/$(shell cf app --guid ${APPLICATION_NAME}) | jq -r ".entity.instances"))
+	@echo "Original instance count: ${PAAS_INSTANCE_COUNT}"
+	cd ${DEPLOYMENT_DIR} && \
+		cf check-manifest ${APPLICATION_NAME} -f manifest.yml && \
+		cf zero-downtime-push ${APPLICATION_NAME} -f manifest.yml && \
+		cf scale -i ${PAAS_INSTANCE_COUNT} ${APPLICATION_NAME}
+
+.PHONY: paas-push
+paas-push: ## Pushes the app to PaaS
+	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
+	cd ${DEPLOYMENT_DIR} && \
+		cf push ${APPLICATION_NAME} -f manifest.yml
+
+.PHONY: paas-clean
+paas-clean: ## Cleans up all files created for the PaaS deployment
+	rm -rf ${DEPLOYMENT_DIR}

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
 	$(if ${RELEASE_NUMBER},,$(error Must specify RELEASE_NUMBER))
 	rm -rf ${DEPLOYMENT_DIR}
 	mkdir ${DEPLOYMENT_DIR}
-	${VIRTUALENV_ROOT}/bin/aws s3 cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/deployment.zip
-	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/deployment.zip
-	rm ${DEPLOYMENT_DIR}/deployment.zip
+	${VIRTUALENV_ROOT}/bin/aws s3 cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/release-${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/release.zip
+	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/release.zip
+	rm ${DEPLOYMENT_DIR}/release.zip
 
 .PHONY: paas-generate-manifest
 paas-generate-manifest: virtualenv ## Generate manifest file for PaaS
@@ -89,3 +89,6 @@ paas-push: ## Pushes the app to PaaS
 .PHONY: paas-clean
 paas-clean: ## Cleans up all files created for the PaaS deployment
 	rm -rf ${DEPLOYMENT_DIR}
+
+build-app:
+	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
 	$(if ${RELEASE_NUMBER},,$(error Must specify RELEASE_NUMBER))
 	rm -rf ${DEPLOYMENT_DIR}
 	mkdir ${DEPLOYMENT_DIR}
-	${VIRTUALENV_ROOT}/bin/aws s3 cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/release-${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/release.zip
+	${VIRTUALENV_ROOT}/bin/aws s3 --only-show-errors cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/release-${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/release.zip
 	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/release.zip
 	rm ${DEPLOYMENT_DIR}/release.zip
 
@@ -57,7 +57,7 @@ paas-generate-manifest: virtualenv ## Generate manifest file for PaaS
 	$(if ${STAGE},,$(error Must specify STAGE))
 	$(if ${DM_CREDENTIALS_REPO},,$(error Must specify DM_CREDENTIALS_REPO))
 	mkdir -p ${DEPLOYMENT_DIR}
-	${VIRTUALENV_ROOT}/bin/dmaws paas-manifest preview api \
+	${VIRTUALENV_ROOT}/bin/dmaws paas-manifest ${STAGE} ${APPLICATION_NAME} \
 		-f <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/common.yaml) \
 		-f <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/${STAGE}.yaml) \
 		-o ${DEPLOYMENT_DIR}/manifest.yml

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,12 @@ download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
 paas-generate-manifest: virtualenv ## Generate manifest file for PaaS
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${STAGE},,$(error Must specify STAGE))
+	$(if ${DM_CREDENTIALS_REPO},,$(error Must specify DM_CREDENTIALS_REPO))
 	mkdir -p ${DEPLOYMENT_DIR}
-	${VIRTUALENV_ROOT}/bin/dmaws paas-manifest preview api -o ${DEPLOYMENT_DIR}/manifest.yml
+	${VIRTUALENV_ROOT}/bin/dmaws paas-manifest preview api \
+		-f <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/common.yaml) \
+		-f <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/${STAGE}.yaml) \
+		-o ${DEPLOYMENT_DIR}/manifest.yml
 
 .PHONY: paas-login
 paas-login: ## Log in to PaaS

--- a/dmaws/commands/paasmanifest.py
+++ b/dmaws/commands/paasmanifest.py
@@ -21,7 +21,7 @@ def paas_manifest(ctx, template, out_file):
     templace_content = load_file(template)
     variables = {
         'environment': ctx.environment,
-        'app': app
+        'app': app.replace('_', '-')
     }
     variables.update(ctx.variables[app])
 

--- a/dmaws/commands/paasmanifest.py
+++ b/dmaws/commands/paasmanifest.py
@@ -2,7 +2,8 @@ import click
 import os
 
 from ..cli import cli_command
-from ..utils import load_file, template_string, run_piped_cmds
+from ..utils import load_file, template_string
+
 
 @cli_command('paas-manifest', max_apps=1)
 @click.option('--template', '-t', default='paas/manifest.j2',
@@ -14,7 +15,7 @@ def paas_manifest(ctx, template, out_file):
     """Generate a PaaS manifest file from a Jinja2 template"""
     app = ctx.apps[0]
 
-    if not app in ctx.variables:
+    if app not in ctx.variables:
         raise ValueError('Application configuration not found')
 
     templace_content = load_file(template)

--- a/dmaws/commands/paasmanifest.py
+++ b/dmaws/commands/paasmanifest.py
@@ -1,7 +1,5 @@
 import click
 import os
-import yaml
-import subprocess
 
 from ..cli import cli_command
 from ..utils import load_file, template_string, run_piped_cmds
@@ -10,20 +8,14 @@ from ..utils import load_file, template_string, run_piped_cmds
 @click.option('--template', '-t', default='paas/manifest.j2',
               type=click.Path(exists=True),
               help="Manifest Jinja2 template file")
-@click.option('--credentials-repo', '-c', envvar='DM_CREDENTIALS_REPO',
-              type=click.Path(exists=True),
-              help="Path to the digitalmarketplace-credentials repository")
 @click.option('--out-file', '-o',
               help="Output file, if empty the template content is printed to the stdout")
-def paas_manifest(ctx, template, credentials_repo, out_file):
+def paas_manifest(ctx, template, out_file):
     """Generate a PaaS manifest file from a Jinja2 template"""
     app = ctx.apps[0]
 
     if not app in ctx.variables:
         raise ValueError('Application configuration not found')
-
-    ctx.add_variables(get_secret_vars(credentials_repo, 'vars/common/.yml'))
-    ctx.add_variables(get_secret_vars(credentials_repo, 'vars/{}.yaml'.format(ctx.environment)))
 
     templace_content = load_file(template)
     variables = {
@@ -40,12 +32,3 @@ def paas_manifest(ctx, template, credentials_repo, out_file):
         os.chmod(out_file, 0o600)
     else:
         print(manifest_content)
-
-def get_secret_vars(credentials_repo, filename):
-    sops_wrapper = '{}/sops-wrapper'.format(credentials_repo)
-    sops_file = '{}/{}'.format(credentials_repo, filename)
-    if os.path.exists(sops_file):
-        secrets_yaml = run_piped_cmds(cmds=[[sops_wrapper, '-d', sops_file]], stdout=subprocess.PIPE)
-        return yaml.load(secrets_yaml)
-
-    return {}

--- a/dmaws/commands/paasmanifest.py
+++ b/dmaws/commands/paasmanifest.py
@@ -1,0 +1,51 @@
+import click
+import os
+import yaml
+import subprocess
+
+from ..cli import cli_command
+from ..utils import load_file, template_string, run_piped_cmds
+
+@cli_command('paas-manifest', max_apps=1)
+@click.option('--template', '-t', default='paas/manifest.j2',
+              type=click.Path(exists=True),
+              help="Manifest Jinja2 template file")
+@click.option('--credentials-repo', '-c', envvar='DM_CREDENTIALS_REPO',
+              type=click.Path(exists=True),
+              help="Path to the digitalmarketplace-credentials repository")
+@click.option('--out-file', '-o',
+              help="Output file, if empty the template content is printed to the stdout")
+def paas_manifest(ctx, template, credentials_repo, out_file):
+    """Generate a PaaS manifest file from a Jinja2 template"""
+    app = ctx.apps[0]
+
+    if not app in ctx.variables:
+        raise ValueError('Application configuration not found')
+
+    ctx.add_variables(get_secret_vars(credentials_repo, 'vars/common/.yml'))
+    ctx.add_variables(get_secret_vars(credentials_repo, 'vars/{}.yaml'.format(ctx.environment)))
+
+    templace_content = load_file(template)
+    variables = {
+        'environment': ctx.environment,
+        'app': app
+    }
+    variables.update(ctx.variables[app])
+
+    manifest_content = template_string(templace_content, variables)
+
+    if out_file is not None:
+        with open(out_file, 'w') as f:
+            f.write(manifest_content)
+        os.chmod(out_file, 0o600)
+    else:
+        print(manifest_content)
+
+def get_secret_vars(credentials_repo, filename):
+    sops_wrapper = '{}/sops-wrapper'.format(credentials_repo)
+    sops_file = '{}/{}'.format(credentials_repo, filename)
+    if os.path.exists(sops_file):
+        secrets_yaml = run_piped_cmds(cmds=[[sops_wrapper, '-d', sops_file]], stdout=subprocess.PIPE)
+        return yaml.load(secrets_yaml)
+
+    return {}

--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -4,7 +4,7 @@ applications:
   - name: digitalmarketplace-{{ app|replace('_', '-') }}
     stack: cflinuxfs2
     buildpack: python_buildpack
-    command: gunicorn -w 4 -b 0.0.0.0:$PORT application:application --log-file -
+    command: ./run.sh gunicorn -w 4 -b 0.0.0.0:$PORT application:application --log-file -
     routes:
       - route: {{ paas.subdomain }}-{{ environment }}.cloudapps.digital{{ paas.path|default('') }}
     instances: {{ paas.instances|default(1) }}

--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -1,0 +1,29 @@
+---
+
+applications:
+  - name: digitalmarketplace-{{ app|replace('_', '-') }}
+    stack: cflinuxfs2
+    buildpack: python_buildpack
+    command: gunicorn -w 4 -b 0.0.0.0:$PORT application:application --log-file -
+    routes:
+      - route: {{ paas.subdomain }}-{{ environment }}.cloudapps.digital{{ paas.path|default('') }}
+    instances: {{ paas.instances|default(1) }}
+    memory: {{ paas.memory|default('512M') }}
+    disk_quota: {{ paas.disk_quota|default('1024M') }}
+    env:
+      DM_APP_NAME: {{ app }}
+      DM_ENVIRONMENT: {{ environment }}
+      DM_METRICS_NAMESPACE: {{ environment }}-{{ environment }}/{{ app }}
+      DM_LOG_PATH: ''
+      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
+      DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
+      {% for env_key, env_value in (paas.env|default({})).iteritems() -%}
+      {{ env_key }}: "{{ env_value }}"
+      {% endfor %}
+
+    {% if paas.services|default([])|length > 0 -%}
+    services:
+      {% for service in paas.services -%}
+        - {{ service }}
+      {% endfor -%}
+    {% endif %}

--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -15,8 +15,10 @@ applications:
       DM_ENVIRONMENT: {{ environment }}
       DM_METRICS_NAMESPACE: {{ environment }}-{{ environment }}/{{ app }}
       DM_LOG_PATH: ''
-      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
+      DM_ELASTICSEARCH_URL: https://preview-elasticsearch.development.digitalmarketplace.service.gov.uk
+      DM_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
+      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
       {% for env_key, env_value in (paas.env|default({})).iteritems() -%}
       {{ env_key }}: "{{ env_value }}"
       {% endfor %}

--- a/paas/run.sh
+++ b/paas/run.sh
@@ -5,13 +5,13 @@ set -e -o pipefail
 TERMINATE_TIMEOUT=30
 
 function check_params {
-  if [ -z "${APPLICATION_NAME}" ]; then
-    echo "You must set APPLICATION_NAME"
+  if [ -z "${DM_APP_NAME}" ]; then
+    echo "You must set DM_APP_NAME"
     exit 1
   fi
 
   if [ -z "${CW_APP_NAME}" ]; then
-    CW_APP_NAME=${APPLICATION_NAME}
+    CW_APP_NAME=${DM_APP_NAME}
   fi
 }
 

--- a/paas/run.sh
+++ b/paas/run.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+TERMINATE_TIMEOUT=30
+
+function check_params {
+  if [ -z "${APPLICATION_NAME}" ]; then
+    echo "You must set APPLICATION_NAME"
+    exit 1
+  fi
+
+  if [ -z "${CW_APP_NAME}" ]; then
+    CW_APP_NAME=${APPLICATION_NAME}
+  fi
+}
+
+function configure_aws_logs {
+  aws configure set plugins.cwlogs cwlogs
+
+  cat > /home/vcap/app/awslogs.conf << EOF
+[general]
+state_file = /home/vcap/logs/awslogs-state
+
+[/home/vcap/logs/app-stdout.log]
+file = /home/vcap/logs/app-stdout.log*
+log_group_name = paas-${CW_APP_NAME}-application
+log_stream_name = {hostname}-stdout
+
+[/home/vcap/logs/app-stderr.log]
+file = /home/vcap/logs/app-stderr.log*
+log_group_name = paas-${CW_APP_NAME}-application
+log_stream_name = {hostname}-stderr
+EOF
+}
+
+function on_exit {
+  echo "Terminating application process with pid ${APP_PID}"
+  kill ${APP_PID} || true
+  n=0
+  while (kill -0 ${APP_PID} 2&>/dev/null); do
+    echo "Application is still running.."
+    sleep 1
+    let n=n+1
+    if [ "$n" -ge "$TERMINATE_TIMEOUT" ]; then
+      echo "Timeout reached, killing process with pid ${APP_PID}"
+      kill -9 ${APP_PID} || true
+      break
+    fi
+  done
+  echo "Application process terminated, waiting 10 seconds"
+  sleep 10
+  echo "Terminating remaining subprocesses.."
+  kill 0
+}
+
+function start_appplication {
+  exec "$@" 2>/home/vcap/logs/app-stderr.log | while read line; do echo $line; echo $line >> /home/vcap/logs/app-stdout.log.`date +%Y-%m-%d`; done &
+  LOGGER_PID=$!
+  APP_PID=`jobs -p`
+  echo "Logger process pid: ${LOGGER_PID}"
+  echo "Application process pid: ${APP_PID}"
+}
+
+function start_aws_logs_agent {
+  exec aws logs push --region eu-west-1 --config-file /home/vcap/app/awslogs.conf &
+  AWSLOGS_AGENT_PID=$!
+  echo "AWS logs agent pid: ${AWSLOGS_AGENT_PID}"
+}
+
+function run {
+  while true; do
+    kill -0 ${APP_PID} 2&>/dev/null || break
+    kill -0 ${LOGGER_PID} 2&>/dev/null || break
+    kill -0 ${AWSLOGS_AGENT_PID} 2&>/dev/null || start_aws_logs_agent
+    sleep 1
+  done
+}
+
+echo "Run script pid: $$"
+
+check_params
+
+trap "on_exit" EXIT
+
+configure_aws_logs
+
+# The application has to start first!
+start_appplication "$@"
+
+start_aws_logs_agent
+
+run

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ toposort==1.1
 
 six==1.10.0
 
+awscli==1.11.44
+
 # loaddata dependencies
 requests==2.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-boto==2.36.0
-boto3==1.3.1
+boto==2.45.0
+botocore==1.5.7
+boto3==1.4.4
 
 click==6.6
 Jinja2==2.8

--- a/terraform/modules/aws-env/main.tf
+++ b/terraform/modules/aws-env/main.tf
@@ -12,3 +12,7 @@ module "switch_roles" {
   developer_policy_arn = "${module.iam_common.aws_iam_policy_developer_arn}"
   aws_main_account_id = "${var.aws_main_account_id}"
 }
+
+module "paas" {
+  source = "../../modules/paas"
+}

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -55,7 +55,10 @@ resource "aws_iam_role_policy" "jenkins" {
     },
     {
       "Effect": "Allow",
-      "Action": "s3:GetObject",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
       "Resource": "arn:aws:s3:::digitalmarketplace-deployment/*"
     }
   ]

--- a/terraform/modules/paas/iam.tf
+++ b/terraform/modules/paas/iam.tf
@@ -1,0 +1,68 @@
+resource "aws_iam_user" "paas_app" {
+  name = "paas-app"
+}
+
+resource "aws_iam_user_policy" "paas_app_policy" {
+  user = "${aws_iam_user.paas_app.name}"
+  name = "PaaSAppPolicy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:Get*",
+        "s3:List*",
+        "s3:Put*",
+        "s3:DeleteObject"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogStreams",
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "arn:aws:logs:eu-west-1:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:PutMetricData"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_user" "paas_metrics_collector" {
+  name = "paas-metrics-collector"
+}
+
+resource "aws_iam_user_policy" "paas_metrics_collector_policy" {
+  user = "${aws_iam_user.paas_metrics_collector.name}"
+  name = "PaaSMetricsCollectorPolicy"
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+              "cloudwatch:PutMetricData"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/terraform/root/aws-dm/.gitignore
+++ b/terraform/root/aws-dm/.gitignore
@@ -1,5 +1,0 @@
-
-# Elastic Beanstalk Files
-.elasticbeanstalk/*
-!.elasticbeanstalk/*.cfg.yml
-!.elasticbeanstalk/*.global.yml

--- a/terraform/root/aws-dm/.gitignore
+++ b/terraform/root/aws-dm/.gitignore
@@ -1,0 +1,5 @@
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -22,8 +22,7 @@ search_api:
   min_instance_count: 1
   max_instance_count: 2
   paas:
-    subdomain: dm
-    path: /search
+    subdomain: dm-search
 
 admin_frontend:
   instance_type: t2.micro

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -12,26 +12,41 @@ api:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 1
+  paas:
+    subdomain: dm-api
+    services:
+      - digitalmarketplace_api_db
 
 search_api:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
+  paas:
+    subdomain: dm
+    path: /search
 
 admin_frontend:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
+  paas:
+    subdomain: dm
+    path: /admin
 
 buyer_frontend:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
+  paas:
+    subdomain: dm
 
 supplier_frontend:
   instance_type: t2.micro
   min_instance_count: 1
   max_instance_count: 2
+  paas:
+    subdomain: dm
+    path: /suppliers
 
 database:
   version: 9.5

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -16,3 +16,26 @@ subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4
   - subnet-82dc63f5
+
+admin_frontend:
+  paas:
+    env:
+      DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-preview-preview
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-preview-preview
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-preview-preview
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communicationspreview-preview
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-preview-preview
+      DM_ASSETS_URL: https://preview-assets.development.digitalmarketplace.service.gov.uk
+
+supplier_frontend:
+  paas:
+    env:
+      DM_G7_DRAFT_DOCUMENTS_BUCKET: digitalmarketplace-g7-draft-documents-preview-preview
+      DM_G7_DRAFT_DOCUMENTS_URL: https://preview-assets.development.digitalmarketplace.service.gov.uk
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-preview-preview
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-preview-preview
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communicationspreview-preview
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-preview-preview
+      DM_ASSETS_URL: https://preview-assets.development.digitalmarketplace.service.gov.uk
+      DM_CLARIFICATION_QUESTION_EMAIL: clarification@digitalmarketplace.service.gov.uk
+      DM_FOLLOW_UP_EMAIL_TO: enquiries@digitalmarketplace.service.gov.uk

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -55,7 +55,16 @@ supplier_frontend:
   max_instance_count: 10
   paas:
     instances: 2
-
+    env:
+      DM_G7_DRAFT_DOCUMENTS_BUCKET: digitalmarketplace-g7-draft-documents-production-production
+      DM_G7_DRAFT_DOCUMENTS_URL: https://assets.digitalmarketplace.service.gov.uk
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-production-production
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-production-production
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communicationsproduction-production
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-production-production
+      DM_ASSETS_URL: https://assets.digitalmarketplace.service.gov.uk
+      DM_CLARIFICATION_QUESTION_EMAIL: clarification@digitalmarketplace.service.gov.uk
+      DM_FOLLOW_UP_EMAIL_TO: enquiries@digitalmarketplace.service.gov.uk
 elasticsearch:
   instance_type: t2.medium
 

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -22,22 +22,32 @@ api:
   instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
+  paas:
+    instances: 2
 
 search_api:
   min_instance_count: 3
   max_instance_count: 5
+  paas:
+    instances: 2
 
 admin_frontend:
   min_instance_count: 3
   max_instance_count: 5
+  paas:
+    instances: 2
 
 buyer_frontend:
   min_instance_count: 3
   max_instance_count: 5
+  paas:
+    instances: 2
 
 supplier_frontend:
   min_instance_count: 3
   max_instance_count: 10
+  paas:
+    instances: 2
 
 elasticsearch:
   instance_type: t2.medium

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -36,6 +36,13 @@ admin_frontend:
   max_instance_count: 5
   paas:
     instances: 2
+    env:
+      DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-production-production
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-production-production
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-production-production
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communications-production-production
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-production-production
+      DM_ASSETS_URL: https://assets.digitalmarketplace.service.gov.uk
 
 buyer_frontend:
   min_instance_count: 3

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -16,3 +16,13 @@ subnets:
   - subnet-9a9713ed
   - subnet-63b1683a
   - subnet-ad0894c8
+
+admin_frontend:
+  paas:
+    env:
+      DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-staging-staging
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-staging-staging
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-staging-staging
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communications-staging-staging
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-staging-staging
+      DM_ASSETS_URL: https://staging-assets.digitalmarketplace.service.gov.uk

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -17,8 +17,17 @@ subnets:
   - subnet-63b1683a
   - subnet-ad0894c8
 
+api:
+  paas:
+    instances: 2
+
+search_api:
+  paas:
+    instances: 2
+
 admin_frontend:
   paas:
+    instances: 2
     env:
       DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-staging-staging
       DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-staging-staging
@@ -26,3 +35,21 @@ admin_frontend:
       DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communications-staging-staging
       DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-staging-staging
       DM_ASSETS_URL: https://staging-assets.digitalmarketplace.service.gov.uk
+
+buyer_frontend:
+  paas:
+    instances: 2
+
+supplier_frontend:
+  paas:
+    instances: 2
+    env:
+      DM_G7_DRAFT_DOCUMENTS_BUCKET: digitalmarketplace-g7-draft-documents-staging-staging
+      DM_G7_DRAFT_DOCUMENTS_URL: https://staging-assets.digitalmarketplace.service.gov.uk
+      DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-staging-staging
+      DM_AGREEMENTS_BUCKET: digitalmarketplace-agreements-staging-staging
+      DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communicationsstaging-staging
+      DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-staging-staging
+      DM_ASSETS_URL: https://staging-assets.digitalmarketplace.service.gov.uk
+      DM_CLARIFICATION_QUESTION_EMAIL: clarification@digitalmarketplace.service.gov.uk
+      DM_FOLLOW_UP_EMAIL_TO: enquiries@digitalmarketplace.service.gov.uk


### PR DESCRIPTION
I added a new command to dmaws to generate PaaS manifest files from a Jinja2 template. The command is using the built-in variable loading mechanism.

Subcommand: paas-manifest
Extra options:
```
  -t, --template PATH             Manifest Jinja2 template file
  -c, --credentials-repo PATH     Path to the digitalmarketplace-credentials
                                  repository
  -o, --out-file TEXT             Output file, if empty the template content
                                  is printed to the stdout
```

Components:
 - Paas manifest Jinja2 template: paas/manifest.j2. Can be changed with the --template option.
 - The PaaS configs are added to the existing apps under the paas key (see vars/common.yml)
 - Application secrets are optional and loaded the same way but from the credentials repo (vars/common.yaml and vars/[environment].yaml)

The configurations are merged in the following order:
 - vars/common.ym
 - vars/[environment].yml
 - [credentials repo]/vars/common.yaml
 - [credentials repo]/vars/[environment].yaml

Example usage:
```
dmaws paas-manifest development supplier-frontend
```