### PR TITLE
Fix formating error with brief-responses yaml

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -1,6 +1,7 @@
 {% extends "_base.j2" %}
 
 {% block env %}
+
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 


### PR DESCRIPTION
When templated by Jinja the first line was treated as a list and
indented.

The extra line prevents this.