### PR TITLE
Replace DB migration `inifnity` sleep with `2h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ deploy-app: ## Deploys the app to PaaS
 .PHONY: deploy-db-migration
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
-	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none -i 1 -m 128M -c 'sleep infinity'
+	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none -i 1 -m 128M -c 'sleep 2h'
 	cf run-task ${APPLICATION_NAME}-db-migration "python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 
 .PHONY: check-db-migration-task


### PR DESCRIPTION
We don't need the DB migration app to run continuously, since we're
pushing it before we run the migration task. So as long as the task
completes within the sleep period we can shut down the instance
afterwards.

2h should be more than enough to run the DB migration.