### PR TITLE
🏀  Baller maintenance page 🏀 

### DIFF
--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -16,7 +16,500 @@
   <meta content="https://assets.publishing.service.gov.uk/static/opengraph-image.png" property="og:image">
   <!--[if lt IE 9]>
   <script>
-    /* inline JavaScript here for < IE9 */
+    /**
+      * @preserve HTML5 Shiv 3.7.3 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed
+    */
+
+    !function(a,b){function c(a,b){var c=a.createElement("p"),d=a.getElementsByTagName("head")[0]||a.documentElement;return c.innerHTML="x<style>"+b+"</style>",d.insertBefore(c.lastChild,d.firstChild)}function d(){var a=y.elements;return"string"==typeof a?a.split(" "):a}function e(a,b){var c=y.elements;"string"!=typeof c&&(c=c.join(" ")),"string"!=typeof a&&(a=a.join(" ")),y.elements=c+" "+a,j(b)}function f(a){var b=x[a[v]];return b||(b={},w++,a[v]=w,x[w]=b),b}function g(a,c,d){if(c||(c=b),q)return c.createElement(a);d||(d=f(c));var e;return e=d.cache[a]?d.cache[a].cloneNode():u.test(a)?(d.cache[a]=d.createElem(a)).cloneNode():d.createElem(a),!e.canHaveChildren||t.test(a)||e.tagUrn?e:d.frag.appendChild(e)}function h(a,c){if(a||(a=b),q)return a.createDocumentFragment();c=c||f(a);for(var e=c.frag.cloneNode(),g=0,h=d(),i=h.length;i>g;g++)e.createElement(h[g]);return e}function i(a,b){b.cache||(b.cache={},b.createElem=a.createElement,b.createFrag=a.createDocumentFragment,b.frag=b.createFrag()),a.createElement=function(c){return y.shivMethods?g(c,a,b):b.createElem(c)},a.createDocumentFragment=Function("h,f","return function(){var n=f.cloneNode(),c=n.createElement;h.shivMethods&&("+d().join().replace(/[\w\-:]+/g,function(a){return b.createElem(a),b.frag.createElement(a),'c("'+a+'")'})+");return n}")(y,b.frag)}function j(a){a||(a=b);var d=f(a);return!y.shivCSS||p||d.hasCSS||(d.hasCSS=!!c(a,"article,aside,dialog,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}mark{background:#FF0;color:#000}template{display:none}")),q||i(a,d),a}function k(a){for(var b,c=a.getElementsByTagName("*"),e=c.length,f=RegExp("^(?:"+d().join("|")+")$","i"),g=[];e--;)b=c[e],f.test(b.nodeName)&&g.push(b.applyElement(l(b)));return g}function l(a){for(var b,c=a.attributes,d=c.length,e=a.ownerDocument.createElement(A+":"+a.nodeName);d--;)b=c[d],b.specified&&e.setAttribute(b.nodeName,b.nodeValue);return e.style.cssText=a.style.cssText,e}function m(a){for(var b,c=a.split("{"),e=c.length,f=RegExp("(^|[\\s,>+~])("+d().join("|")+")(?=[[\\s,>+~#.:]|$)","gi"),g="$1"+A+"\\:$2";e--;)b=c[e]=c[e].split("}"),b[b.length-1]=b[b.length-1].replace(f,g),c[e]=b.join("}");return c.join("{")}function n(a){for(var b=a.length;b--;)a[b].removeNode()}function o(a){function b(){clearTimeout(g._removeSheetTimer),d&&d.removeNode(!0),d=null}var d,e,g=f(a),h=a.namespaces,i=a.parentWindow;return!B||a.printShived?a:("undefined"==typeof h[A]&&h.add(A),i.attachEvent("onbeforeprint",function(){b();for(var f,g,h,i=a.styleSheets,j=[],l=i.length,n=Array(l);l--;)n[l]=i[l];for(;h=n.pop();)if(!h.disabled&&z.test(h.media)){try{f=h.imports,g=f.length}catch(o){g=0}for(l=0;g>l;l++)n.push(f[l]);try{j.push(h.cssText)}catch(o){}}j=m(j.reverse().join("")),e=k(a),d=c(a,j)}),i.attachEvent("onafterprint",function(){n(e),clearTimeout(g._removeSheetTimer),g._removeSheetTimer=setTimeout(b,500)}),a.printShived=!0,a)}var p,q,r="3.7.3",s=a.html5||{},t=/^<|^(?:button|map|select|textarea|object|iframe|option|optgroup)$/i,u=/^(?:a|b|code|div|fieldset|h1|h2|h3|h4|h5|h6|i|label|li|ol|p|q|span|strong|style|table|tbody|td|th|tr|ul)$/i,v="_html5shiv",w=0,x={};!function(){try{var a=b.createElement("a");a.innerHTML="<xyz></xyz>",p="hidden"in a,q=1==a.childNodes.length||function(){b.createElement("a");var a=b.createDocumentFragment();return"undefined"==typeof a.cloneNode||"undefined"==typeof a.createDocumentFragment||"undefined"==typeof a.createElement}()}catch(c){p=!0,q=!0}}();var y={elements:s.elements||"abbr article aside audio bdi canvas data datalist details dialog figcaption figure footer header hgroup main mark meter nav output picture progress section summary template time video",version:r,shivCSS:s.shivCSS!==!1,supportsUnknownElements:q,shivMethods:s.shivMethods!==!1,type:"default",shivDocument:j,createElement:g,createDocumentFragment:h,addElements:e};a.html5=y,j(b);var z=/^$|\b(?:all|print)\b/,A="html5shiv",B=!q&&function(){var c=b.documentElement;return!("undefined"==typeof b.namespaces||"undefined"==typeof b.parentWindow||"undefined"==typeof c.applyElement||"undefined"==typeof c.removeNode||"undefined"==typeof a.attachEvent)}();y.type+=" print",y.shivPrint=o,o(b),"object"==typeof module&&module.exports&&(module.exports=y)}("undefined"!=typeof window?window:this,document);
+    /*
+        json2.js
+        2011-10-19
+
+        Public Domain.
+
+        NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+        See http://www.JSON.org/js.html
+
+
+        This code should be minified before deployment.
+        See http://javascript.crockford.com/jsmin.html
+
+        USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+        NOT CONTROL.
+
+
+        This file creates a global JSON object containing two methods: stringify
+        and parse.
+
+            JSON.stringify(value, replacer, space)
+                value       any JavaScript value, usually an object or array.
+
+                replacer    an optional parameter that determines how object
+                            values are stringified for objects. It can be a
+                            function or an array of strings.
+
+                space       an optional parameter that specifies the indentation
+                            of nested structures. If it is omitted, the text will
+                            be packed without extra whitespace. If it is a number,
+                            it will specify the number of spaces to indent at each
+                            level. If it is a string (such as '\t' or '&nbsp;'),
+                            it contains the characters used to indent at each level.
+
+                This method produces a JSON text from a JavaScript value.
+
+                When an object value is found, if the object contains a toJSON
+                method, its toJSON method will be called and the result will be
+                stringified. A toJSON method does not serialize: it returns the
+                value represented by the name/value pair that should be serialized,
+                or undefined if nothing should be serialized. The toJSON method
+                will be passed the key associated with the value, and this will be
+                bound to the value
+
+                For example, this would serialize Dates as ISO strings.
+
+                    Date.prototype.toJSON = function (key) {
+                        function f(n) {
+                            // Format integers to have at least two digits.
+                            return n < 10 ? '0' + n : n;
+                        }
+
+                        return this.getUTCFullYear()   + '-' +
+                             f(this.getUTCMonth() + 1) + '-' +
+                             f(this.getUTCDate())      + 'T' +
+                             f(this.getUTCHours())     + ':' +
+                             f(this.getUTCMinutes())   + ':' +
+                             f(this.getUTCSeconds())   + 'Z';
+                    };
+
+                You can provide an optional replacer method. It will be passed the
+                key and value of each member, with this bound to the containing
+                object. The value that is returned from your method will be
+                serialized. If your method returns undefined, then the member will
+                be excluded from the serialization.
+
+                If the replacer parameter is an array of strings, then it will be
+                used to select the members to be serialized. It filters the results
+                such that only members with keys listed in the replacer array are
+                stringified.
+
+                Values that do not have JSON representations, such as undefined or
+                functions, will not be serialized. Such values in objects will be
+                dropped; in arrays they will be replaced with null. You can use
+                a replacer function to replace those with JSON values.
+                JSON.stringify(undefined) returns undefined.
+
+                The optional space parameter produces a stringification of the
+                value that is filled with line breaks and indentation to make it
+                easier to read.
+
+                If the space parameter is a non-empty string, then that string will
+                be used for indentation. If the space parameter is a number, then
+                the indentation will be that many spaces.
+
+                Example:
+
+                text = JSON.stringify(['e', {pluribus: 'unum'}]);
+                // text is '["e",{"pluribus":"unum"}]'
+
+
+                text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+                // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+                text = JSON.stringify([new Date()], function (key, value) {
+                    return this[key] instanceof Date ?
+                        'Date(' + this[key] + ')' : value;
+                });
+                // text is '["Date(---current time---)"]'
+
+
+            JSON.parse(text, reviver)
+                This method parses a JSON text to produce an object or array.
+                It can throw a SyntaxError exception.
+
+                The optional reviver parameter is a function that can filter and
+                transform the results. It receives each of the keys and values,
+                and its return value is used instead of the original value.
+                If it returns what it received, then the structure is not modified.
+                If it returns undefined then the member is deleted.
+
+                Example:
+
+                // Parse the text. Values that look like ISO date strings will
+                // be converted to Date objects.
+
+                myData = JSON.parse(text, function (key, value) {
+                    var a;
+                    if (typeof value === 'string') {
+                        a =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                        if (a) {
+                            return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                                +a[5], +a[6]));
+                        }
+                    }
+                    return value;
+                });
+
+                myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                    var d;
+                    if (typeof value === 'string' &&
+                            value.slice(0, 5) === 'Date(' &&
+                            value.slice(-1) === ')') {
+                        d = new Date(value.slice(5, -1));
+                        if (d) {
+                            return d;
+                        }
+                    }
+                    return value;
+                });
+
+
+        This is a reference implementation. You are free to copy, modify, or
+        redistribute.
+    */
+
+    /*jslint evil: true, regexp: true */
+
+    /*members "", "\b", "\t", "\n", "\f", "\r", "\"", JSON, "\\", apply,
+        call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+        getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+        lastIndex, length, parse, prototype, push, replace, slice, stringify,
+        test, toJSON, toString, valueOf
+    */
+
+
+    // Create a JSON object only if one does not already exist. We create the
+    // methods in a closure to avoid creating global variables.
+
+    var JSON;
+    if (!JSON) {
+        JSON = {};
+    }
+
+    (function () {
+        'use strict';
+
+        function f(n) {
+            // Format integers to have at least two digits.
+            return n < 10 ? '0' + n : n;
+        }
+
+        if (typeof Date.prototype.toJSON !== 'function') {
+
+            Date.prototype.toJSON = function (key) {
+
+                return isFinite(this.valueOf())
+                    ? this.getUTCFullYear()     + '-' +
+                        f(this.getUTCMonth() + 1) + '-' +
+                        f(this.getUTCDate())      + 'T' +
+                        f(this.getUTCHours())     + ':' +
+                        f(this.getUTCMinutes())   + ':' +
+                        f(this.getUTCSeconds())   + 'Z'
+                    : null;
+            };
+
+            String.prototype.toJSON      =
+                Number.prototype.toJSON  =
+                Boolean.prototype.toJSON = function (key) {
+                    return this.valueOf();
+                };
+        }
+
+        var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+            escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+            gap,
+            indent,
+            meta = {    // table of character substitutions
+                '\b': '\\b',
+                '\t': '\\t',
+                '\n': '\\n',
+                '\f': '\\f',
+                '\r': '\\r',
+                '"' : '\\"',
+                '\\': '\\\\'
+            },
+            rep;
+
+
+        function quote(string) {
+
+    // If the string contains no control characters, no quote characters, and no
+    // backslash characters, then we can safely slap some quotes around it.
+    // Otherwise we must also replace the offending characters with safe escape
+    // sequences.
+
+            escapable.lastIndex = 0;
+            return escapable.test(string) ? '"' + string.replace(escapable, function (a) {
+                var c = meta[a];
+                return typeof c === 'string'
+                    ? c
+                    : '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+            }) + '"' : '"' + string + '"';
+        }
+
+
+        function str(key, holder) {
+
+    // Produce a string from holder[key].
+
+            var i,          // The loop counter.
+                k,          // The member key.
+                v,          // The member value.
+                length,
+                mind = gap,
+                partial,
+                value = holder[key];
+
+    // If the value has a toJSON method, call it to obtain a replacement value.
+
+            if (value && typeof value === 'object' &&
+                    typeof value.toJSON === 'function') {
+                value = value.toJSON(key);
+            }
+
+    // If we were called with a replacer function, then call the replacer to
+    // obtain a replacement value.
+
+            if (typeof rep === 'function') {
+                value = rep.call(holder, key, value);
+            }
+
+    // What happens next depends on the value's type.
+
+            switch (typeof value) {
+            case 'string':
+                return quote(value);
+
+            case 'number':
+
+    // JSON numbers must be finite. Encode non-finite numbers as null.
+
+                return isFinite(value) ? String(value) : 'null';
+
+            case 'boolean':
+            case 'null':
+
+    // If the value is a boolean or null, convert it to a string. Note:
+    // typeof null does not produce 'null'. The case is included here in
+    // the remote chance that this gets fixed someday.
+
+                return String(value);
+
+    // If the type is 'object', we might be dealing with an object or an array or
+    // null.
+
+            case 'object':
+
+    // Due to a specification blunder in ECMAScript, typeof null is 'object',
+    // so watch out for that case.
+
+                if (!value) {
+                    return 'null';
+                }
+
+    // Make an array to hold the partial results of stringifying this object value.
+
+                gap += indent;
+                partial = [];
+
+    // Is the value an array?
+
+                if (Object.prototype.toString.apply(value) === '[object Array]') {
+
+    // The value is an array. Stringify every element. Use null as a placeholder
+    // for non-JSON values.
+
+                    length = value.length;
+                    for (i = 0; i < length; i += 1) {
+                        partial[i] = str(i, value) || 'null';
+                    }
+
+    // Join all of the elements together, separated with commas, and wrap them in
+    // brackets.
+
+                    v = partial.length === 0
+                        ? '[]'
+                        : gap
+                        ? '[\n' + gap + partial.join(',\n' + gap) + '\n' + mind + ']'
+                        : '[' + partial.join(',') + ']';
+                    gap = mind;
+                    return v;
+                }
+
+    // If the replacer is an array, use it to select the members to be stringified.
+
+                if (rep && typeof rep === 'object') {
+                    length = rep.length;
+                    for (i = 0; i < length; i += 1) {
+                        if (typeof rep[i] === 'string') {
+                            k = rep[i];
+                            v = str(k, value);
+                            if (v) {
+                                partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                            }
+                        }
+                    }
+                } else {
+
+    // Otherwise, iterate through all of the keys in the object.
+
+                    for (k in value) {
+                        if (Object.prototype.hasOwnProperty.call(value, k)) {
+                            v = str(k, value);
+                            if (v) {
+                                partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                            }
+                        }
+                    }
+                }
+
+    // Join all of the member texts together, separated with commas,
+    // and wrap them in braces.
+
+                v = partial.length === 0
+                    ? '{}'
+                    : gap
+                    ? '{\n' + gap + partial.join(',\n' + gap) + '\n' + mind + '}'
+                    : '{' + partial.join(',') + '}';
+                gap = mind;
+                return v;
+            }
+        }
+
+    // If the JSON object does not yet have a stringify method, give it one.
+
+        if (typeof JSON.stringify !== 'function') {
+            JSON.stringify = function (value, replacer, space) {
+
+    // The stringify method takes a value and an optional replacer, and an optional
+    // space parameter, and returns a JSON text. The replacer can be a function
+    // that can replace values, or an array of strings that will select the keys.
+    // A default replacer method can be provided. Use of the space parameter can
+    // produce text that is more easily readable.
+
+                var i;
+                gap = '';
+                indent = '';
+
+    // If the space parameter is a number, make an indent string containing that
+    // many spaces.
+
+                if (typeof space === 'number') {
+                    for (i = 0; i < space; i += 1) {
+                        indent += ' ';
+                    }
+
+    // If the space parameter is a string, it will be used as the indent string.
+
+                } else if (typeof space === 'string') {
+                    indent = space;
+                }
+
+    // If there is a replacer, it must be a function or an array.
+    // Otherwise, throw an error.
+
+                rep = replacer;
+                if (replacer && typeof replacer !== 'function' &&
+                        (typeof replacer !== 'object' ||
+                        typeof replacer.length !== 'number')) {
+                    throw new Error('JSON.stringify');
+                }
+
+    // Make a fake root object containing our value under the key of ''.
+    // Return the result of stringifying the value.
+
+                return str('', {'': value});
+            };
+        }
+
+
+    // If the JSON object does not yet have a parse method, give it one.
+
+        if (typeof JSON.parse !== 'function') {
+            JSON.parse = function (text, reviver) {
+
+    // The parse method takes a text and an optional reviver function, and returns
+    // a JavaScript value if the text is a valid JSON text.
+
+                var j;
+
+                function walk(holder, key) {
+
+    // The walk method is used to recursively walk the resulting structure so
+    // that modifications can be made.
+
+                    var k, v, value = holder[key];
+                    if (value && typeof value === 'object') {
+                        for (k in value) {
+                            if (Object.prototype.hasOwnProperty.call(value, k)) {
+                                v = walk(value, k);
+                                if (v !== undefined) {
+                                    value[k] = v;
+                                } else {
+                                    delete value[k];
+                                }
+                            }
+                        }
+                    }
+                    return reviver.call(holder, key, value);
+                }
+
+
+    // Parsing happens in four stages. In the first stage, we replace certain
+    // Unicode characters with escape sequences. JavaScript handles many characters
+    // incorrectly, either silently deleting them, or treating them as line endings.
+
+                text = String(text);
+                cx.lastIndex = 0;
+                if (cx.test(text)) {
+                    text = text.replace(cx, function (a) {
+                        return '\\u' +
+                            ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                    });
+                }
+
+    // In the second stage, we run the text against regular expressions that look
+    // for non-JSON patterns. We are especially concerned with '()' and 'new'
+    // because they can cause invocation, and '=' because it can cause mutation.
+    // But just to be safe, we want to reject all unexpected forms.
+
+    // We split the second stage into 4 regexp operations in order to work around
+    // crippling inefficiencies in IE's and Safari's regexp engines. First we
+    // replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+    // replace all simple value tokens with ']' characters. Third, we delete all
+    // open brackets that follow a colon or comma or that begin the text. Finally,
+    // we look to see that the remaining characters are only whitespace or ']' or
+    // ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+                if (/^[\],:{}\s]*$/
+                        .test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+                            .replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+                            .replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+
+    // In the third stage we use the eval function to compile the text into a
+    // JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+    // in JavaScript: it can begin a block or an object literal. We wrap the text
+    // in parens to eliminate the ambiguity.
+
+                    j = eval('(' + text + ')');
+
+    // In the optional fourth stage, we recursively walk the new structure, passing
+    // each name/value pair to a reviver function for possible transformation.
+
+                    return typeof reviver === 'function'
+                        ? walk({'': j}, '')
+                        : j;
+                }
+
+    // If the text is not JSON parseable, then a SyntaxError is thrown.
+
+                throw new SyntaxError('JSON.parse');
+            };
+        }
+    }());
+
+
   </script>
   <![endif]-->
   <!--[if IE 8]><link href="https://assets.publishing.service.gov.uk/static/fonts-ie8.css" media="all" rel="stylesheet" />
@@ -25,12 +518,1215 @@
   <link href="https://assets.publishing.service.gov.uk/static/fonts.css" media="all" rel="stylesheet"><!--<![endif]-->
   <!--[if gt IE 8]><!-->
   <style>
-    /* inline CSS here for >= IE9 */
-  </style>
+    #global-header .header-wrapper .header-global .header-logo:after,#global-header .header-wrapper .header-global:after,#global-header .header-wrapper:after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+
+    #footer .footer-wrapper,#global-header-bar {
+      max-width: 960px;
+      margin: 0 15px;
+    }
+
+    @-ms-viewport {
+      width:device-width;
+    }
+
+    html {
+      font-family: "nta",Arial,sans-serif;
+    }
+
+    body,div,footer,h1,h2,header,html,nav {
+      vertical-align: baseline;
+    }
+
+    .group:after,.group:before {
+      content: "\0020";
+      display: block;
+      height: 0;
+      overflow: hidden;
+    }
+
+    .group:after {
+      clear: both;
+    }
+
+    .group {
+      zoom: 1;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      background-color: #dee0e2;
+      -ms-overflow-style: scrollbar;
+      overflow-y: scroll;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    body {
+      background: #fff;
+      color: #0b0c0c;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    a:link {
+      color: #005ea5;
+    }
+
+    a:visited {
+      color: #4c2c92;
+    }
+
+    a:active,a:hover {
+      color: #2b8cc4;
+    }
+
+    strong {
+      font-weight: 600;
+    }
+
+    .hidden {
+      display: none;
+      visibility: hidden;
+    }
+
+    .visuallyhidden {
+      position: absolute;
+      left: -9999em;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    a {
+      -webkit-tap-highlight-color: rgba(0,0,0,.3);
+    }
+
+    a:focus {
+      background-color: #ffbf47;
+      outline: 3px solid #ffbf47;
+    }
+
+    .skiplink {
+      position: absolute;
+      left: -9999em;
+    }
+
+    #global-header a:focus,.skiplink:focus,.skiplink:visited {
+      color: #0b0c0c;
+    }
+
+    .skiplink:focus {
+      left: 0;
+      z-index: 1;
+    }
+
+    #skiplink-container {
+      text-align: center;
+      background: #0b0c0c;
+    }
+
+    #skiplink-container div {
+      text-align: left;
+      margin: 0 auto;
+      max-width: 1020px;
+    }
+
+    #skiplink-container .skiplink {
+      display: -moz-inline-stack;
+      display: inline-block;
+      margin: .75em 0 0 30px;
+    }
+
+    #global-header {
+      background-color: #0b0c0c;
+      width: 100%;
+    }
+
+    #global-header .header-wrapper {
+      background-color: #0b0c0c;
+      max-width: 990px;
+      margin: 0 auto;
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+
+    #global-header .header-wrapper .header-global .header-logo {
+      float: left;
+      margin-top: 2px;
+    }
+
+    #global-header .header-wrapper .header-global .header-logo .content,#global-header.with-proposition .header-wrapper .header-proposition .content {
+      margin: 0 15px;
+    }
+
+    #global-header #logo {
+      float: left;
+      overflow: visible;
+      color: #fff;
+      font-weight: 700;
+      font-size: 30px;
+      line-height: 1;
+      text-decoration: none;
+      text-rendering: optimizeLegibility;
+      border-bottom: 1px solid transparent;
+      background: url(https://assets.publishing.service.gov.uk/static/images/gov.uk_logotype_crown.png?0.19.2) no-repeat;
+      background-size: 36px 32px;
+      background-position: 0 0;
+    }
+
+    #global-header #logo img {
+      margin: 2px 1px 0 0;
+      vertical-align: bottom;
+      visibility: hidden;
+    }
+
+    #global-header #logo:focus,#global-header #logo:hover {
+      text-decoration: none;
+      border-bottom-color: #fff;
+    }
+
+    #global-header .header-proposition {
+      padding-top: 10px;
+    }
+
+    #global-header .header-proposition #proposition-name {
+      font-family: "nta",Arial,sans-serif;
+      text-transform: none;
+      font-size: 18px;
+      line-height: 1.2;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+    }
+
+    #global-header .header-proposition a#proposition-name:hover {
+      text-decoration: underline;
+    }
+
+    #global-header .header-proposition #proposition-menu {
+      margin-top: 5px;
+    }
+
+    #global-header-bar {
+      height: 10px;
+      background-color: #005ea5;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul,#footer h2 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 14px;
+    }
+
+    #footer {
+      background-color: #dee0e2;
+      border-top: 1px solid #a1acb2;
+    }
+
+    #footer .footer-wrapper {
+      background-color: #dee0e2;
+      padding-top: 20px;
+    }
+
+    #footer a {
+      color: #454a4c;
+    }
+
+    #footer a:hover {
+      color: #171819;
+    }
+
+    #footer h2 {
+      font-size: 18px;
+      line-height: 1.2;
+      font-weight: 700;
+      color: #0b0c0c;
+      margin: 0;
+    }
+
+    #footer .footer-meta {
+      padding-bottom: 60px;
+      clear: both;
+      font-size: 0;
+      color: #454a4c;
+    }
+
+    #footer .footer-meta .footer-meta-inner {
+      display: inline-block;
+      vertical-align: bottom;
+      width: 100%;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul {
+      line-height: 1.5;
+      display: inline-block;
+      list-style: none;
+      margin: 0 0 1.5em;
+      padding: 0;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul li {
+      display: inline-block;
+      margin: 0 15px 0 0;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence {
+      clear: left;
+      position: relative;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence .logo {
+      margin-bottom: 1em;
+      padding-top: 0;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
+      display: block;
+      width: 41px;
+      height: 17px;
+      overflow: hidden;
+      text-indent: -999em;
+      background: url(https://assets.publishing.service.gov.uk/static/images/open-government-licence.png?0.19.2) 0 0 no-repeat;
+    }
+
+    #footer .footer-meta .copyright,#footer .footer-meta .footer-meta-inner .open-government-licence p {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 14px;
+      line-height: 1.14286;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence p {
+      padding-top: .1em;
+      margin: 0;
+    }
+
+    #footer .footer-meta .copyright {
+      margin: 30px 0 0;
+      width: 100%;
+      display: block;
+    }
+
+    #footer .footer-meta .copyright a {
+      display: block;
+      background-image: url(https://assets.publishing.service.gov.uk/static/images/govuk-crest.png?0.19.2);
+      background-repeat: no-repeat;
+      background-position: 50% 0%;
+      text-align: center;
+      text-decoration: none;
+      padding: 115px 0 0;
+    }
+
+    #footer .footer-categories .footer-about,#footer .footer-categories .footer-buyers,#footer .footer-categories .footer-suppliers,.column-two-thirds {
+      padding: 0 15px;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+
+    .page-heading-smaller {
+      margin: 15px 0;
+    }
+
+    .page-heading-smaller h1 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      text-transform: none;
+      font-size: 32px;
+      line-height: 1.09375;
+    }
+
+    .page-heading-smaller h1 {
+      font-size: 24px;
+      line-height: 1.04167;
+    }
+
+    .phase-banner {
+      padding: 10px 0 8px;
+      border-bottom: 1px solid #bfc1c3;
+    }
+
+    .phase-banner p {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+    }
+
+    .phase-banner p {
+      display: table;
+      margin: 0;
+      color: #000;
+      font-size: 14px;
+      line-height: 1.14286;
+    }
+
+    .phase-banner .phase-tag,.phase-tag {
+      display: -moz-inline-stack;
+      display: inline-block;
+      margin: 0 8px 0 0;
+      padding: 2px 5px 0;
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      font-size: 14px;
+      line-height: 1.14286;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      text-decoration: none;
+      color: #fff;
+      background-color: #005ea5;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence p {
+      padding-bottom: 0;
+    }
+
+    #wrapper {
+      padding-bottom: 60px;
+    }
+
+    a,div,footer,h1,h2,header,html,img,li,main,nav,p,strong,ul {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+    }
+
+    body {
+      padding: 0;
+      border: 0;
+    }
+
+    main {
+      display: block;
+    }
+
+    ul {
+      list-style: none;
+    }
+
+    body {
+      margin: 0;
+    }
+
+    .error-page,body {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 16px;
+      line-height: 1.25;
+    }
+
+    .error-page p {
+      padding-bottom: 10px;
+    }
+
+    #wrapper,.phase-banner {
+      max-width: 960px;
+      margin: 0 15px;
+    }
+
+    #footer .footer-categories,#footer .footer-meta,.grid-row {
+      margin: 0 -15px;
+    }
+
+    #footer .footer-categories h2 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      text-transform: none;
+    }
+
+    #footer .footer-categories h2 {
+      padding: 10px 0 0;
+      border-bottom: none;
+      font-size: 16px;
+      line-height: 1.25;
+      margin: 0;
+    }
+
+    #footer .footer-categories ul li {
+      display: block;
+      padding: 10px 0 0;
+      margin: 0 15px 5px 0;
+    }
+
+    #footer .footer-categories hr {
+      clear: both;
+      margin: 30px 0;
+      border: 1px solid #bfc1c3;
+      border-width: 1px 0 0;
+    }
+
+    #footer .footer-meta {
+      padding-left: 15px;
+      padding-right: 15px;
+      font-size-adjust: none;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence p a {
+      font-size: 16px;
+    }
+
+    #footer .footer-categories ul {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 14px;
+      line-height: 1.14286;
+    }
+
+    #footer .footer-categories ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    #footer .footer-categories:after,#footer .footer-meta:after,.grid-row:after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+
+    @media (min-width:641px) {
+      #footer .footer-wrapper,#global-header-bar {
+        margin: 0 30px;
+      }
+
+      #global-header .header-wrapper {
+        padding-left: 15px;
+        padding-right: 15px;
+      }
+
+      #footer h2,#global-header .header-proposition #proposition-name {
+        font-size: 24px;
+        line-height: 1.25;
+      }
+
+      #footer .footer-meta .footer-meta-inner .open-government-licence p {
+        font-size: 16px;
+        line-height: 1.25;
+      }
+
+      #footer .footer-wrapper {
+        padding-top: 60px;
+      }
+
+      #footer .footer-meta .footer-meta-inner {
+        width: 75%;
+      }
+
+      #footer .footer-meta .footer-meta-inner ul {
+        font-size: 16px;
+        line-height: 1.5;
+        margin: 0 0 1em;
+      }
+
+      #footer .footer-meta .footer-meta-inner .open-government-licence {
+        padding-left: 53px;
+      }
+
+      #footer .footer-meta .footer-meta-inner .open-government-licence .logo {
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 41px;
+        height: 100%;
+      }
+
+      #footer .footer-meta .copyright {
+        font-size: 16px;
+        line-height: 1.25;
+        display: inline-block;
+        text-align: inherit;
+        width: 25%;
+        padding-top: 15px;
+        margin-top: 0;
+      }
+
+      #footer .footer-meta .copyright a {
+        background-position: 100% 0%;
+        text-align: right;
+      }
+
+      .phase-banner p {
+        font-size: 16px;
+        line-height: 1.25;
+      }
+
+      #footer .footer-categories .footer-about,#footer .footer-categories .footer-buyers,#footer .footer-categories .footer-suppliers {
+        float: left;
+        width: 33.33333%;
+      }
+
+      .column-two-thirds {
+        float: left;
+        width: 66.66667%;
+      }
+
+      .page-heading-smaller {
+        margin: 45px 0;
+      }
+
+      .page-heading-smaller h1 {
+        font-size: 36px;
+        line-height: 1.11111;
+      }
+
+      .phase-banner {
+        padding-bottom: 10px;
+      }
+
+      .phase-banner .phase-tag,.phase-tag {
+        font-size: 16px;
+        line-height: 1.25;
+      }
+
+      #footer .footer-categories ul {
+        font-size: 16px;
+        line-height: 1.25;
+      }
+
+      #footer .footer-categories ul {
+        margin-top: 15px;
+      }
+
+      #footer .footer-categories h2,.error-page,body {
+        font-size: 19px;
+        line-height: 1.31579;
+      }
+
+      #wrapper,.phase-banner {
+        margin: 0 30px;
+      }
+
+      #footer .footer-categories .footer-about,#footer .footer-categories .footer-buyers,#footer .footer-categories .footer-suppliers {
+        padding-bottom: 60px;
+      }
+
+      #footer .footer-categories h2 {
+        padding: 0 0 20px;
+        border-bottom: 1px solid #a1acb2;
+      }
+
+      #footer .footer-categories ul li {
+        padding: 15px 0 0;
+        margin: 0 15px 0 0;
+      }
+
+      #footer .footer-categories hr {
+        margin-top: 0;
+      }
+
+      #footer .footer-meta {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+
+    @media (min-width:769px) {
+      #global-header .header-wrapper .header-global .header-logo {
+        width: 33.33%;
+      }
+
+      #global-header.with-proposition .header-wrapper .header-global {
+        float: left;
+        width: 33.33%;
+      }
+
+      #global-header.with-proposition .header-wrapper .header-global .header-logo {
+        width: 100%;
+      }
+
+      #global-header.with-proposition .header-wrapper .header-proposition {
+        width: 66.66%;
+        float: left;
+      }
+
+      #global-header .header-proposition {
+        padding-top: 0;
+      }
+    }
+
+    @media (min-width:1020px) {
+      #footer .footer-wrapper,#global-header-bar,#wrapper,.phase-banner {
+        margin: 0 auto;
+      }
+    }
+
+    @media screen and (max-width:379px) {
+      #global-header .header-wrapper .header-global .header-logo {
+        width: auto;
+        float: none;
+      }
+    }
+
+    @media only screen and (-webkit-min-device-pixel-ratio:2),only screen and (min--moz-device-pixel-ratio:2),only screen and (-o-min-device-pixel-ratio:20/10),only screen and (min-device-pixel-ratio:2),only screen and (min-resolution:192dpi),only screen and (min-resolution:2dppx) {
+      #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
+        background-image: url(https://assets.publishing.service.gov.uk/static/images/open-government-licence_2x.png?0.19.2);
+        background-size: 41px 17px;
+      }
+
+      #footer .footer-meta .copyright a {
+        background-image: url(https://assets.publishing.service.gov.uk/static/images/govuk-crest-2x.png?0.19.2);
+        background-size: 125px 102px;
+      }
+    }
+    </style>
   <!--<![endif]-->
   <!--[if IE 8]>
   <style>
