### PR TITLE
Bump preview instance count back to one

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,6 +1,5 @@
 ---
 domain: preview.marketplace.team
-instances: 3
 
 api:
   memory: 2GB


### PR DESCRIPTION
We took the instance counts on PaaS up to 3 for the game day so that
preview would be closer to production.

Removing the specification for the number of instances here will set it
to its default of one.