### PR TITLE
Update travis python version to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.6"
 install:
-  - pip install --no-use-wheel -r requirements_for_test.txt
+  - pip install --no-use-wheel -r requirements-dev.txt
 script:
   - make test
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ requirements: virtualenv ## Install requirements
 virtualenv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
 
 ${VIRTUALENV_ROOT}/activate:
-	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv venv || true
+	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv -p python3 venv || true
 
 .PHONY: preview
 preview: ## Set stage to preview

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==2.7.0
+pytest==2.9.1
 pep8==1.5.7
 mock==1.0.1
 


### PR DESCRIPTION
Updates pytest to work with python 3.6 and renames dev requirements
file to match the file name in app repos.