### PR TITLE
Logit streaming

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -100,6 +100,7 @@ module "log_streaming" {
 
   name = "preview-log-stream-lambda"
   elasticsearch_url = "${var.logs_elasticsearch_url}"
+  elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
   log_groups = ["${concat(module.preview_nginx.json_log_groups, module.application_logs.log_groups)}"]
 }

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -28,6 +28,7 @@ variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
+variable "logs_elasticsearch_api_key" {}
 
 variable "mode" {
   default = "live"

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -100,6 +100,7 @@ module "log_streaming" {
 
   name = "production-log-stream-lambda"
   elasticsearch_url = "${var.logs_elasticsearch_url}"
+  elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
   log_groups = ["${concat(module.production_nginx.json_log_groups, module.application_logs.log_groups)}"]
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -28,6 +28,7 @@ variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
+variable "logs_elasticsearch_api_key" {}
 
 variable "mode" {
   default = "live"

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -100,6 +100,7 @@ module "log_streaming" {
 
   name = "staging-log-stream-lambda"
   elasticsearch_url = "${var.logs_elasticsearch_url}"
+  elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
   log_groups = ["${concat(module.staging_nginx.json_log_groups, module.application_logs.log_groups)}"]
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -28,6 +28,7 @@ variable "elasticsearch_auth" {}
 variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
+variable "logs_elasticsearch_api_key" {}
 
 variable "mode" {
   default = "live"

--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
   retention_in_days = 7
 }
 
+
 resource "aws_iam_role" "lambda" {
   name = "${var.name}"
   assume_role_policy = <<EOF
@@ -45,11 +46,6 @@ resource "aws_iam_role_policy" "lambda_logging" {
       "Resource": [
         "arn:aws:logs:*:*:*"
       ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": "es:ESHttpPost",
-      "Resource": "arn:aws:es:*:*:*"
     }
   ]
 }
@@ -70,6 +66,7 @@ resource "aws_lambda_function" "log_stream_lambda" {
   environment {
     variables = {
       ELASTICSEARCH_URL = "${var.elasticsearch_url}"
+      ELASTICSEARCH_API_KEY = "${var.elasticsearch_api_key}"
     }
   }
 }

--- a/terraform/modules/log-streaming/src/main.js
+++ b/terraform/modules/log-streaming/src/main.js
@@ -6,7 +6,8 @@ var https = require('https');
 var zlib = require('zlib');
 var crypto = require('crypto');
 
-var endpoint = process.env.ELASTICSEARCH_URL;
+var ENDPOINT = process.env.ELASTICSEARCH_URL;
+var API_KEY = process.env.ELASTICSEARCH_API_KEY;
 
 exports.handler = function(input, context) {
     // decode input from base64
@@ -98,12 +99,6 @@ function buildSource(message) {
         delete source[key];
     });
 
-    // Rewrite Apache logs request time to match nginx
-    if (source['requestTimeMicro']) {
-        source['requestTime'] = source['requestTimeMicro'] / 1000000;
-        delete source['requestTimeMicro'];
-    }
-
     return source;
 }
 
@@ -126,7 +121,7 @@ function isNumeric(n) {
 }
 
 function post(body, callback) {
-    var requestParams = buildRequest(endpoint, body);
+    var requestParams = buildRequest(ENDPOINT, API_KEY, body);
 
     var request = https.request(requestParams, function(response) {
         var responseBody = '';
@@ -163,71 +158,20 @@ function post(body, callback) {
     request.end(requestParams.body);
 }
 
-function buildRequest(endpoint, body) {
-    var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
-    var region = endpointParts[2];
-    var service = endpointParts[3];
+function buildRequest(endpoint, api_key, body) {
     var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
     var date = datetime.substr(0, 8);
-    var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
-    var kRegion = hmac(kDate, region);
-    var kService = hmac(kRegion, service);
-    var kSigning = hmac(kService, 'aws4_request');
 
-    var request = {
+    return {
         host: endpoint,
         method: 'POST',
         path: '/_bulk',
         body: body,
         headers: {
-            'Content-Type': 'application/json',
             'Host': endpoint,
+            'ApiKey': api_key,
+            'Content-Type': 'application/json',
             'Content-Length': Buffer.byteLength(body),
-            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
-            'X-Amz-Date': datetime
         }
     };
-
-    var canonicalHeaders = Object.keys(request.headers)
-        .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
-        .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
-        .join('\n');
-
-    var signedHeaders = Object.keys(request.headers)
-        .map(function(k) { return k.toLowerCase(); })
-        .sort()
-        .join(';');
-
-    var canonicalString = [
-        request.method,
-        request.path, '',
-        canonicalHeaders, '',
-        signedHeaders,
-        hash(request.body, 'hex'),
-    ].join('\n');
-
-    var credentialString = [ date, region, service, 'aws4_request' ].join('/');
-
-    var stringToSign = [
-        'AWS4-HMAC-SHA256',
-        datetime,
-        credentialString,
-        hash(canonicalString, 'hex')
-    ] .join('\n');
-
-    request.headers.Authorization = [
-        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
-        'SignedHeaders=' + signedHeaders,
-        'Signature=' + hmac(kSigning, stringToSign, 'hex')
-    ].join(', ');
-
-    return request;
-}
-
-function hmac(key, str, encoding) {
-    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
-}
-
-function hash(str, encoding) {
-    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
 }

--- a/terraform/modules/log-streaming/src/main.js
+++ b/terraform/modules/log-streaming/src/main.js
@@ -95,8 +95,16 @@ function buildSource(message) {
 
     var source = JSON.parse(jsonSubString);
 
-    ['time', 'remoteLogname', 'user'].forEach(function (key) {
+    ['time', 'user'].forEach(function (key) {
         delete source[key];
+    });
+
+    // Convert nested objects and arrays to strings to stop Kibana from rejecting records
+    // for missing nested keys mappings
+    Object.keys(source).forEach(function (key) {
+      if (typeof source[key] === 'object') {
+        source[key] = JSON.stringify(source[key]);
+      }
     });
 
     return source;
@@ -159,9 +167,6 @@ function post(body, callback) {
 }
 
 function buildRequest(endpoint, api_key, body) {
-    var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
-    var date = datetime.substr(0, 8);
-
     return {
         host: endpoint,
         method: 'POST',

--- a/terraform/modules/log-streaming/variables.tf
+++ b/terraform/modules/log-streaming/variables.tf
@@ -1,5 +1,6 @@
 variable "name" {}
 variable "elasticsearch_url" {}
+variable "elasticsearch_api_key" {}
 
 variable "log_groups" {
   type = "list"


### PR DESCRIPTION
### Update log streaming lambda function to stream to Logit Elasitcsearch

Removes AWS Elasitcsearch permissions and request signing logic from
the function and adds authenticaton header for Logit Elasticsearch.

### Fix log streaming errors caused by nested objects in log fields

Nested keys in log message fields are causing issues with Kibana,
especially when the field type changes between messages. Eg api_error
can be both a string message or a dictionary, which isn't valid in
Elasticsearch index mapping.

Since we don't use the nested keys for searching and filtering and
and having them mapped creates issues with log streaming we can
serialize them to JSON strings in the streaming Lambda function.

All nested objects and arrays are serialized.

#### Switch AWS environments to stream logs to Logit