### PR TITLE
Fix production DM_ELASTICSEARCH_URL

### DIFF
--- a/paas/search-api.j2
+++ b/paas/search-api.j2
@@ -5,7 +5,7 @@
       AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
-      DM_ELASTICSEARCH_URL: https://{{ environment }}-elasticsearch:{{ elasticsearch_password }}@elasticsearch.{{ environment }}.marketplace.team
+      DM_ELASTICSEARCH_URL: https://{{ environment }}-elasticsearch:{{ elasticsearch_password }}@elasticsearch.{{ domain }}
 
       DM_SEARCH_API_AUTH_TOKENS: {{ search_api.auth_tokens|join(':') }}
 {% endblock %}


### PR DESCRIPTION
production.marketplace.team domain will not exist after the switch,
so we need to point the search api to the elasticsearch using the
actual production service domain.