### PR TITLE
Fix "string argument without an encoding" python3 error in bcrypt script

### DIFF
--- a/scripts/generate-bcrypt-hashed-password.py
+++ b/scripts/generate-bcrypt-hashed-password.py
@@ -16,7 +16,7 @@ from docopt import docopt
 
 
 def hash_password(password, cost_factor):
-    return bcrypt.hashpw(bytes(password), bcrypt.gensalt(cost_factor)).decode('utf-8')
+    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt(cost_factor)).decode('utf-8')
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)


### PR DESCRIPTION
generate-bcrypt-hashed-password raises an error on python3 since `bytes` is called without an encoding argument. Replacing it with `.encode` should fix the problem.