### PR TITLE
Replace mandrill with notify api key for admin

### DIFF
--- a/paas/admin-frontend.j2
+++ b/paas/admin-frontend.j2
@@ -8,7 +8,7 @@
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
-      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
       SECRET_KEY: {{ shared_tokens.password_key }}
       SHARED_EMAIL_KEY: {{ shared_tokens.shared_email_key }}


### PR DESCRIPTION
The admin apps sends emails to invite supplier contributors. It used to
use Mandrill, now it uses Notify.