### PR TITLE
Don't bind cdn-route service to the router app

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -7,8 +7,6 @@ router:
     - api.{env}.marketplace.team
     - search-api.{env}.marketplace.team
     - assets.{env}.marketplace.team
-  services:
-    - router_cdn
 
 api:
   routes:


### PR DESCRIPTION
cdn-route doesn't support binding to an app. It doesn't provide
any service variables to the application, and since traffic is
routed based on the application domain there's no need to bind it
to the app.