-    /* inline CSS here for < IE9 */
+    #global-header .header-wrapper .header-global .header-logo:after,#global-header .header-wrapper .header-global:after,#global-header .header-wrapper:after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+
+    #footer .footer-wrapper,#global-header-bar {
+      max-width: 960px;
+      width: 960px;
+      margin: 0 auto;
+    }
+
+    @-ms-viewport {
+      width:device-width;
+    }
+
+    html {
+      font-family: "nta",Arial,sans-serif;
+    }
+
+    body,div,footer,h1,h2,header,html,nav {
+      vertical-align: baseline;
+    }
+
+    .group:after,.group:before {
+      content: "\0020";
+      display: block;
+      height: 0;
+      overflow: hidden;
+    }
+
+    .group:after {
+      clear: both;
+    }
+
+    .group {
+      zoom: 1;
+    }
+
+    html {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+      background-color: #dee0e2;
+      -ms-overflow-style: scrollbar;
+      overflow-y: scroll;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    body {
+      background: #fff;
+      color: #0b0c0c;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    a:link {
+      color: #005ea5;
+    }
+
+    a:visited {
+      color: #4c2c92;
+    }
+
+    a:active,a:hover {
+      color: #2b8cc4;
+    }
+
+    strong {
+      font-weight: 600;
+    }
+
+    .hidden {
+      display: none;
+      visibility: hidden;
+    }
+
+    .visuallyhidden {
+      position: absolute;
+      left: -9999em;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    a {
+      -webkit-tap-highlight-color: rgba(0,0,0,.3);
+    }
+
+    a:focus {
+      background-color: #ffbf47;
+      outline: 3px solid #ffbf47;
+    }
+
+    .skiplink {
+      position: absolute;
+      left: -9999em;
+    }
+
+    #global-header a:focus,.skiplink:focus,.skiplink:visited {
+      color: #0b0c0c;
+    }
+
+    .skiplink:focus {
+      left: 0;
+      z-index: 1;
+    }
+
+    #skiplink-container {
+      text-align: center;
+      background: #0b0c0c;
+    }
+
+    #skiplink-container div {
+      text-align: left;
+      margin: 0 auto;
+      max-width: 1020px;
+    }
+
+    #skiplink-container .skiplink {
+      display: -moz-inline-stack;
+      display: inline-block;
+      margin: .75em 0 0 30px;
+    }
+
+    #global-header {
+      background-color: #0b0c0c;
+      width: 100%;
+    }
+
+    #global-header .header-wrapper {
+      background-color: #0b0c0c;
+      max-width: 990px;
+      margin: 0 auto;
+      padding: 8px 15px;
+      width: 990px;
+    }
+
+    #global-header .header-wrapper .header-global .header-logo {
+      float: left;
+      width: 33.33%;
+      margin-top: 2px;
+    }
+
+    #global-header .header-wrapper .header-global .header-logo .content {
+      margin: 0 15px;
+    }
+
+    #global-header.with-proposition .header-wrapper .header-global {
+      float: left;
+      width: 33.33%;
+    }
+
+    #global-header.with-proposition .header-wrapper .header-global .header-logo {
+      width: 100%;
+    }
+
+    #global-header.with-proposition .header-wrapper .header-proposition {
+      width: 66.66%;
+      float: left;
+    }
+
+    #global-header.with-proposition .header-wrapper .header-proposition .content {
+      margin: 0 15px;
+    }
+
+    #global-header #logo {
+      float: left;
+      overflow: visible;
+      color: #fff;
+      font-weight: 700;
+      font-size: 30px;
+      line-height: 1;
+      text-decoration: none;
+      text-rendering: optimizeLegibility;
+      border-bottom: 1px solid transparent;
+      background: url(https://assets.publishing.service.gov.uk/static/images/gov.uk_logotype_crown.png?0.19.2) no-repeat;
+      background-size: 36px 32px;
+      background-position: 0 0;
+      background-image: url(https://assets.publishing.service.gov.uk/static/images/gov.uk_logotype_crown-1x.png?0.19.2);
+    }
+
+    #global-header #logo img {
+      margin: 2px 1px 0 0;
+      vertical-align: bottom;
+      visibility: hidden;
+    }
+
+    #global-header #logo:focus,#global-header #logo:hover {
+      text-decoration: none;
+      border-bottom-color: #fff;
+    }
+
+    #global-header .header-proposition {
+      padding-top: 0;
+    }
+
+    #global-header .header-proposition #proposition-name {
+      font-family: "nta",Arial,sans-serif;
+      text-transform: none;
+      font-size: 24px;
+      line-height: 1.25;
+      font-weight: 700;
+      color: #fff;
+      text-decoration: none;
+    }
+
+    #global-header .header-proposition a#proposition-name:hover {
+      text-decoration: underline;
+    }
+
+    #global-header .header-proposition #proposition-menu {
+      margin-top: 5px;
+    }
+
+    #global-header-bar {
+      height: 10px;
+      background-color: #005ea5;
+      font-size: 0;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul,#footer h2 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 16px;
+    }
+
+    #footer {
+      background-color: #dee0e2;
+      border-top: 1px solid #a1acb2;
+    }
+
+    #footer .footer-wrapper {
+      background-color: #dee0e2;
+      padding-top: 60px;
+    }
+
+    #footer a {
+      color: #454a4c;
+    }
+
+    #footer a:hover {
+      color: #171819;
+    }
+
+    #footer h2 {
+      font-size: 24px;
+      line-height: 1.25;
+      font-weight: 700;
+      color: #0b0c0c;
+      margin: 0;
+    }
+
+    #footer .footer-meta {
+      padding-bottom: 60px;
+      clear: both;
+      font-size: 0;
+      color: #454a4c;
+    }
+
+    #footer .footer-meta .footer-meta-inner {
+      display: inline-block;
+      vertical-align: bottom;
+      width: 75%;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul {
+      line-height: 1.5;
+      display: inline-block;
+      list-style: none;
+      padding: 0;
+      margin: 0 0 1em;
+    }
+
+    #footer .footer-meta .footer-meta-inner ul li {
+      display: inline-block;
+      margin: 0 15px 0 0;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence {
+      clear: left;
+      position: relative;
+      padding-left: 53px;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence .logo {
+      margin-bottom: 1em;
+      padding-top: 0;
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 41px;
+      height: 100%;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
+      display: block;
+      width: 41px;
+      height: 17px;
+      overflow: hidden;
+      text-indent: -999em;
+      background: url(https://assets.publishing.service.gov.uk/static/images/open-government-licence.png?0.19.2) 0 0 no-repeat;
+    }
+
+    #footer .footer-meta .copyright,#footer .footer-meta .footer-meta-inner .open-government-licence p {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 16px;
+      line-height: 1.25;
+      margin: 0;
+      padding-top: .1em;
+    }
+
+    #footer .footer-meta .copyright {
+      display: inline-block;
+      text-align: inherit;
+      width: 25%;
+      padding-top: 15px;
+    }
+
+    #footer .footer-meta .copyright a {
+      display: block;
+      background-image: url(https://assets.publishing.service.gov.uk/static/images/govuk-crest.png?0.19.2);
+      background-repeat: no-repeat;
+      background-position: 100% 0%;
+      text-decoration: none;
+      text-align: right;
+      padding: 115px 0 0;
+    }
+
+    .column-two-thirds {
+      float: left;
+      width: 100%;
+      padding: 0 15px;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+
+    .column-two-thirds {
+      width: 50%;
+    }
+
+    .column-two-thirds {
+      width: 33.33333%;
+    }
+
+    .column-two-thirds {
+      width: 66.66667%;
+    }
+
+    .page-heading-smaller {
+      margin: 45px 0;
+    }
+
+    .page-heading-smaller h1 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      text-transform: none;
+      font-size: 48px;
+      line-height: 1.04167;
+    }
+
+    .page-heading-smaller h1 {
+      font-size: 36px;
+      line-height: 1.11111;
+    }
+
+    .phase-banner {
+      padding: 10px 0;
+      border-bottom: 1px solid #bfc1c3;
+    }
+
+    .phase-banner p {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+    }
+
+    .phase-banner p {
+      display: table;
+      margin: 0;
+      color: #000;
+      font-size: 16px;
+      line-height: 1.25;
+    }
+
+    .phase-banner .phase-tag,.phase-tag {
+      display: -moz-inline-stack;
+      display: inline-block;
+      margin: 0 8px 0 0;
+      padding: 2px 5px 0;
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      font-size: 16px;
+      line-height: 1.25;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      text-decoration: none;
+      color: #fff;
+      background-color: #005ea5;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence p {
+      padding-bottom: 0;
+    }
+
+    #wrapper {
+      padding-bottom: 60px;
+    }
+
+    a,div,footer,h1,h2,header,html,img,li,main,nav,p,strong,ul {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+    }
+
+    body {
+      padding: 0;
+      border: 0;
+    }
+
+    main {
+      display: block;
+    }
+
+    ul {
+      list-style: none;
+    }
+
+    body {
+      margin: 0;
+    }
+
+    .error-page,body {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 400;
+      text-transform: none;
+      font-size: 19px;
+      line-height: 1.31579;
+    }
+
+    .error-page p {
+      padding-bottom: 10px;
+    }
+
+    #footer .footer-categories ul {
+      font-family: "nta",Arial,sans-serif;
+      list-style: none;
+    }
+
+    #wrapper,.phase-banner {
+      max-width: 960px;
+      width: 960px;
+      margin: 0 auto;
+    }
+
+    #footer .footer-categories,#footer .footer-meta,.grid-row {
+      margin: 0 -15px;
+    }
+
+    #footer .footer-categories .footer-about,#footer .footer-categories .footer-buyers,#footer .footer-categories .footer-suppliers {
+      float: left;
+      width: 33.33333%;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      padding: 0 15px 60px;
+    }
+
+    #footer .footer-categories h2 {
+      font-family: "nta",Arial,sans-serif;
+      font-weight: 700;
+      text-transform: none;
+    }
+
+    #footer .footer-categories h2 {
+      padding: 0 0 20px;
+      border-bottom: 1px solid #a1acb2;
+      font-size: 19px;
+      line-height: 1.31579;
+      margin: 0;
+    }
+
+    #footer .footer-categories ul {
+      padding: 0;
+      margin: 15px 0 0;
+    }
+
+    #footer .footer-categories ul li {
+      display: block;
+      padding: 15px 0 0;
+      margin: 0 15px 0 0;
+    }
+
+    #footer .footer-categories hr {
+      clear: both;
+      border: 1px solid #bfc1c3;
+      border-width: 1px 0 0;
+      margin: 0 0 30px;
+    }
+
+    #footer .footer-meta {
+      padding-left: 0;
+      padding-right: 0;
+      font-size-adjust: none;
+    }
+
+    #footer .footer-meta .footer-meta-inner .open-government-licence p a {
+      font-size: 16px;
+    }
+
+    #footer .footer-categories ul {
+      font-weight: 400;
+      text-transform: none;
+      font-size: 16px;
+      line-height: 1.25;
+    }
+
+    #footer .footer-categories:after,#footer .footer-meta:after,.grid-row:after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+
+    @media screen and (max-width:379px) {
+      #global-header .header-wrapper .header-global .header-logo {
+        width: auto;
+        float: none;
+      }
+    }
+
+    @media only screen and (-webkit-min-device-pixel-ratio:2),only screen and (min--moz-device-pixel-ratio:2),only screen and (-o-min-device-pixel-ratio:20/10),only screen and (min-device-pixel-ratio:2),only screen and (min-resolution:192dpi),only screen and (min-resolution:2dppx) {
+      #footer .footer-meta .footer-meta-inner .open-government-licence .logo a {
+        background-image: url(https://assets.publishing.service.gov.uk/static/images/open-government-licence_2x.png?0.19.2);
+        background-size: 41px 17px;
+      }
+
+      #footer .footer-meta .copyright a {
+        background-image: url(https://assets.publishing.service.gov.uk/static/images/govuk-crest-2x.png?0.19.2);
+        background-size: 125px 102px;
+      }
+    }
   </style>
   <![endif]-->
 </head>

