### PR TITLE
Add Make rule to populate PaaS db from dump

### DIFF
--- a/scripts/paas_populate_db.sh
+++ b/scripts/paas_populate_db.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+DB_DUMP=$1
+
+cf create-service-key digitalmarketplace_api_db DATA_MIGRATION_KEY
+KEY_DATA=$(cf curl /v2/service_keys/$(cf service-key digitalmarketplace_api_db DATA_MIGRATION_KEY --guid))
+DB_HOST=$(echo $KEY_DATA | jq -r '.entity.credentials.host')
+DB_PASSWORD=$(echo $KEY_DATA | jq -r '.entity.credentials.password')
+DB_USERNAME=$(echo $KEY_DATA | jq -r '.entity.credentials.username')
+DB_NAME=$(echo $KEY_DATA | jq -r '.entity.credentials.name')
+(cf ssh-code | pbcopy)
+ssh -f -o ExitOnForwardFailure=yes  -L 63306:$DB_HOST:5432 -p 2222 cf:$(cf app api --guid)/0@ssh.cloud.service.gov.uk sleep 10
+psql -d postgresql://$DB_USERNAME:$DB_PASSWORD@localhost:63306/$DB_NAME < $DB_DUMP
+cf delete-service-key digitalmarketplace_api_db DATA_MIGRATION_KEY


### PR DESCRIPTION
We need to set up an ssh tunnel via the api app to allow importing of
data into the PaaS db's from a local dump.

The `PAAS_SPACE` needs to be provided as a parameter which is checked
against the currently targeted cf stage to prevent accidental writing to
the wrong db.