### PR TITLE
Add terraform/ansible/nginx setup to enable maintenance mode

### DIFF
--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -364,7 +364,8 @@
             "-e www_subdomain=", {"Ref": "Subdomain"}, " ",
             "-e buyer_frontend_url=", {"Ref": "BuyerFrontendURL"}, " ",
             "-e admin_frontend_url=", {"Ref": "AdminFrontendURL"}, " ",
-            "-e supplier_frontend_url=", {"Ref": "SupplierFrontendURL"}
+            "-e supplier_frontend_url=", {"Ref": "SupplierFrontendURL"}, " ",
+            "-e nginx_config=live_config"
         ]]}}
       }
     }

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -365,7 +365,7 @@
             "-e buyer_frontend_url=", {"Ref": "BuyerFrontendURL"}, " ",
             "-e admin_frontend_url=", {"Ref": "AdminFrontendURL"}, " ",
             "-e supplier_frontend_url=", {"Ref": "SupplierFrontendURL"}, " ",
-            "-e nginx_config=live"
+            "-e mode=live"
         ]]}}
       }
     }

--- a/cloudformation_templates/aws_nginx.json
+++ b/cloudformation_templates/aws_nginx.json
@@ -365,7 +365,7 @@
             "-e buyer_frontend_url=", {"Ref": "BuyerFrontendURL"}, " ",
             "-e admin_frontend_url=", {"Ref": "AdminFrontendURL"}, " ",
             "-e supplier_frontend_url=", {"Ref": "SupplierFrontendURL"}, " ",
-            "-e nginx_config=live_config"
+            "-e nginx_config=live"
         ]]}}
       }
     }

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -1,14 +1,14 @@
 ---
-live_config:
-  - www
-  - api
-  - assets
-  - healthcheck
-  - elasticsearch
-  - digitalservicesstore
-
-maintenance_config:
-  - healthcheck
-  - maintenance
+nginx_configs:
+  live:
+    - www
+    - api
+    - assets
+    - healthcheck
+    - elasticsearch
+    - digitalservicesstore
+  maintenance:
+    - healthcheck
+    - maintenance
 
 static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -7,6 +7,8 @@ live_config:
   - elasticsearch
   - digitalservicesstore
 
-maintenance_config: maintenance
+maintenance_config:
+  - healthcheck
+  - maintenance
 
 static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
-nginx_configs:
+live_config:
   - www
   - api
   - assets
   - healthcheck
   - elasticsearch
   - digitalservicesstore
+
+maintenance_config: maintenance
 
 static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -11,4 +11,6 @@ nginx_configs:
     - healthcheck
     - maintenance
 
+mode: live
+
 static_files_root: /usr/share/nginx/html

--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -1,0 +1,1 @@
+<h1>Sorry, we're down for maintenance</h1>

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -73,7 +73,7 @@
   notify: reload nginx
   with_items: "{{ live_config }}"
   tags: instance-config
-  when: nginx_config == "live_config"
+  when: nginx_config == "live"
 
 - name: Create the Nginx maintenance configuration files
   template: src={{ item }}.j2
@@ -82,7 +82,7 @@
   notify: reload nginx
   with_items: "{{ maintenance_config }}"
   tags: instance-config
-  when: nginx_config == "maintenance_config"
+  when: nginx_config == "maintenance"
 
 - name: Ensure that the live configuration files are enabled
   command: ln -s /etc/nginx/sites-available/{{ item }}
@@ -91,7 +91,7 @@
   notify: reload nginx
   with_items: "{{ live_config }}"
   tags: instance-config
-  when: nginx_config == "live_config"
+  when: nginx_config == "live"
 
 - name: Ensure that the maintenance configuration files are enabled
   command: ln -s /etc/nginx/sites-available/{{ item }}
@@ -100,7 +100,7 @@
   notify: reload nginx
   with_items: "{{ maintenance_config }}"
   tags: instance-config
-  when: nginx_config == "maintenance_config"
+  when: nginx_config == "maintenance"
 
 - name: Ensure Nginx service is started
   service: name=nginx state=started enabled=yes

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -66,41 +66,21 @@
   notify: reload nginx
   tags: instance-config
 
-- name: Create the Nginx live configuration files
+- name: Create the Nginx configuration files
   template: src={{ item }}.j2
             dest=/etc/nginx/sites-available/{{ item }}
             backup=yes
   notify: reload nginx
-  with_items: "{{ live_config }}"
+  with_items: "{{ nginx_configs[mode] }}"
   tags: instance-config
-  when: nginx_config == "live"
 
