### PR TITLE
Preview paas router manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ generate-manifest: virtualenv ## Generate manifest file for PaaS
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${STAGE},,$(error Must specify STAGE))
 	$(if ${DM_CREDENTIALS_REPO},,$(error Must specify DM_CREDENTIALS_REPO))
-	${DM_CREDENTIALS_REPO}/sops-wrapper -v > /dev/null # Avoid asking for MFA twice (when mandatory)
-	${VIRTUALENV_ROOT}/bin/python scripts/generate-paas-manifest.py ${STAGE} ${APPLICATION_NAME} \
+	@${DM_CREDENTIALS_REPO}/sops-wrapper -v > /dev/null # Avoid asking for MFA twice (when mandatory)
+	@${VIRTUALENV_ROOT}/bin/python scripts/generate-paas-manifest.py ${STAGE} ${APPLICATION_NAME} \
 		-f <(${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/${STAGE}.yaml)
 
 .PHONY: paas-login

--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -3,14 +3,16 @@
 applications:
   - name: {{ app|replace('_', '-') }}-release
     routes:
-{% for path in (paths|default([''])) %}
-      - route: {{ subdomain }}-{{ environment }}.cloudapps.digital{{ path }}
+{% for route in routes|default([]) %}
+      - route: {{ route.format(env=environment) }}
 {% endfor %}
     instances: {{ instances|default(1) }}
     memory: {{ memory|default('512M') }}
     disk_quota: {{ disk_quota|default('1024M') }}
+{% if routes %}
     health-check-type: http
-    health-check-http-endpoint: {{ (paths|default(['']))[0] }}/_status?ignore-dependencies
+    health-check-http-endpoint: {{ routes[0].partition('/')[1:]|join("") }}/_status?ignore-dependencies
+{% endif %}
     env:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}

--- a/paas/router.j2
+++ b/paas/router.j2
@@ -1,0 +1,25 @@
+{% extends "_base.j2" %}
+
+{% block env %}
+
+      AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
+      AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
+
+      DM_ADMIN_USER_IPS: '{{ admin_user_ips|join(",") }}'
+      DM_DEV_USER_IPS: '{{ dev_user_ips|join(",") }}'
+      DM_USER_IPS: '{{ user_ips|join(",") }}'
+
+      DM_API_URL: 'https://dm-api-{{ environment }}.cloudapps.digital'
+      DM_SEARCH_API_URL: 'https://dm-search-api-{{ environment }}.cloudapps.digital'
+      DM_FRONTEND_URL: 'https://dm-{{ environment }}.cloudapps.digital'
+
+      DM_G7_DRAFT_DOCUMENTS_S3_URL: {{ g7_draft_documents_s3_url }}
+      DM_DOCUMENTS_S3_URL: {{ documents_s3_url }}
+      DM_AGREEMENTS_S3_URL: {{ agreements_s3_url }}
+      DM_COMMUNICATIONS_S3_URL: {{ communications_s3_url }}
+      DM_SUBMISSIONS_S3_URL: {{ submissions_s3_url }}
+
+      DM_APP_AUTH: '{{ app_auth }}'
+      DM_MODE: '{{ maintenance_mode }}'
+
+{% endblock %}

--- a/scripts/unmap-route.sh
+++ b/scripts/unmap-route.sh
@@ -13,10 +13,12 @@ ROUTE_URLS=$(cf curl /v2/apps/${APP_GUID}/route_mappings | jq -r '.resources[].e
 for ROUTE_URL in ${ROUTE_URLS}; do
   ROUTE_DATA=$(cf curl ${ROUTE_URL} | jq '.entity')
 
+  ROUTE_DOMAIN=$(cf curl $(echo $ROUTE_DATA | jq -r '.domain_url') | jq -r '.entity.name')
+
   ROUTE_HOST=$(echo $ROUTE_DATA | jq -r '.host')
   ROUTE_PATH=$(echo $ROUTE_DATA | jq -r '.path')
 
-  echo "Unmapping ${ROUTE_HOST}.cloudapps.digital/${ROUTE_PATH} from ${APPLICATION_NAME}"
+  echo "Unmapping ${ROUTE_HOST}.${ROUTE_DOMAIN}/${ROUTE_PATH} from ${APPLICATION_NAME}"
 
-  cf unmap-route "${APPLICATION_NAME}" cloudapps.digital --hostname "${ROUTE_HOST}" --path "${ROUTE_PATH}"
+  cf unmap-route "${APPLICATION_NAME}" ${ROUTE_DOMAIN} --hostname "${ROUTE_HOST}" --path "${ROUTE_PATH}"
 done

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,4 +1,15 @@
 ---
+maintenance_mode: live
+
+router:
+  routes:
+    - www.{env}.marketplace.team
+    - api.{env}.marketplace.team
+    - search-api.{env}.marketplace.team
+    - assets.{env}.marketplace.team
+  services:
+    - router_cdn
+
 api:
   routes:
     - dm-api-{env}.cloudapps.digital

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,46 +1,41 @@
 ---
 api:
-  subdomain: dm-api
+  routes:
+    - dm-api-{env}.cloudapps.digital
   services:
     - digitalmarketplace_api_db
 
 search-api:
-  subdomain: dm-search-api
+  routes:
+    - dm-search-api-{env}.cloudapps.digital
   services:
     - search_api_elasticsearch
 
 user-frontend:
-  subdomain: dm
-  paths:
-    - /user
+  routes:
+    - dm-{env}.cloudapps.digital/user
 
 admin-frontend:
-  subdomain: dm
-  paths:
-    - /admin
+  routes:
+    - dm-{env}.cloudapps.digital/admin
 
 buyer-frontend:
-  subdomain: dm
-  paths:
-    - ''
-    - /buyers/direct-award
+  routes:
+    - dm-{env}.cloudapps.digital
+    - dm-{env}.cloudapps.digital/buyers/direct-award
 
 supplier-frontend:
-  subdomain: dm
-  paths:
-    - /suppliers
+  routes:
+    - dm-{env}.cloudapps.digital/suppliers
 
 briefs-frontend:
-  subdomain: dm
-  paths:
-    - /buyers
+  routes:
+    - dm-{env}.cloudapps.digital/buyers
 
 brief-responses-frontend:
-  subdomain: dm
-  paths:
-   - /suppliers/opportunities
+  routes:
+   - dm-{env}.cloudapps.digital/suppliers/opportunities
 
 db-backup:
-  subdomain: dm-db-backup
   services:
     - digitalmarketplace_api_db


### PR DESCRIPTION
### Remove shell commands from the generate-manifest output

By default, make prints the command being executed, so when the output of generate-manifest is being redirected to a file the resulting manifest contains the command names before the YAML front matter.

Adding `@` stops make from printing the commands, but keeps the command output.

### Explicitly list full routes in PaaS vars

Changes the base manifest template to include application routes as-is (only formatting them to add current environment) instead of constructing the route from domain / subdomain and paths.

This allows us to specify multiple subdomains / domains per app, and specify manifests for apps that don't need a route.

To avoid duplicating the application paths between environments we format routes with the current environment, so they can be specified once in the common vars file.

### Update unmap-route script to support custom domains

PaaS now allows us to add custom domains and map them to existing applications, so route unmapping script should look up the domain for each route instead of always using cloudapps.digital.


### Add PaaS manifest template for the nginx router app

Adds a manifest template and preview variables that would map the subdomains and the CloudFront instance to the nginx router app deployed to PaaS.

This allows us to use the application release pipeline to deploy nginx changes.