### PR TITLE
Downscale user-frontend and admin-frontend apps

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -4,3 +4,9 @@ instances: 5
 
 api:
   memory: 2GB
+
+user-frontend:
+  instances: 2
+
+admin-frontend:
+  instances: 2


### PR DESCRIPTION
## Summary
Reviewing monitoring for the last week, our user-frontend and admin-frontend barely hit 2% CPU. Let's scale down the default number of instances we create for these apps.