### PR TITLE
Raise preview PaaS instance counts to 3 per app for the game day

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,5 +1,6 @@
 ---
 domain: preview.marketplace.team
+instances: 3
 
 api:
   memory: 2GB


### PR DESCRIPTION
For the duration of the exercise we're raising the instance counts
to 3.