### PR TITLE
Don't convert nulls to strings in the log streaming lambda

### DIFF
--- a/terraform/modules/log-streaming/src/main.js
+++ b/terraform/modules/log-streaming/src/main.js
@@ -102,7 +102,7 @@ function buildSource(message) {
     // Convert nested objects and arrays to strings to stop Kibana from rejecting records
     // for missing nested keys mappings
     Object.keys(source).forEach(function (key) {
-      if (typeof source[key] === 'object') {
+      if (typeof source[key] === 'object' && source[key] !== null) {
         source[key] = JSON.stringify(source[key]);
       }
     });


### PR DESCRIPTION
`typeof null === 'object'`, so some of the None values were being
converted to `"null"` when trying to stringify nested objects.

This causes an error for numerical fields, since `"null"` is not
a valid value.