### PR TITLE
Add new field to Kibana log streamer

### DIFF
--- a/terraform/modules/log-streaming/src/main.js
+++ b/terraform/modules/log-streaming/src/main.js
@@ -71,6 +71,7 @@ function transform(payload) {
         ].join('.');
 
         var source = buildSource(logEvent.message);
+        source['instance_id'] = payload.logStream;
         source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
 
         var action = { "index": {} };


### PR DESCRIPTION
## Summary
Add the instance ID (from payload.logStream) to log entries in Kibana to help troubleshoot possible errors with specific app instances

## Ticket
https://trello.com/c/RWkQeJE3/22-add-paas-instance-ids-to-kibana-logs