### PR TITLE
Bump API model to t2.medium as larger memory required

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,6 +19,7 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
+  instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10
 


### PR DESCRIPTION
When downloading lists of users from the API we have seen our instances run out of memory. This should resolve that problem.

![image](https://cloud.githubusercontent.com/assets/7228605/23301947/6fe35662-fa84-11e6-951e-89d56f197c30.png)

