### PR TITLE
Add a ci.marketplace.team DNS record for the Jenkins instance

### DIFF
--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -40,3 +40,13 @@ resource "aws_route53_record" "production_ns" {
     "ns-1915.awsdns-47.co.uk",
   ]
 }
+
+resource "aws_route53_record" "ci_marketplace_team" {
+  zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
+  name = "ci.marketplace.team"
+  type = "A"
+  ttl = "300"
+  records = [
+    "${var.jenkins_ip}"
+  ]
+}

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -1,3 +1,4 @@
+variable "jenkins_ip" {}
 variable "dev_user_ips" {
   type = "list"
 }


### PR DESCRIPTION
Moves away from the beta service domain that's not managed by
Terraform.