### PR TITLE
Add aws creds to brief-responses manifest

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -2,6 +2,9 @@
 
 {% block env %}
 
+      AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
+      AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
+
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 


### PR DESCRIPTION
The aws-logs agent needs creds to send logs to cloudwatch