### PR TITLE
Set PaaS api instance memory limit to 1024m

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -24,6 +24,8 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
+  memory: 1024m
+
   instance_type: t2.medium
   min_instance_count: 3
   max_instance_count: 10

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -7,6 +7,9 @@ instances: 2
 root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:acm:eu-west-1:050019655025:certificate/a0eb63fa-fdf8-4598-bae5-17d082966e0b"
 
+api:
+  memory: 1024m
+
 monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"
 


### PR DESCRIPTION
Some requests (eg framework suppliers list) get killed by uwsgi
master process when running with the 512m limit.

This brings the instance sizes closer to what we're running in
production at the moment before we can investigate the issue
further.