### PR TITLE
Don't pass downstream HSTS header to the client

### DIFF
--- a/playbooks/roles/nginx/templates/_macros.j2
+++ b/playbooks/roles/nginx/templates/_macros.j2
@@ -12,4 +12,7 @@ proxy_set_header X-Forwarded-Host "$http_host";
 
 proxy_set_header DM-Request-ID "";
 
+# drop headers returned by the app server that shouldn't be forwarded to the client
+proxy_hide_header "Strict-Transport-Security";
+
 {% endmacro %}


### PR DESCRIPTION
Our nginx configuration sets HSTS header for all requests
apart from the health checks coming from the ELB.

At the same time, our downstream application servers hosted on PaaS
are returning another HSTS header set by Cloud Foundry router.

The combination of `proxy_pass` and `add_header` makes nginx return
two HSTS headers to the client (our one and CF one), which is invalid.

CF header applies to the cloudapps.digital domain and while it's
unlikely to be removed it shouldn't affect our approach to HSTS for
our own domains. So we're removing the downstream header and are only
passing our own `add_header` to the client.