### PR TITLE
Add briefs log groups for staging and production

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -100,5 +100,6 @@ module "log_streaming" {
   elasticsearch_url = "${var.logs_elasticsearch_url}"
   elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
-  log_groups = ["${concat(module.production_nginx.json_log_groups, module.application_logs.log_groups)}"]
+  nginx_log_groups = ["${concat(module.production_nginx.json_log_groups, module.application_logs.nginx_log_groups)}"]
+  application_log_groups = ["${module.application_logs.application_log_groups}"]
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -100,5 +100,6 @@ module "log_streaming" {
   elasticsearch_url = "${var.logs_elasticsearch_url}"
   elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
-  log_groups = ["${concat(module.staging_nginx.json_log_groups, module.application_logs.log_groups)}"]
+  nginx_log_groups = ["${concat(module.staging_nginx.json_log_groups, module.application_logs.nginx_log_groups)}"]
+  application_log_groups = ["${module.application_logs.application_log_groups}"]
 }


### PR DESCRIPTION
Similarly to how we added the briefs log groups to preview, which
required splitting the log groups types to avoid Terraform weirdness
(see previous commits), we add them here to staging and prod.