### PR TITLE
Remove nginx plaintext log group

### DIFF
--- a/playbooks/roles/cloudwatch/templates/nginx_awslogs.conf.j2
+++ b/playbooks/roles/cloudwatch/templates/nginx_awslogs.conf.j2
@@ -1,12 +1,6 @@
 [general]
 state_file = /var/awslogs/state/agent-state
 
-[nginx-access-log]
-file = /var/log/nginx/access.log
-log_group_name = {{ log_group }}
-log_stream_name = {hostname}
-datetime_format = %d/%b/%Y:%H:%M:%S %z
-
 [nginx-error-log]
 file = /var/log/nginx/error.log
 log_group_name = {{ error_log_group }}

--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -41,11 +41,6 @@ http {
 
     # Logging Settings
 
-    log_format access_txt 'nginx-access "$upstream_http_dm_request_id" $remote_addr - '
-                          '$remote_user [$time_local] "$request" $status '
-                          '$body_bytes_sent "$http_referer" "$http_user_agent" '
-                          '$request_time $http_host';
-
     log_format access_json '{"logType": "nginx-access", '
                            ' "requestId": "$upstream_http_dm_request_id", '
                            ' "remoteHost": "$remote_addr", '
@@ -59,7 +54,6 @@ http {
                            ' "requestTime": $request_time, '
                            ' "httpHost": "$http_host"}';
 
-    access_log /var/log/nginx/access.log access_txt;
     access_log /var/log/nginx/access_json.log access_json;
     error_log /var/log/nginx/error.log warn;
 

--- a/terraform/modules/nginx/autoscaling.tf
+++ b/terraform/modules/nginx/autoscaling.tf
@@ -70,7 +70,6 @@ cd /home/ubuntu/provisioning && ansible-playbook -c local -i localhost, nginx_pl
     -e admin_user_ips='${join(",", var.admin_user_ips)}' \
     -e dev_user_ips='${join(",", var.dev_user_ips)}' \
     -e user_ips='${join(",", var.user_ips)}' \
-    -e log_group='${module.logs.log_group_name}' \
     -e json_log_group='${module.json_logs.log_group_name}' \
     -e error_log_group='${module.error_logs.log_group_name}' \
     -e g7_draft_documents_s3_url='${var.g7_draft_documents_s3_url}' \

--- a/terraform/modules/nginx/main.tf
+++ b/terraform/modules/nginx/main.tf
@@ -1,11 +1,3 @@
-module "logs" {
-  source = "../log-group"
-
-  name = "${var.name}"
-  iam_role_id = "${aws_iam_role.nginx_role.id}"
-  log_retention_days = "${var.log_retention_days}"
-}
-
 module "json_logs" {
   source = "../log-group"
 


### PR DESCRIPTION
We're not storing plaintext logs for any of the other app logs, so
we can remove them from nginx as well.

JSON logs have the same data, are streamed to Kibana  and are stored
in CloudWatch for 10 years now.