### PR TITLE
Use cf push to deploy docker images instead of local directories

### DIFF
--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -3,8 +3,6 @@
 applications:
   - name: {{ app|replace('_', '-') }}-release
     stack: cflinuxfs2
-    buildpack: python_buildpack
-    command: ./run.sh gunicorn -w 4 -b 0.0.0.0:$PORT application:application --log-file -
     routes:
       - route: {{ paas.subdomain }}-{{ environment }}.cloudapps.digital{{ paas.path|default('') }}
     instances: {{ paas.instances|default(1) }}


### PR DESCRIPTION
Updates `cf push` commands to set the docker container name when
deploying an app.

Removes command from the manifest so that it doesn't override the
docker container ENTRYPOINT.

Removes build-app, download-deployment-zip and DEPLOYMENT_DIR
related code.