--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -5,63 +5,55 @@
 <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  <title>Page could not be found - Digital Marketplace</title><!--[if gt IE 8]><!-->
-  <link href="/static/stylesheets/govuk-template.css?0.19.2" media="screen" rel="stylesheet"><!--<![endif]-->
-  <!--[if IE 6]><link href="/static/stylesheets/govuk-template-ie6.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
-  <!--[if IE 7]><link href="/static/stylesheets/govuk-template-ie7.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
-  <!--[if IE 8]><link href="/static/stylesheets/govuk-template-ie8.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
-  <link href="/static/stylesheets/govuk-template-print.css?0.19.2" media="print" rel="stylesheet"><!--[if IE 8]><link href="/static/stylesheets/fonts-ie8.css?0.19.2" media="all" rel="stylesheet" /><![endif]-->
-  <!--[if gte IE 9]><!-->
-  <link href="/static/stylesheets/fonts.css?0.19.2" media="all" rel="stylesheet"><!--<![endif]-->
-  <!--[if lt IE 9]><script src="/static/javascripts/ie.js?0.19.2"></script><![endif]-->
-  <link href="/static/images/favicon.ico?0.19.2" rel="shortcut icon" type="image/x-icon">
-  <link href="/static/images/gov.uk_logotype_crown.svg?0.19.2" rel="mask-icon">
-  <link href="/static/images/apple-touch-icon-152x152.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="152x152">
-  <link href="/static/images/apple-touch-icon-120x120.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="120x120">
-  <link href="/static/images/apple-touch-icon-76x76.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="76x76">
-  <link href="/static/images/apple-touch-icon-60x60.png?0.19.2" rel="apple-touch-icon-precomposed">
+  <title>Scheduled maintenance - Digital Marketplace</title>
+  <link href="https://assets.publishing.service.gov.uk/static/favicon.ico" rel="shortcut icon" type="image/x-icon">
+  <link href="https://assets.publishing.service.gov.uk/static/gov.uk_logotype_crown.svg" rel="mask-icon">
+  <link href="https://assets.publishing.service.gov.uk/static/apple-touch-icon-152x152.png" rel="apple-touch-icon-precomposed" sizes="152x152">
+  <link href="https://assets.publishing.service.gov.uk/static/apple-touch-icon-120x120.png" rel="apple-touch-icon-precomposed" sizes="120x120">
+  <link href="https://assets.publishing.service.gov.uk/static/apple-touch-icon-76x76.png" rel="apple-touch-icon-precomposed" sizes="76x76">
+  <link href="https://assets.publishing.service.gov.uk/static/apple-touch-icon-60x60.png" rel="apple-touch-icon-precomposed">
   <meta content="width=device-width, initial-scale=1" name="viewport">
