### PR TITLE
Remove remnants of old way of turning on maintenance mode

### DIFF
--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -26,7 +26,3 @@ variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}
-
-variable "mode" {
-  default = "live"
-}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -26,7 +26,3 @@ variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}
-
-variable "mode" {
-  default = "live"
-}

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -26,7 +26,3 @@ variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}
-
-variable "mode" {
-  default = "live"
-}


### PR DESCRIPTION
Maintenance mode is now turned on by using paas manifests rather
than AWS ngxin groups after the move to the PaaS router.

This commit removes some left over references to maintenance mode
in our terraform set up.