### PR TITLE
Add dev and prod infrastructure user groups

### DIFF
--- a/terraform/modules/iam-users/infrastructure.tf
+++ b/terraform/modules/iam-users/infrastructure.tf
@@ -1,0 +1,67 @@
+resource "aws_iam_group" "dev_infrastructure" {
+  name = "DevInfrastructure"
+}
+
+resource "aws_iam_group_policy" "dev_infrastructure" {
+  name = "DevInfrastructure"
+  group = "${aws_iam_group.dev_infrastructure.name}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.aws_dev_account_id}:role/infrastructure",
+        "arn:aws:iam::${var.aws_dev_account_id}:role/packer"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_group_membership" "dev_infrastructure" {
+  name = "dev_infrastructure"
+  users = ["${var.dev_infrastructure_users}"]
+  group = "${aws_iam_group.dev_infrastructure.name}"
+  depends_on = ["module.users"]
+}
+
+resource "aws_iam_group" "prod_infrastructure" {
+  name = "ProdInfrastructure"
+}
+
+resource "aws_iam_group_policy" "prod_infrastructure" {
+  name = "ProdInfrastructure"
+  group = "${aws_iam_group.prod_infrastructure.name}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::${var.aws_dev_account_id}:role/infrastructure",
+        "arn:aws:iam::${var.aws_dev_account_id}:role/packer",
+        "arn:aws:iam::${var.aws_prod_account_id}:role/infrastructure",
+        "arn:aws:iam::${var.aws_prod_account_id}:role/packer"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_group_membership" "prod_infrastructure" {
+  name = "prod_infrastructure"
+  users = ["${var.prod_infrastructure_users}"]
+  group = "${aws_iam_group.prod_infrastructure.name}"
+  depends_on = ["module.users"]
+}

--- a/terraform/modules/iam-users/variables.tf
+++ b/terraform/modules/iam-users/variables.tf
@@ -11,6 +11,14 @@ variable "dev_s3_only_users" {
   type = "list"
 }
 
+variable "dev_infrastructure_users" {
+  type = "list"
+}
+
+variable "prod_infrastructure_users" {
+  type = "list"
+}
+
 variable "ip_restricted_access_policy_arn" {}
 variable "iam_manage_account_policy_arn" {}
 variable "developer_policy_arn" {}

--- a/terraform/root/aws-dm/main.tf
+++ b/terraform/root/aws-dm/main.tf
@@ -17,6 +17,8 @@ module "iam_users" {
   prod_developers = "${var.prod_developers}"
   dev_s3_only_users = "${var.dev_s3_only_users}"
   admin_policy_arn = "${module.iam_common.aws_iam_policy_admin_arn}"
+  dev_infrastructure_users = "${var.dev_infrastructure_users}"
+  prod_infrastructure_users = "${var.prod_infrastructure_users}"
 }
 
 module "sops_credentials" {

--- a/terraform/root/aws-dm/variables.tf
+++ b/terraform/root/aws-dm/variables.tf
@@ -21,3 +21,9 @@ variable "prod_developers" {
 variable "dev_s3_only_users" {
   type = "list"
 }
+variable "dev_infrastructure_users" {
+  type = "list"
+}
+variable "prod_infrastructure_users" {
+  type = "list"
+}


### PR DESCRIPTION
This PR adds two news groups:
 - DevInfrastructure: users who can assume the infrastructure role in the dev account
 - ProdInfrastructure: users who can assume the infrastructure role in the dev/prod accounts