-  <meta content="/static/images/opengraph-image.png?0.19.2" property="og:image"><!--[if gt IE 8]><!-->
-  <link href="/static/stylesheets/application.css?59cf6fbd80f1a163cb8f21d7d1128928" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
-  <!--[if IE 6]>
-  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie6.css?d5539ccd43382ed90c12a6df517d9fe1" />
-<![endif]-->
-  <!--[if IE 7]>
-  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie7.css?5fd0d14edef0b09fee7673442b5386eb" />
-<![endif]-->
+  <meta content="https://assets.publishing.service.gov.uk/static/opengraph-image.png" property="og:image">
+  <!--[if lt IE 9]>
+  <script>
+    /* inline JavaScript here for < IE9 */
+  </script>
+  <![endif]-->
+  <!--[if IE 8]><link href="https://assets.publishing.service.gov.uk/static/fonts-ie8.css" media="all" rel="stylesheet" />
+  <![endif]-->
+  <!--[if gt IE 8]><!-->
+  <link href="https://assets.publishing.service.gov.uk/static/fonts.css" media="all" rel="stylesheet"><!--<![endif]-->
+  <!--[if gt IE 8]><!-->
+  <style>
+    /* inline CSS here for >= IE9 */
+  </style>
+  <!--<![endif]-->
   <!--[if IE 8]>