-- name: Create the Nginx maintenance configuration files
-  template: src={{ item }}.j2
-            dest=/etc/nginx/sites-available/{{ item }}
-            backup=yes
-  notify: reload nginx
-  with_items: "{{ maintenance_config }}"
-  tags: instance-config
-  when: nginx_config == "maintenance"
-
-- name: Ensure that the live configuration files are enabled
+- name: Ensure that the configuration files are enabled
   command: ln -s /etc/nginx/sites-available/{{ item }}
            /etc/nginx/sites-enabled/{{ item }}
            creates=/etc/nginx/sites-enabled/{{ item }}
   notify: reload nginx
-  with_items: "{{ live_config }}"
+  with_items: "{{ nginx_configs[mode] }}"
   tags: instance-config
-  when: nginx_config == "live"
-
-- name: Ensure that the maintenance configuration files are enabled
-  command: ln -s /etc/nginx/sites-available/{{ item }}
-           /etc/nginx/sites-enabled/{{ item }}
-           creates=/etc/nginx/sites-enabled/{{ item }}
-  notify: reload nginx
-  with_items: "{{ maintenance_config }}"
-  tags: instance-config
-  when: nginx_config == "maintenance"
 
 - name: Ensure Nginx service is started
   service: name=nginx state=started enabled=yes

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -48,6 +48,10 @@
     - robots_assets.txt
   tags: image-setup
 
+- name: Copy maintenance.html file
+  copy: src=maintenance.html dest={{ static_files_root }}/maintenance.html owner=root group=root mode=0644
+  tags: image-setup
+
 - name: Create nginx http auth file
   template: src=nginx_htpasswd.j2
             dest=/etc/nginx/.htpasswd
@@ -62,21 +66,41 @@
   notify: reload nginx
   tags: instance-config
 
-- name: Create the Nginx configuration files
+- name: Create the Nginx live configuration files
   template: src={{ item }}.j2
             dest=/etc/nginx/sites-available/{{ item }}
             backup=yes
   notify: reload nginx
-  with_items: nginx_configs
+  with_items: "{{ live_config }}"
   tags: instance-config
+  when: nginx_config == "live_config"
 
-- name: Ensure that the configuration files are enabled
+- name: Create the Nginx maintenance configuration files
+  template: src={{ item }}.j2
+            dest=/etc/nginx/sites-available/{{ item }}
+            backup=yes
+  notify: reload nginx
+  with_items: "{{ maintenance_config }}"
+  tags: instance-config
+  when: nginx_config == "maintenance_config"
+
+- name: Ensure that the live configuration files are enabled
   command: ln -s /etc/nginx/sites-available/{{ item }}
            /etc/nginx/sites-enabled/{{ item }}
            creates=/etc/nginx/sites-enabled/{{ item }}
   notify: reload nginx
-  with_items: nginx_configs
+  with_items: "{{ live_config }}"
   tags: instance-config
+  when: nginx_config == "live_config"
+
+- name: Ensure that the maintenance configuration files are enabled
+  command: ln -s /etc/nginx/sites-available/{{ item }}
+           /etc/nginx/sites-enabled/{{ item }}
+           creates=/etc/nginx/sites-enabled/{{ item }}
+  notify: reload nginx
+  with_items: "{{ maintenance_config }}"
+  tags: instance-config
+  when: nginx_config == "maintenance_config"
 
 - name: Ensure Nginx service is started
   service: name=nginx state=started enabled=yes

--- a/playbooks/roles/nginx/templates/maintenance.j2
+++ b/playbooks/roles/nginx/templates/maintenance.j2
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name _;
+    server_name www.*;
     root {{ static_files_root }};
 
     {% for user_ip in user_ips.split(",") %}

