### PR TITLE
Add correct production domains to router app

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -2,6 +2,14 @@
 domain: "digitalmarketplace.service.gov.uk"
 instances: 5
 
+router:
+  instances: 3
+  routes:
+    - www.digitalmarketplace.service.gov.uk
+    - api.digitalmarketplace.service.gov.uk
+    - search-api.digitalmarketplace.service.gov.uk
+    - assets.digitalmarketplace.service.gov.uk
+
 api:
   memory: 2GB
 


### PR DESCRIPTION
Production doesn't follow the `*.{env}.marketplace.team` domain
pattern, so we need to set the domains explicitly.

This also scales router app to 3 instances from the production default
of 5. Nginx is pretty fast and additional instances would reduce cache
hits for any pages or assets cached by nginx.