-  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie8.css?0383ad0ddb694cfd8c3980433aca9dfc" />
-<![endif]-->
+  <style>
+    /* inline CSS here for < IE9 */
+  </style>
+  <![endif]-->
 </head>
 <body class="">
   <script>
-  document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   </script>
   <div id="skiplink-container">
     <div>
       <a class="skiplink" href="#content">Skip to main content</a>
     </div>
   </div>
-  <div id="global-cookie-message">
-    <p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
-  </div>
   <header class="with-proposition" id="global-header" role="banner">
     <div class="header-wrapper">
       <div class="header-global">
         <div class="header-logo">
-          <a class="content" href="https://www.gov.uk" id="logo" title="Go to the GOV.UK homepage"><img alt="" height="32" src="/static/images/gov.uk_logotype_crown_invert_trans.png?0.19.2" width="36"> GOV.UK</a>
+          <a class="content" href="https://www.gov.uk" id="logo" title="Go to the GOV.UK homepage"><img alt="" height="32" src="https://assets.publishing.service.gov.uk/static/images/gov.uk_logotype_crown.png" width="36"> GOV.UK</a>
         </div>
       </div>
       <div class="header-proposition">
         <div class="content">
-          <a class="js-header-toggle menu" href="#proposition-links">Menu</a>
           <nav id="proposition-menu">
             <a href="/" id="proposition-name">Digital Marketplace</a>
