### PR TITLE
Set up log groups for PaaS apps

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -87,3 +87,10 @@ module "preview_elasticsearch" {
 
   nginx_security_group_id = "${module.preview_nginx.instance_security_group_id}"
 }
+
+module "application_logs" {
+  source = "../../modules/application-logs"
+
+  environment = "preview"
+  retention_in_days = "180"
+}

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -87,3 +87,10 @@ module "production_elasticsearch" {
 
   nginx_security_group_id = "${module.production_nginx.instance_security_group_id}"
 }
+
+module "application_logs" {
+  source = "../../modules/application-logs"
+
+  environment = "production"
+  retention_in_days = "3653"
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -87,3 +87,10 @@ module "staging_elasticsearch" {
 
   nginx_security_group_id = "${module.staging_nginx.instance_security_group_id}"
 }
+
+module "application_logs" {
+  source = "../../modules/application-logs"
+
+  environment = "staging"
+  retention_in_days = "180"
+}

--- a/terraform/modules/application-logs/main.tf
+++ b/terraform/modules/application-logs/main.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudwatch_log_group" "application_logs" {
+  count = 5
+  name = "${var.environment}-${element(var.app_names, count.index)}-application"
+  retention_in_days = "${var.retention_in_days}"
+}
+
+resource "aws_cloudwatch_log_group" "nginx_logs" {
+  count = 5
+  name = "${var.environment}-${element(var.app_names, count.index)}-nginx"
+  retention_in_days = "${var.retention_in_days}"
+}

--- a/terraform/modules/application-logs/variables.tf
+++ b/terraform/modules/application-logs/variables.tf
@@ -1,0 +1,6 @@
+variable "environment" {}
+variable "retention_in_days" {}
+variable "app_names" {
+  type = "list"
+  default = ["buyer-frontend", "supplier-frontend", "admin-frontend", "api", "search-api"]
+}


### PR DESCRIPTION
Trello: https://trello.com/c/FtoKj86m

When the apps are running in the PaaS, they'll produce application logs and nginx logs. We need to capture these in CloudWatch in separate log groups to aide in processing them.

This sets up the log groups in Terraform. Prod logs need to be kept for at least 10 years.