### PR TITLE
User email domain change to `marketplace.team`

### DIFF
--- a/dmaws/rds.py
+++ b/dmaws/rds.py
@@ -239,7 +239,7 @@ class RDSPostgresClient(object):
             bcrypt.gensalt(4)
         ).decode('utf-8')
         self.cursor.execute(
-            "UPDATE users SET name = 'Test user', email_address = id || '-user@example.com', password = '{}'"
+            "UPDATE users SET name = 'Test user', email_address = id || '@user.marketplace.team', password = '{}'"
             .format(hashed_password)
         )
 


### PR DESCRIPTION
This will mean our email addresses for our users can be added to mailchimp lists. This is important so we can run scripts that add users to mailchimp lists on our preview and staging environments.

We can no longer use @example.com to do this because mailchimp does not allow emails with this domain to be added as it affects its delivery rate (the same reason you can not subscribe a google
group to a mailchimp list under the group email).

Related trello story where we wish to add user emails to mailchimp lists: https://trello.com/c/XOCeuOYW/254-update-mailchimp-user-list-everyday