### PR TITLE
Add brief responses frontend

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -1,0 +1,12 @@
+{% extends "_base.j2" %}
+
+{% block env %}
+      DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
+      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
+
+      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+
+      SECRET_KEY: {{ shared_tokens.password_key }}
+
+      PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
+{% endblock %}

--- a/terraform/modules/application-logs/variables.tf
+++ b/terraform/modules/application-logs/variables.tf
@@ -2,5 +2,13 @@ variable "environment" {}
 variable "retention_in_days" {}
 variable "app_names" {
   type = "list"
-  default = ["buyer-frontend", "supplier-frontend", "admin-frontend", "api", "search-api", "briefs-frontend"]
+  default = [
+    "buyer-frontend",
+    "supplier-frontend",
+    "admin-frontend",
+    "api",
+    "search-api",
+    "briefs-frontend",
+    "brief-responses-frontend"
+  ]
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -22,6 +22,10 @@ briefs-frontend:
   subdomain: dm
   path: /buyers
 
+brief-responses-frontend:
+  subdomain: dm
+  path: /suppliers/opportunities
+
 db-backup:
   subdomain: dm-db-backup
   services:


### PR DESCRIPTION
### Add brief-responses-frontend to list of apps in terraform
Adding the new app to the list in the application logs module will
create the log groups as well as the metrics.

### Add brief-responses-frontend to vars/common.yml
This sets the domain and the path for the new app when deployed to PaaS.


