### PR TITLE
Open production environment for all IPs

### DIFF
--- a/paas/admin-frontend.j2
+++ b/paas/admin-frontend.j2
@@ -21,7 +21,7 @@
       DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-{{ environment }}-{{ environment }}
 
       # TODO remove once admin app is updated to use DM_DOCUMENTS_BUCKET instead
-      DM_S3_DOCUMENTS_BUCKET: digitalmarketplace-documents-{{ environment }}-{{ environment }}
+      DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-{{ environment }}-{{ environment }}
 
       DM_ASSETS_URL: https://assets.{{ domain }}
 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -39,7 +39,7 @@ module "production_nginx" {
 
   admin_user_ips = "${var.admin_user_ips}"
   dev_user_ips = "${var.dev_user_ips}"
-  user_ips = "${var.user_ips}"
+  user_ips = ["0.0.0.0/0"]
 
   g7_draft_documents_s3_url = "${var.g7_draft_documents_s3_url}"
   documents_s3_url = "${var.documents_s3_url}"


### PR DESCRIPTION
user_ips are set in common credential variables since they're the
same for all environments apart from production.

We could override the value with the production variable file, but
it making production explicitly set 0.0.0.0/0 as allowed IPs seems
more straightforward and less prone to error if the config file
load order changes for some reason.