--- a/playbooks/roles/nginx/templates/maintenance.j2
+++ b/playbooks/roles/nginx/templates/maintenance.j2
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    server_name _;
+    root {{ static_files_root }};
+
+    {% for user_ip in user_ips.split(",") %}
+    allow {{ user_ip }};
+    {% endfor %}
+    deny all;
+
+    location / {
+        return 503;
+    }
+
+    error_page 503 @maintenance;
+    location @maintenance {
+        rewrite ^(.*)$ /maintenance.html break;
+    }
+}

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -57,7 +57,7 @@ module "preview_nginx" {
   elasticsearch_auth = "${var.elasticsearch_auth}"
   app_auth = "${var.app_auth}"
 
-  nginx_config = "${var.nginx_config}"
+  mode = "${var.mode}"
 }
 
 module "preview_elasticsearch" {

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -56,6 +56,8 @@ module "preview_nginx" {
 
   elasticsearch_auth = "${var.elasticsearch_auth}"
   app_auth = "${var.app_auth}"
+
+  nginx_config = "${var.nginx_config}"
 }
 
 module "preview_elasticsearch" {

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -26,6 +26,6 @@ variable "supplier_frontend_url" {}
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
-variable "nginx_config" {
+variable "mode" {
   default = "live"
 }

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -27,5 +27,5 @@ variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
 variable "nginx_config" {
-  default = "live_config"
+  default = "live"
 }

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -25,3 +25,7 @@ variable "supplier_frontend_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
+
+variable "nginx_config" {
+  default = "live_config"
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -57,7 +57,7 @@ module "staging_nginx" {
   elasticsearch_auth = "${var.elasticsearch_auth}"
   app_auth = "${var.app_auth}"
 
-  nginx_config = "${var.nginx_config}"
+  mode = "${var.mode}"
 }
 
 module "staging_elasticsearch" {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -56,6 +56,8 @@ module "staging_nginx" {
 
   elasticsearch_auth = "${var.elasticsearch_auth}"
   app_auth = "${var.app_auth}"
+
+  nginx_config = "${var.nginx_config}"
 }
 
 module "staging_elasticsearch" {

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -26,6 +26,6 @@ variable "supplier_frontend_url" {}
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
-variable "nginx_config" {
+variable "mode" {
   default = "live"
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -27,5 +27,5 @@ variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
 variable "nginx_config" {
-  default = "live_config"
+  default = "live"
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -25,3 +25,7 @@ variable "supplier_frontend_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
+
+variable "nginx_config" {
+  default = "live_config"
+}

--- a/terraform/modules/nginx/autoscaling.tf
+++ b/terraform/modules/nginx/autoscaling.tf
@@ -88,7 +88,7 @@ cd /home/ubuntu/provisioning && ansible-playbook -c local -i localhost, nginx_pl
     -e app_auth='${var.app_auth}' \
     -e aws_region='${data.aws_region.current.name}' \
     -e nameserver_ip="$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)" \
-    -e nginx_config='${var.nginx_config}'
+    -e mode='${var.mode}'
 END
 
   lifecycle {

--- a/terraform/modules/nginx/autoscaling.tf
+++ b/terraform/modules/nginx/autoscaling.tf
@@ -87,7 +87,8 @@ cd /home/ubuntu/provisioning && ansible-playbook -c local -i localhost, nginx_pl
     -e elasticsearch_auth='${var.elasticsearch_auth}' \
     -e app_auth='${var.app_auth}' \
     -e aws_region='${data.aws_region.current.name}' \
-    -e nameserver_ip="$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)"
+    -e nameserver_ip="$(awk '/nameserver/{ print $2; exit}' /etc/resolv.conf)" \
+    -e nginx_config='${var.nginx_config}'
 END
 
   lifecycle {

--- a/terraform/modules/nginx/elb.tf
+++ b/terraform/modules/nginx/elb.tf
@@ -33,6 +33,12 @@ resource "aws_elb" "nginx" {
   cross_zone_load_balancing = true
 }
 
+resource "aws_lb_cookie_stickiness_policy" "nginx_elb_sticky_sessions" {
+  name = "${var.name}-elb-sticky-sessions"
+  load_balancer = "${aws_elb.nginx.id}"
+  lb_port = 443
+}
+
 resource "aws_security_group" "nginx_elb" {
   name = "${var.name}-elb"
   vpc_id = "${var.vpc_id}"

--- a/terraform/modules/nginx/variables.tf
+++ b/terraform/modules/nginx/variables.tf
@@ -44,4 +44,4 @@ variable "elasticsearch_url" {}
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
-variable "nginx_config" {}
+variable "mode" {}

--- a/terraform/modules/nginx/variables.tf
+++ b/terraform/modules/nginx/variables.tf
@@ -43,3 +43,5 @@ variable "elasticsearch_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}
+
+variable "nginx_config" {}


### PR DESCRIPTION
Doesn't seem to have a Pivotal Story, but this is connected [https://www.pivotaltracker.com/story/show/143486469](https://www.pivotaltracker.com/story/show/143486469).

We don't currently have a way to switch the site to a maintenance mode if we have planned down time.

If the `nginx_config` variable is set to `live` in Terraform for a particular environment the site will behave as usual. If it is set to `maintenance` then Ansible will update the Nginx autoscaling group and only load up the maintenance and healthcheck nginx configs.

The healthcheck config allows the ELB healthchecks to pass, and the maintenance config returns a static html file for any url on the www subdomain. This html file needs updating once content and design have looked at it.