### PR TITLE
Add briefs frontend

### DIFF
--- a/paas/briefs-frontend.j2
+++ b/paas/briefs-frontend.j2
@@ -1,0 +1,17 @@
+{% extends "_base.j2" %}
+
+{% block env %}
+
+      AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
+      AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
+
+      DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
+      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
+
+      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+
+      PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
+
+      SECRET_KEY: {{ shared_tokens.password_key }}
+      SHARED_EMAIL_KEY: {{ shared_tokens.shared_email_key }}
+{% endblock %}

--- a/playbooks/roles/nginx/templates/assets.j2
+++ b/playbooks/roles/nginx/templates/assets.j2
@@ -11,7 +11,7 @@ server {
 
     set $documents_s3_url "{{ documents_s3_url }}";
     set $g7_draft_documents_s3_url "{{ g7_draft_documents_s3_url }}";
-    set $buyer_frontend_url "{{ buyer_frontend_url }}";
+    set $frontend_url "{{ frontend_url }}";
     set $agreements_s3_url "{{ agreements_s3_url }}";
     set $communications_s3_url "{{ communications_s3_url }}";
     set $submissions_s3_url "{{ submissions_s3_url }}";
@@ -68,10 +68,10 @@ server {
     location /404 {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
-        proxy_pass $buyer_frontend_url;
+        proxy_pass $frontend_url;
     }
 
     location /static {
-        proxy_pass $buyer_frontend_url;
+        proxy_pass $frontend_url;
     }
 }

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -8,9 +8,7 @@ server {
     {% endfor %}
     deny all;
 
-    set $buyer_frontend_url "{{ buyer_frontend_url }}";
-    set $admin_frontend_url "{{ admin_frontend_url }}";
-    set $supplier_frontend_url "{{ supplier_frontend_url }}";
+    set $frontend_url "{{ frontend_url }}";
 
     location /robots.txt {
         alias {{ static_files_root }}/robots_www.txt;
@@ -20,9 +18,9 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass $buyer_frontend_url;
+        proxy_pass $frontend_url;
     }
-
+    
     location /admin {
         {% for admin_ip in admin_user_ips.split(",") %}
         allow {{ admin_ip }};
@@ -32,13 +30,6 @@ server {
         {{ proxy_headers () }}
         proxy_set_header Authorization "Basic {{ app_auth }}";
 
-        proxy_pass $admin_frontend_url;
-    }
-
-    location ~ ^/suppliers(/|$) {
-        {{ proxy_headers () }}
-        proxy_set_header Authorization "Basic {{ app_auth }}";
-
-        proxy_pass $supplier_frontend_url;
+        proxy_pass $frontend_url;
     }
 }

--- a/playbooks/roles/nginx/templates/www.j2
+++ b/playbooks/roles/nginx/templates/www.j2
@@ -20,7 +20,7 @@ server {
 
         proxy_pass $frontend_url;
     }
-    
+
     location /admin {
         {% for admin_ip in admin_user_ips.split(",") %}
         allow {{ admin_ip }};

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -49,9 +49,7 @@ module "preview_nginx" {
 
   api_url = "${var.api_url}"
   search_api_url = "${var.search_api_url}"
-  buyer_frontend_url = "${var.buyer_frontend_url}"
-  admin_frontend_url = "${var.admin_frontend_url}"
-  supplier_frontend_url = "${var.supplier_frontend_url}"
+  frontend_url = "${var.frontend_url}"
   elasticsearch_url = "${module.preview_elasticsearch.elb_url}"
 
   elasticsearch_auth = "${var.elasticsearch_auth}"

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -20,9 +20,7 @@ variable "submissions_s3_url" {}
 
 variable "api_url" {}
 variable "search_api_url" {}
-variable "buyer_frontend_url" {}
-variable "admin_frontend_url" {}
-variable "supplier_frontend_url" {}
+variable "frontend_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}

--- a/terraform/modules/nginx/autoscaling.tf
+++ b/terraform/modules/nginx/autoscaling.tf
@@ -79,9 +79,7 @@ cd /home/ubuntu/provisioning && ansible-playbook -c local -i localhost, nginx_pl
     -e submissions_s3_url='${var.submissions_s3_url}' \
     -e api_url='${var.api_url}' \
     -e search_api_url='${var.search_api_url}' \
-    -e buyer_frontend_url='${var.buyer_frontend_url}' \
-    -e admin_frontend_url='${var.admin_frontend_url}' \
-    -e supplier_frontend_url='${var.supplier_frontend_url}' \
+    -e frontend_url='${var.frontend_url}' \
     -e elasticsearch_url='${var.elasticsearch_url}' \
     -e elasticsearch_auth='${var.elasticsearch_auth}' \
     -e app_auth='${var.app_auth}' \

--- a/terraform/modules/nginx/variables.tf
+++ b/terraform/modules/nginx/variables.tf
@@ -36,9 +36,7 @@ variable "submissions_s3_url" {}
 
 variable "api_url" {}
 variable "search_api_url" {}
-variable "buyer_frontend_url" {}
-variable "admin_frontend_url" {}
-variable "supplier_frontend_url" {}
+variable "frontend_url" {}
 variable "elasticsearch_url" {}
 
 variable "elasticsearch_auth" {}

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -17,3 +17,7 @@ buyer-frontend:
 supplier-frontend:
   subdomain: dm
   path: /suppliers
+
+briefs-frontend:
+  subdomain: dm-briefs
+  path: /buyer


### PR DESCRIPTION
## Consolidate frontend urls
PaaS is handling routing for specific frontend apps. This means that
from nginx we can just pass all traffic to a single frontend url.

We keep the rule for /admin so we can firewall certain ips.

## Add subdomain and path for briefs frontend
The subdomain being used is different from the other front end apps so
that the app doesn't immediately get traffic. We'll want to get the app
up and running before we send traffic to it.

## Add manifest template for briefs frontend
The briefs frontend won't need search api details, so we drop them from
the template.