### PR TITLE
Allow undefinition of 'routes' variable

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -9,7 +9,7 @@ applications:
     instances: {{ instances|default(1) }}
     memory: {{ memory|default('512M') }}
     disk_quota: {{ disk_quota|default('1024M') }}
-{% if routes %}
+{% if routes|default([]) %}
     health-check-type: http
     health-check-http-endpoint: {{ routes[0].partition('/')[1:]|join("") }}/_status?ignore-dependencies
 {% endif %}


### PR DESCRIPTION
As Jinja is in `StrictUndefined` mode, the only function that
can be called on an undefined object is the `defined` function.
Therefore we make sure that we don't try to access `routes`
unless we are sure it is defined.