### PR TITLE
Fix docker db migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ deploy-app: ## Deploys the app to PaaS
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none -i 1 -m 128M -c 'sleep 2h'
-	cf run-task ${APPLICATION_NAME}-db-migration "python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
+	cf run-task ${APPLICATION_NAME}-db-migration "python /app/application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 
 .PHONY: check-db-migration-task
 check-db-migration-task: ## Get the status for the last db migration task

--- a/paas/manifest.j2
+++ b/paas/manifest.j2
@@ -2,7 +2,6 @@
 
 applications:
   - name: {{ app|replace('_', '-') }}-release
-    stack: cflinuxfs2
     routes:
       - route: {{ paas.subdomain }}-{{ environment }}.cloudapps.digital{{ paas.path|default('') }}
     instances: {{ paas.instances|default(1) }}


### PR DESCRIPTION
### Remove stack from default paas manifest

Setting 'stack' in the manifest makes `cf push` raise an error
(The app is invalid: Lifecycle type cannot be changed) when pushing
to a docker app that already exists.

Removing 'stack' solves the issue.

### Set the correct application.py path for db-migration task

Docker app images copy the application files to /app, but the
working directory is not set when SSH-ing into the instance or
running the CF task, so we need to specify the full path.