### PR TITLE
Add routing for direct-award on buyer-frontend

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -3,12 +3,14 @@
 applications:
   - name: {{ app|replace('_', '-') }}-release
     routes:
-      - route: {{ subdomain }}-{{ environment }}.cloudapps.digital{{ path|default('') }}
+{% for path in (paths|default([''])) %}
+      - route: {{ subdomain }}-{{ environment }}.cloudapps.digital{{ path }}
+{% endfor %}
     instances: {{ instances|default(1) }}
     memory: {{ memory|default('512M') }}
     disk_quota: {{ disk_quota|default('1024M') }}
     health-check-type: http
-    health-check-http-endpoint: {{ path|default('') }}/_status?ignore-dependencies
+    health-check-http-endpoint: {{ (paths|default(['']))[0] }}/_status?ignore-dependencies
     env:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}

--- a/scripts/unmap-route.sh
+++ b/scripts/unmap-route.sh
@@ -8,13 +8,16 @@ fi
 APPLICATION_NAME=$1
 APP_GUID=$(cf app --guid ${APPLICATION_NAME})
 
-ROUTE_URL=$(cf curl /v2/apps/${APP_GUID}/route_mappings | jq -r '.resources[0].entity.route_url')
+ROUTE_URLS=$(cf curl /v2/apps/${APP_GUID}/route_mappings | jq -r '.resources[].entity.route_url')
 
-ROUTE_DATA=$(cf curl ${ROUTE_URL} | jq '.entity')
+for ROUTE_URL in ${ROUTE_URLS}; do
+  ROUTE_DATA=$(cf curl ${ROUTE_URL} | jq '.entity')
 
-ROUTE_HOST=$(echo $ROUTE_DATA | jq -r '.host')
-ROUTE_PATH=$(echo $ROUTE_DATA | jq -r '.path')
+  ROUTE_HOST=$(echo $ROUTE_DATA | jq -r '.host')
+  ROUTE_PATH=$(echo $ROUTE_DATA | jq -r '.path')
 
-echo "Unmapping ${ROUTE_HOST}.cloudapps.digital/${ROUTE_PATH} from ${APPLICATION_NAME}"
+  echo "Unmapping ${ROUTE_HOST}.cloudapps.digital/${ROUTE_PATH} from ${APPLICATION_NAME}"
 
-cf unmap-route "${APPLICATION_NAME}" cloudapps.digital --hostname "${ROUTE_HOST}" --path "${ROUTE_PATH}"
+  cf unmap-route "${APPLICATION_NAME}" cloudapps.digital --hostname "${ROUTE_HOST}" --path "${ROUTE_PATH}"
+  done
+done

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -9,22 +9,29 @@ search-api:
 
 admin-frontend:
   subdomain: dm
-  path: /admin
+  paths:
+    - /admin
 
 buyer-frontend:
   subdomain: dm
+  paths:
+    - ''
+    - /buyers/direct-award
 
 supplier-frontend:
   subdomain: dm
-  path: /suppliers
+  paths:
+    - /suppliers
 
 briefs-frontend:
   subdomain: dm
-  path: /buyers
+  paths:
+    - /buyers
 
 brief-responses-frontend:
   subdomain: dm
-  path: /suppliers/opportunities
+  paths:
+   - /suppliers/opportunities
 
 db-backup:
   subdomain: dm-db-backup


### PR DESCRIPTION
## Summary
Adds routing so that buyer-frontend will receive anything that goes to `/buyers/direct-award` and also be the fallback for un-routed urls at `/`. Tweaks templating to allow multiple paths to be supplied. The first path specified in `common.yml` against the app will be the one used for the healthcheck. Not sure if this is preferrable to explicitly adding another key called e.g. `healthcheck_endpoint`, but will leave that open to review.

Also not sure what you do so far as testing, but I didn't see anything pre-existing to edit or add to. Did I just miss it, or is it in another repo, or..?

## Ticket
https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project