### PR TITLE
Add make steps to dump and restore Kibana configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ user.yml
 venv
 /tmp
 .envrc
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There are a few independent tools we're using that are configured and run from t
 * `dmaws` contains some helper python functions used by some of the scripts
 * `paas` contains PaaS manifest templates that are rendered by `make generate-manifest`
 * `vars` contains environment specific variables used in the PaaS manifest generation
+* `kibana` contains a Makefile and dependencies list for managing Kibana configuration
 
 ## Setup
 
@@ -60,22 +61,17 @@ removed and the AutoScaling groups will no longer be able to scale.
 AMIs can be deleted from the EC2 console by deregestering the AMI and
 deleting the related EBS snapshot.
 
-## Deploying AWS Lambda functions
+## Managing Kibana configuration
 
-Lambda functions are created by the CloudFormation stack, but rerunning the stack won't updated
-the function code. Instead, functions can be updating using the `lambda-release` command:
+`kibana/Makefile` contains make steps to manage Kibana configs.
 
-```
-dmaws lambda-release preview cloudwatch_logs_lambda
-```
+`make dump STAGE=...` will download Kibana index (including mapping, saved searches, visualizations
+and dashboards) and store them in `kibana-export.json`.
 
-This will package function code from `lambdas/cloudwatch_logs`, upload the archive to S3 and update
-the function code in AWS Lambda.
+`make restore STAGE=...` uploads configuration from `kibana-export.json` to the target STAGE stack
+and replaces any settings that were there before.
 
-This command can also be used to upload the initial function code archive to S3 before running the
-function stack for the first time. In this case, updating the function code will fail, since the
-function doesn't exist yet, but an archive will be uploaded to S3 and CloudFormation will use it
-when creating the function stack.
+Both commands use credentials from terraform files, so they need `sops` profile to be active.
 
 ## SSHing into instances
 

--- a/kibana/Makefile
+++ b/kibana/Makefile
@@ -1,0 +1,30 @@
+SHELL := /bin/bash
+
+.PHONY: requirements
+requirements:
+	npm install
+
+.PHONY: elasticsearch-url
+elasticsearch-url:
+	jq -r '.logs_elasticsearch_url' <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/terraform/environments/${STAGE}.json)
+
+
+.PHONY: elasticsearch-auth
+elasticsearch-auth:
+	jq '{ApiKey: .logs_elasticsearch_api_key}' <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/terraform/environments/${STAGE}.json)
+
+.PHONY: dump
+dump:
+	$(if ${STAGE},,$(error Must specify STAGE))
+	./node_modules/elasticdump/bin/elasticdump \
+	    --input https://$$(make -s elasticsearch-url)/.kibana \
+	    --headers "$$(make -s elasticsearch-auth)" \
+	    --output kibana-export.json
+
+.PHONY: restore
+restore:
+	$(if ${STAGE},,$(error Must specify STAGE))
+	./node_modules/elasticdump/bin/elasticdump \
+	    --output https://$$(make -s elasticsearch-url)/.kibana \
+	    --headers "$$(make -s elasticsearch-auth)" \
+	    --input kibana-export.json

--- a/kibana/package.json
+++ b/kibana/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "elasticdump": "^3.3.1"
+  },
+  "devDependencies": {}
+}


### PR DESCRIPTION
`make dump STAGE=...` downloads Kibana index from a specified stage stack
and stores the output in `kibana-export.json`.

`make restore STAGE=...` replaces target stack Kibana index with data
from `kibana-export.json`.