### PR TITLE
Bump preview and staging api memory to 2GB

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -6,6 +6,9 @@ domain: preview.marketplace.team
 root_domain: "development.digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:iam::381494870249:server-certificate/nginx-preview-preview"
 
+api:
+  memory: 2GB
+
 monitoring:
   email: "support+development-preview@digitalmarketplace.service.gov.uk"
 
@@ -20,4 +23,3 @@ subnets:
   - subnet-bf8c5ce6
   - subnet-916bfcf4
   - subnet-82dc63f5
-

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -8,7 +8,7 @@ root_domain: "digitalmarketplace.service.gov.uk"
 ssl_certificate_id: "arn:aws:acm:eu-west-1:050019655025:certificate/a0eb63fa-fdf8-4598-bae5-17d082966e0b"
 
 api:
-  memory: 1024m
+  memory: 2GB
 
 monitoring:
   email: "support+production-staging@digitalmarketplace.service.gov.uk"


### PR DESCRIPTION
Downloading the buyers user list from the admin app is still breaking
on preview and staging. Bumping to match production where it works.