### PR TITLE
Set the basic auth header when requesting the assets 404 page

### DIFF
--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -66,6 +66,8 @@ server {
     }
 
     location /404 {
+        {{ proxy_headers () }}
+        proxy_set_header Authorization "Basic {{ app_auth }}";
         proxy_pass $buyer_frontend_url;
     }
 


### PR DESCRIPTION
"Page not found" layout for the failed assets. requests is served
from the buyer frontend, which means we need to set the auth headers
when sending the request to the CloudFoundry app.