### PR TITLE
Let Jenkins assume packer role

### DIFF
--- a/scripts/clean_docker_images.sh
+++ b/scripts/clean_docker_images.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+LATEST_IMAGE_IDS=$(docker images -a | awk '$2 == "latest" {print $3}')
+ALL_IMAGE_IDS=$(docker images -aq | sort | uniq)
+
+for image_id in $ALL_IMAGE_IDS; do
+  if ! echo $LATEST_IMAGE_IDS | grep -q -w $image_id; then
+    docker rmi $image_id 2>/dev/null
+  fi
+done

--- a/terraform/modules/iam-common/packer.tf
+++ b/terraform/modules/iam-common/packer.tf
@@ -37,7 +37,8 @@ resource "aws_iam_policy" "packer" {
       "Sid": "PackerSnapshotAccess",
       "Action": [
         "ec2:CreateSnapshot",
-        "ec2:DescribeSnapshots"
+        "ec2:DescribeSnapshots",
+        "ec2:DeleteSnapshot"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -43,6 +43,13 @@ resource "aws_iam_role_policy" "jenkins" {
       "Action": [
         "sts:AssumeRole"
       ],
+      "Resource": "arn:aws:iam::${var.aws_main_account_id}:role/packer"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
       "Resource": "arn:aws:iam::${var.aws_main_account_id}:role/sops-credentials-access"
     },
     {


### PR DESCRIPTION
As part of the process of cleaning up old AMIs, we need to delete the
snapshot that is created.

To automate the process of cleaning up AMI images, Jenkins should be
able to assume the packer role.