### PR TITLE
Add elasticsearch nginx config to maintenance mode

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -1,13 +1,14 @@
 ---
 nginx_configs:
   live:
-    - www
     - api
     - assets
-    - healthcheck
-    - elasticsearch
     - digitalservicesstore
+    - elasticsearch
+    - healthcheck
+    - www
   maintenance:
+    - elasticsearch
     - healthcheck
     - maintenance
 


### PR DESCRIPTION
Without adding the elasticsearch config we lose the connection from search-api to elasticsearch when in maintenance mode.