### PR TITLE
Consolidate frontend urls on staging and production

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -49,9 +49,7 @@ module "production_nginx" {
 
   api_url = "${var.api_url}"
   search_api_url = "${var.search_api_url}"
-  buyer_frontend_url = "${var.buyer_frontend_url}"
-  admin_frontend_url = "${var.admin_frontend_url}"
-  supplier_frontend_url = "${var.supplier_frontend_url}"
+  frontend_url = "${var.frontend_url}"
   elasticsearch_url = "${module.production_elasticsearch.elb_url}"
 
   elasticsearch_auth = "${var.elasticsearch_auth}"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -20,9 +20,7 @@ variable "submissions_s3_url" {}
 
 variable "api_url" {}
 variable "search_api_url" {}
-variable "buyer_frontend_url" {}
-variable "admin_frontend_url" {}
-variable "supplier_frontend_url" {}
+variable "frontend_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -49,9 +49,7 @@ module "staging_nginx" {
 
   api_url = "${var.api_url}"
   search_api_url = "${var.search_api_url}"
-  buyer_frontend_url = "${var.buyer_frontend_url}"
-  admin_frontend_url = "${var.admin_frontend_url}"
-  supplier_frontend_url = "${var.supplier_frontend_url}"
+  frontend_url = "${var.frontend_url}"
   elasticsearch_url = "${module.staging_elasticsearch.elb_url}"
 
   elasticsearch_auth = "${var.elasticsearch_auth}"

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -20,9 +20,7 @@ variable "submissions_s3_url" {}
 
 variable "api_url" {}
 variable "search_api_url" {}
-variable "buyer_frontend_url" {}
-variable "admin_frontend_url" {}
-variable "supplier_frontend_url" {}
+variable "frontend_url" {}
 
 variable "elasticsearch_auth" {}
 variable "app_auth" {}


### PR DESCRIPTION
Like preview, we can consolidate the frontend urls we give to nginx as
the routing is handled by PaaS.