-            <ul id="proposition-links">
-              <li>
-                <a href="/login">Log in</a>
-              </li>
-            </ul>
           </nav>
         </div>
       </div>
@@ -77,10 +69,10 @@
         <div class="index-page grid-row">
           <div class="column-two-thirds">
             <header class="page-heading-smaller">
-              <h1>Page could not be found</h1>
+              <h1>Scheduled maintenance</h1>
             </header>
-            <p>Check you've entered the correct web address or start again on the Digital Marketplace homepage.</p>
-            <p>If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
+            <p>The Digital Marketplace will be unavailable for a short period of time as it undergoes scheduled maintenance.</p>
+            <p>If you require something urgently, send an email to <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.</p>
           </div>
         </div>
       </div>
@@ -108,9 +100,6 @@
             </li>
             <li>
               <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
-            </li>
-            <li>
-              <a href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
             </li>
             <li>
               <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
@@ -152,12 +141,6 @@
         <div class="footer-meta-inner">
           <h2 class="visuallyhidden">Support links</h2>
           <ul>
-            <li>
-              <a class="terms-and-conditions" href="/terms-and-conditions">Terms and conditions</a>
-            </li>
-            <li>
-              <a href="/cookies">Cookies</a>
-            </li>
             <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
             </li>
           </ul>
