### PR TITLE
Remove sops key access from dev and prod users

### DIFF
--- a/terraform/modules/sops-credentials/iam.tf
+++ b/terraform/modules/sops-credentials/iam.tf
@@ -39,7 +39,7 @@ resource "aws_iam_role" "sops_credentials_access" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": [${join(",", formatlist("\"arn:aws:iam::%s:root\"", var.aws_account_ids))}]
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "sts:AssumeRole"
     }


### PR DESCRIPTION
Previous IAM role allowed dev and prod account users to assume the
role for accessing sops KMS keys. But our applications never
decrypt the credentials themselves and we're moving all users to
the main account, so we don't need these permissions.