### PR TITLE
Stop db migration app before running the task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ deploy-app: ## Deploys the app to PaaS
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none -i 1 -m 128M -c 'sleep 2h'
+	cf stop ${APPLICATION_NAME}-db-migration
 	cf run-task ${APPLICATION_NAME}-db-migration "cd /app && python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 
 .PHONY: check-db-migration-task


### PR DESCRIPTION
With a finite sleep command db migration app keeps restarting every
N hours.

Since the CF tasks spin up a new container for the task we don't
need any application instances to keep running once the code is
pushed, we're only using the db migration app as the source of
configuration and container data.

So we should be able to stop it before running the task.