@@ -173,12 +156,8 @@
     </div>
   </footer>
   <div class="app-error hidden" id="global-app-error"></div>
-  <script src="/static/javascripts/govuk-template.js?0.19.2">
-  </script>
-  <script src="/static/javascripts/application.js?f7ffc21a180a33d47377be716f9e7d56" type="text/javascript">
-  </script>
   <script>
-  if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');
+    if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');
   </script>
 </body>
 </html>

--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -5,7 +5,7 @@
 <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  <title>Scheduled maintenance - Digital Marketplace</title>
+  <title>Planned maintenance - Digital Marketplace</title>
   <link href="https://assets.publishing.service.gov.uk/static/favicon.ico" rel="shortcut icon" type="image/x-icon">
   <link href="https://assets.publishing.service.gov.uk/static/gov.uk_logotype_crown.svg" rel="mask-icon">
   <link href="https://assets.publishing.service.gov.uk/static/apple-touch-icon-152x152.png" rel="apple-touch-icon-precomposed" sizes="152x152">
@@ -1774,10 +1774,10 @@
         <div class="index-page grid-row">
           <div class="column-two-thirds">
             <header class="page-heading-smaller">
-              <h1>Scheduled maintenance</h1>
+              <h1>Planned maintenance</h1>
             </header>
-            <p>The Digital Marketplace will be unavailable for a short period of time as it undergoes scheduled maintenance.</p>
-            <p>If you require something urgently, send an email to <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.</p>
+            <p>The Digital Marketplace is unavailable because of planned maintenance. It’ll be available again soon.</p>
+            <p>If you need help urgently, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a>.</p>
           </div>
         </div>
       </div>

--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -1729,6 +1729,15 @@
     }
   </style>
   <![endif]-->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-49258698-1', 'auto');
+    ga('send', 'pageview');
+  </script>
 </head>
 <body class="">
   <script>

