### PR TITLE
Raise log streaming lambda function timeout to 10s

### DIFF
--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "log_stream_lambda" {
   handler = "main.handler"
   runtime = "nodejs6.10"
   memory_size = 128
-  timeout = 5
+  timeout = 10
 
   environment {
     variables = {


### PR DESCRIPTION
We've seen some occasional (a few per day) timeouts on the log
streaming lambda functions likely caused by slow Elasticsearch
responses.

Raising the timeout value from 5s to 10s might help reduce the number
of failed runs. We don't want a very high timeout value since if
Elasticsearch at any point starts to respond to requests very slowly
our functions will spend more time waiting which can very quickly
raise the AWS Lambda costs.