### PR TITLE
Fix warning during terraform plan - 'roles' key is deprecated.

### DIFF
--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -21,7 +21,7 @@ EOF
 
 resource "aws_iam_instance_profile" "jenkins" {
   name = "jenkins-ci-InstanceProfile-AOFDQ580SQSK"
-  roles = ["${aws_iam_role.jenkins.id}"]
+  role = "${aws_iam_role.jenkins.id}"
 }
 
 resource "aws_iam_role_policy" "jenkins" {


### PR DESCRIPTION
2nd line Trello card: https://trello.com/c/f19CB6rO/102-fix-terraform-warning

While running 'make plan' the following warning is shown:
```
module.jenkins.aws_iam_instance_profile.jenkins: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
```

This change to 'role' instead of 'roles' and passing a single value instead of a list makes the warning go away.