### PR TITLE
Add notify api key to briefs and supplier frontends

### DIFF
--- a/paas/briefs-frontend.j2
+++ b/paas/briefs-frontend.j2
@@ -8,7 +8,7 @@
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
-      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 

--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -9,6 +9,7 @@
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
       SECRET_KEY: {{ shared_tokens.password_key }}
       SHARED_EMAIL_KEY: {{ shared_tokens.shared_email_key }}


### PR DESCRIPTION
The briefs and supplier frontends are going to send user create/invite
emails with notify, hence the need for the notify api key.

Briefs frontend will only use notify so we can drop the mandrill key.
Supplier frontend will still use both.