### PR TITLE
Fix router 500s metric name to match application ones

### DIFF
--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -281,7 +281,7 @@ resource "aws_cloudwatch_log_metric_filter" "router-500s" {
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-500s"
+    name  = "${var.environment}-router-nginx-500s"
     namespace = "DM-500s"
     value     = "1"
   }


### PR DESCRIPTION
Since we're using the same application dashboard for applications
and router the metric names need to match.

Application 500s use {app_name}-nginx-500s, so we need to rename
router metric from router-500s to router-nginx-500s. This metric
is already being picked up by the cloudwatch-to-graphite app.