### PR TITLE
Bump production API instance size to 2GB

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -24,7 +24,7 @@ database:
   snapshot_id: "production-2015-07-17t1204"
 
 api:
-  memory: 1024m
+  memory: 2GB
 
   instance_type: t2.medium
   min_instance_count: 3


### PR DESCRIPTION
Getting a list of framework suppliers seems to run into the memory
limits on production.