### PR TITLE
Change production domain to digitalmarketplace.service.gov.uk

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -16,7 +16,7 @@ module "production_nginx" {
 
   name = "production-nginx"
   environment = "production"
-  domain = "production.marketplace.team"
+  domain = "digitalmarketplace.service.gov.uk"
 
   vpc_id = "vpc-70319115"
   subnet_ids = [

--- a/terraform/modules/elasticsearch/autoscaling.tf
+++ b/terraform/modules/elasticsearch/autoscaling.tf
@@ -96,7 +96,7 @@ ENDPOLICY
 
 resource "aws_iam_instance_profile" "elasticsearch_profile" {
   name = "${var.name}"
-  roles = ["${aws_iam_role.elasticsearch.name}"]
+  role = "${aws_iam_role.elasticsearch.name}"
 }
 
 resource "aws_iam_policy" "elasticsearch_discovery" {

--- a/terraform/modules/nginx/autoscaling.tf
+++ b/terraform/modules/nginx/autoscaling.tf
@@ -114,7 +114,7 @@ ENDPOLICY
 
 resource "aws_iam_instance_profile" "nginx_profile" {
   name = "${var.name}"
-  roles = ["${aws_iam_role.nginx_role.name}"]
+  role = "${aws_iam_role.nginx_role.name}"
 }
 
 resource "aws_security_group" "nginx_instance" {


### PR DESCRIPTION
The production state file has been updated in S3 so that the nginx route53 zone being managed by Terraform is now the original digitalmarketplace.service.gov.uk zone. This is so that when we make the switch from production.marketplace.team, we don't need to recreate the zone file and lose the name server records.

The domain is updated here to match the new zone file. The original subdomain records for api, assets etc will need to be deleted before this is applied so that Terraform can recreate them.