### PR TITLE
Set briefs subdomain to `dm`

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -19,5 +19,5 @@ supplier-frontend:
   path: /suppliers
 
 briefs-frontend:
-  subdomain: dm-briefs
+  subdomain: dm
   path: /buyers


### PR DESCRIPTION
The briefs subdomain was set to `dm-briefs` so the new app could be
released without receiving traffic straight away so we could ensure it
worked properly without breaking the buyer frontend.

Now that we've tested it, we can change the subdomain here so subsequent
releases are assigned the correct subdomain.