### PR TITLE
Release tag for paas jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ virtualenv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exis
 ${VIRTUALENV_ROOT}/activate:
 	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv venv || true
 
-.PHONY: build
-build: requirements ## Build project
-
 .PHONY: preview
 preview: ## Set stage to preview
 	$(eval export STAGE=preview)

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ production: ## Set stage to production
 
 download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
-	$(if ${RELEASE_NUMBER},,$(error Must specify RELEASE_NUMBER))
+	$(if ${RELEASE_NAME},,$(error Must specify RELEASE_NAME))
 	rm -rf ${DEPLOYMENT_DIR}
 	mkdir -p ${DEPLOYMENT_DIR}
-	${VIRTUALENV_ROOT}/bin/aws s3 --only-show-errors cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/release-${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/release.zip
+	${VIRTUALENV_ROOT}/bin/aws s3 --only-show-errors cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/${RELEASE_NAME}.zip ${DEPLOYMENT_DIR}/release.zip
 	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/release.zip
 	rm ${DEPLOYMENT_DIR}/release.zip
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PAAS_API ?= api.cloud.service.gov.uk
 PAAS_ORG ?= digitalmarketplace
 PAAS_SPACE ?= ${STAGE}
 
-DEPLOYMENT_DIR := ${CURDIR}/tmp
+DEPLOYMENT_DIR := ${CURDIR}/releases/${RELEASE_NAME}
 
 .PHONY: help
 help:
@@ -41,7 +41,7 @@ download-deployment-zip: virtualenv ## Downloads the deployment zip file from S3
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${RELEASE_NUMBER},,$(error Must specify RELEASE_NUMBER))
 	rm -rf ${DEPLOYMENT_DIR}
-	mkdir ${DEPLOYMENT_DIR}
+	mkdir -p ${DEPLOYMENT_DIR}
 	${VIRTUALENV_ROOT}/bin/aws s3 --only-show-errors cp --region eu-west-1 s3://digitalmarketplace-deployment/${APPLICATION_NAME}/release-${RELEASE_NUMBER}.zip ${DEPLOYMENT_DIR}/release.zip
 	unzip -q -d ${DEPLOYMENT_DIR} ${DEPLOYMENT_DIR}/release.zip
 	rm ${DEPLOYMENT_DIR}/release.zip


### PR DESCRIPTION
### Force push release tags in EB deployment jobs

We're running PaaS deployments in parallel with existing EB ones at the moment, and they're creating the same release-* tags. Which means we can no longer depend on the EB application version existing when the tag exists. Since we don't have a way to check that EB version exists, we ignore any errors instead and force the tag push.

### Make a separate deployment dir for each release tag

Should make it easier to see what release was being deployed and can help avoid any accidental clashes for failed cleanup.

### Replace RELEASE_NUMBER with RELEASE_NAME

RELEASE_NAME contains the full tag/archive name with the "release-" prefix, so we don't need to add it in the make step.