### PR TITLE
Add user-frontend app to Terraform and PaaS

### DIFF
--- a/paas/user-frontend.j2
+++ b/paas/user-frontend.j2
@@ -1,0 +1,17 @@
+{% extends "_base.j2" %}
+
+{% block env %}
+
+      AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
+      AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
+
+      DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
+      DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
+
+      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+
+      PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
+
+      SECRET_KEY: {{ shared_tokens.password_key }}
+      SHARED_EMAIL_KEY: {{ shared_tokens.shared_email_key }}
+{% endblock %}

--- a/terraform/modules/application-logs/variables.tf
+++ b/terraform/modules/application-logs/variables.tf
@@ -9,6 +9,7 @@ variable "app_names" {
     "api",
     "search-api",
     "briefs-frontend",
-    "brief-responses-frontend"
+    "brief-responses-frontend",
+    "user-frontend"
   ]
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -7,6 +7,11 @@ api:
 search-api:
   subdomain: dm-search-api
 
+user-frontend:
+  subdomains: dm
+  paths:
+    - /user
+
 admin-frontend:
   subdomain: dm
   paths:


### PR DESCRIPTION
Adds user-frontend to the Terraform apps list to create
log groups and monitoring metrics.

Sets up a manifest template for PaaS deployments.