--- a/playbooks/roles/nginx/files/maintenance.html
+++ b/playbooks/roles/nginx/files/maintenance.html
@@ -1,1 +1,184 @@
-<h1>Sorry, we're down for maintenance</h1>
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="en"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="en">
+<!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <title>Page could not be found - Digital Marketplace</title><!--[if gt IE 8]><!-->
+  <link href="/static/stylesheets/govuk-template.css?0.19.2" media="screen" rel="stylesheet"><!--<![endif]-->
+  <!--[if IE 6]><link href="/static/stylesheets/govuk-template-ie6.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
+  <!--[if IE 7]><link href="/static/stylesheets/govuk-template-ie7.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
+  <!--[if IE 8]><link href="/static/stylesheets/govuk-template-ie8.css?0.19.2" media="screen" rel="stylesheet" /><![endif]-->
+  <link href="/static/stylesheets/govuk-template-print.css?0.19.2" media="print" rel="stylesheet"><!--[if IE 8]><link href="/static/stylesheets/fonts-ie8.css?0.19.2" media="all" rel="stylesheet" /><![endif]-->
+  <!--[if gte IE 9]><!-->
+  <link href="/static/stylesheets/fonts.css?0.19.2" media="all" rel="stylesheet"><!--<![endif]-->
+  <!--[if lt IE 9]><script src="/static/javascripts/ie.js?0.19.2"></script><![endif]-->
+  <link href="/static/images/favicon.ico?0.19.2" rel="shortcut icon" type="image/x-icon">
+  <link href="/static/images/gov.uk_logotype_crown.svg?0.19.2" rel="mask-icon">
+  <link href="/static/images/apple-touch-icon-152x152.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="152x152">
+  <link href="/static/images/apple-touch-icon-120x120.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="120x120">
+  <link href="/static/images/apple-touch-icon-76x76.png?0.19.2" rel="apple-touch-icon-precomposed" sizes="76x76">
+  <link href="/static/images/apple-touch-icon-60x60.png?0.19.2" rel="apple-touch-icon-precomposed">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <meta content="/static/images/opengraph-image.png?0.19.2" property="og:image"><!--[if gt IE 8]><!-->
+  <link href="/static/stylesheets/application.css?59cf6fbd80f1a163cb8f21d7d1128928" media="screen" rel="stylesheet" type="text/css"><!--<![endif]-->
+  <!--[if IE 6]>
+  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie6.css?d5539ccd43382ed90c12a6df517d9fe1" />
+<![endif]-->
+  <!--[if IE 7]>
+  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie7.css?5fd0d14edef0b09fee7673442b5386eb" />
+<![endif]-->
+  <!--[if IE 8]>
+  <link type="text/css" rel="stylesheet" media="screen" href="/static/stylesheets/application-ie8.css?0383ad0ddb694cfd8c3980433aca9dfc" />
+<![endif]-->
+</head>
+<body class="">
+  <script>
+  document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+  <div id="skiplink-container">
+    <div>
+      <a class="skiplink" href="#content">Skip to main content</a>
+    </div>
+  </div>
+  <div id="global-cookie-message">
+    <p>GOV.UK uses cookies to make the site simpler. <a href="/cookies">Find out more about cookies</a></p>
+  </div>
+  <header class="with-proposition" id="global-header" role="banner">
+    <div class="header-wrapper">
+      <div class="header-global">
+        <div class="header-logo">
+          <a class="content" href="https://www.gov.uk" id="logo" title="Go to the GOV.UK homepage"><img alt="" height="32" src="/static/images/gov.uk_logotype_crown_invert_trans.png?0.19.2" width="36"> GOV.UK</a>
+        </div>
+      </div>
+      <div class="header-proposition">
+        <div class="content">
+          <a class="js-header-toggle menu" href="#proposition-links">Menu</a>
+          <nav id="proposition-menu">
+            <a href="/" id="proposition-name">Digital Marketplace</a>
+            <ul id="proposition-links">
+              <li>
+                <a href="/login">Log in</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div id="global-header-bar"></div>
+  <div class="phase-banner">
+    <p><strong class="phase-tag">BETA</strong> This is a <a href="https://www.gov.uk/help/beta">beta service</a> – please send your feedback to <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
+  </div>
+  <div id="wrapper">
+    <main id="content" role="main">
+      <div class="error-page">
+        <div class="index-page grid-row">
+          <div class="column-two-thirds">
+            <header class="page-heading-smaller">
+              <h1>Page could not be found</h1>
+            </header>
+            <p>Check you've entered the correct web address or start again on the Digital Marketplace homepage.</p>
+            <p>If you can't find what you're looking for, email <a href="mailto:enquiries@digitalmarketplace.service.gov.uk?subject=Digital%20Marketplace%20feedback" title="Please send feedback to enquiries@digitalmarketplace.service.gov.uk">enquiries@digitalmarketplace.service.gov.uk</a></p>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+  <footer class="group js-footer" id="footer" role="contentinfo">
+    <div class="footer-wrapper">
+      <div class="footer-categories">
+        <div class="footer-about">
+          <h2>Contact</h2>
+          <ul>
+            <li>
+              <a href="mailto:enquiries@digitalmarketplace.service.gov.uk">Digital Marketplace support</a>
+            </li>
+          </ul>
+        </div>
+        <div class="footer-buyers">
+          <h2>About the Digital Marketplace</h2>
+          <ul>
+            <li>
+              <a href="https://www.gov.uk/government/collections/digital-marketplace-buyers-and-suppliers-information">Digital Marketplace information</a>
+            </li>
+            <li>
+              <a href="https://digitalmarketplace.blog.gov.uk">Digital Marketplace blog</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/the-g-cloud-framework-on-the-digital-marketplace">G-Cloud framework</a>
+            </li>
+            <li>
+              <a href="/g-cloud/suppliers">G-Cloud supplier A–Z</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/the-crown-hosting-data-centres-framework-on-the-digital-marketplace">Crown Hosting framework</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/government/organisations/crown-commercial-service">Crown Commercial Service</a>
+            </li>
+          </ul>
+        </div>
+        <div class="footer-suppliers">
+          <h2>Guidance</h2>
+          <ul>
+            <li>
+              <a href="https://www.gov.uk/guidance/digital-marketplace-buyers-guide">Digital Marketplace buyers’ guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/digital-marketplace-suppliers-guide">Digital Marketplace suppliers’ guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/g-cloud-buyers-guide">G-Cloud buyers’ guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/g-cloud-suppliers-guide">G-Cloud suppliers’ guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-buyers-guide">Digital Outcomes and Specialists buyers’ guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/how-to-hire-user-research-labs-on-the-digital-marketplace">Digital Outcomes and Specialists user research labs buyers' guide</a>
+            </li>
+            <li>
+              <a href="https://www.gov.uk/guidance/digital-outcomes-and-specialists-suppliers-guide">Digital Outcomes and Specialists suppliers’ guide</a>
+            </li>
+          </ul>
+        </div>
+        <hr>
+      </div>
+      <div class="footer-meta">
+        <div class="footer-meta-inner">
+          <h2 class="visuallyhidden">Support links</h2>
+          <ul>
+            <li>
+              <a class="terms-and-conditions" href="/terms-and-conditions">Terms and conditions</a>
+            </li>
+            <li>
+              <a href="/cookies">Cookies</a>
+            </li>
+            <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+            </li>
+          </ul>
+          <div class="open-government-licence">
+            <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+            <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+          </div>
+        </div>
+        <div class="copyright">
+          <a href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">&copy; Crown copyright</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <div class="app-error hidden" id="global-app-error"></div>
+  <script src="/static/javascripts/govuk-template.js?0.19.2">
+  </script>
+  <script src="/static/javascripts/application.js?f7ffc21a180a33d47377be716f9e7d56" type="text/javascript">
+  </script>
+  <script>
+  if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Adding a maintenance page template that looks like [our 404 page](https://www.digitalmarketplace.service.gov.uk/sponge-avengers).

Started with the 404 page HTML and then made a bunch of small changes.  [Second commit](https://github.com/alphagov/digitalmarketplace-aws/commit/7ba21c061563f4a42a2371d62000f4a71429d38c) is probably the most interesting one. Also did some magic behind the scenes to crunch down all that CSS, but it's still gonna weigh in at ~2000 lines.  (aside: our reset CSS rules are repeated 8(!) times in our compiled `application.css`. 😱 ) 

@tracy-content's had a look at this, so I've removed the `WIP`.

## current screenshot 

![screen shot 2017-05-08 at 14 33 00](https://cloud.githubusercontent.com/assets/2454380/25806520/5e8988e0-33fb-11e7-8ce4-a0def9ddba91.png)


#### Note 

I've created a repository that does all of the CSS munging.  If you want to update the maintenance page or create more static pages with our Digital Marketplace styles, it's a good place to start.  Find it here: https://github.com/alphagov/digitalmarketplace-maintenance
