### PR TITLE
Replace Mandrill API key with Notify for user-frontend

### DIFF
--- a/paas/user-frontend.j2
+++ b/paas/user-frontend.j2
@@ -8,7 +8,7 @@
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
-      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 


### PR DESCRIPTION
Reset password emails are being switched to use Notify in
alphagov/digitalmarketplace-user-frontend#10 so it'll need new
environment variables.

This PR has to be merged immediately before the user-frontend one.