### PR TITLE
Change PaaS production instance counts to 5 per app

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,7 +1,6 @@
 ---
 domain: "digitalmarketplace.service.gov.uk"
-instances: 3
-
+instances: 5
 
 # AWS
 


### PR DESCRIPTION
This matches the average number of production instances we had on
the AWS environment over the last month.