### PR TITLE
Fix signed agreements cleanup

### DIFF
--- a/scripts/clean-db-dump.sql
+++ b/scripts/clean-db-dump.sql
@@ -85,7 +85,7 @@ SET signed_agreement_details = ('{"signerName": "A. Nonymous",
                                   "uploaderUserId": ' || TEXT(signed_agreement_details->'uploaderUserId') || ',
                                   "frameworkAgreementVersion": ' || TEXT(signed_agreement_details->'frameworkAgreementVersion') || '}'
                                )::json,
-    signed_agreement_path = 'not/the/real/path.pdf',
+    signed_agreement_path = 'not/the/real/path.pdf'
 WHERE signed_agreement_details IS NOT NULL
 AND cast(signed_agreement_details AS TEXT) != 'null';
 

--- a/scripts/clean-db-dump.sql
+++ b/scripts/clean-db-dump.sql
@@ -1,3 +1,5 @@
+\set ON_ERROR_STOP on
+
 \echo 'Update users'
 UPDATE users
 SET name = 'Test user',


### PR DESCRIPTION
##  Interrupt and exit the clean DB dump SQL script on error

Currently, if any of the SQL commands in the clean DB dump script
fail to apply psql will ignore the error and continue, existing with
a 0 status in the end. This could result in DB dumps that still
contain personal data if eg there's a syntax error in one of the
clean-up commands.

ON_ERROR_STOP will terminate psql and exit with a non-zero status if
any of the SQL commands return with an error.

### Fix a typo in signed_agreements clean up SQL statement

