### PR TITLE
Fix admin and supplier frontend PaaS healthcheck path

### DIFF
--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -11,7 +11,7 @@ applications:
     memory: {{ paas.memory|default('512M') }}
     disk_quota: {{ paas.disk_quota|default('1024M') }}
     health-check-type: http
-    health-check-http-endpoint: /_status?ignore-dependencies
+    health-check-http-endpoint: {{ paas.path|default('') }}/_status?ignore-dependencies
     env:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}


### PR DESCRIPTION
Since admin and supplier apps server their status endpoint from /admin/_status and /suppliers/_status we need to add the path prefix to the health check URL