### PR TITLE
Add 429 metric filter and update Grafana overview dashboard

### DIFF
--- a/grafana/dm-apps.json
+++ b/grafana/dm-apps.json
@@ -1,5 +1,5 @@
 {
-  "title": "DM Apps",
+  "title": "DM Apps - sum",
   "tags": [],
   "style": "dark",
   "timezone": "browser",
@@ -85,48 +85,48 @@
         "options": [
           {
             "text": "api",
-            "value": "api",
-            "selected": true
+            "selected": true,
+            "value": "api"
           },
           {
             "text": "search-api",
-            "value": "search-api",
-            "selected": false
+            "selected": false,
+            "value": "search-api"
           },
           {
             "text": "user-frontend",
-            "value": "user-frontend",
-            "selected": false
+            "selected": false,
+            "value": "user-frontend"
           },
           {
             "text": "buyer-frontend",
-            "value": "buyer-frontend",
-            "selected": false
+            "selected": false,
+            "value": "buyer-frontend"
           },
           {
             "text": "supplier-frontend",
-            "value": "supplier-frontend",
-            "selected": false
+            "selected": false,
+            "value": "supplier-frontend"
           },
           {
             "text": "admin-frontend",
-            "value": "admin-frontend",
-            "selected": false
+            "selected": false,
+            "value": "admin-frontend"
           },
           {
             "text": "briefs-frontend",
-            "value": "briefs-frontend",
-            "selected": false
+            "selected": false,
+            "value": "briefs-frontend"
           },
           {
             "text": "brief-responses-frontend",
-            "value": "brief-responses-frontend",
-            "selected": false
+            "selected": false,
+            "value": "brief-responses-frontend"
           },
           {
             "text": "router",
-            "value": "router",
-            "selected": false
+            "selected": false,
+            "value": "router"
           }
         ],
         "includeAll": false
@@ -138,7 +138,7 @@
   },
   "refresh": "5m",
   "schemaVersion": 13,
-  "version": 2,
+  "version": 0,
   "links": [],
   "gnetId": null,
   "alertPanelMap": {},
@@ -160,52 +160,52 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_0.samplecount:max, '0-0.025s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_0.sum:max, '0-0.025s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_1.samplecount:max, '0.025-0.05s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_1.sum:max, '0.025-0.05s')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_2.samplecount:max, '0.05-0.1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_2.sum:max, '0.05-0.1s')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_3.samplecount:max, '0.1-0.25s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_3.sum:max, '0.1-0.25s')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_4.samplecount:max, '0.25-0.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_4.sum:max, '0.25-0.5s')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_5.samplecount:max, '0.5-1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_5.sum:max, '0.5-1s')"
             },
             {
               "hide": false,
               "refId": "G",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_6.samplecount:max, '1-2.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_6.sum:max, '1-2.5s')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,
@@ -311,17 +311,17 @@
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.$app.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,

--- a/grafana/dm-apps.json
+++ b/grafana/dm-apps.json
@@ -1,5 +1,5 @@
 {
-  "title": "DM Apps - sum",
+  "title": "DM Apps",
   "tags": [],
   "style": "dark",
   "timezone": "browser",
@@ -138,7 +138,7 @@
   },
   "refresh": "5m",
   "schemaVersion": 13,
-  "version": 0,
+  "version": 3,
   "links": [],
   "gnetId": null,
   "alertPanelMap": {},

--- a/grafana/dm-overview.json
+++ b/grafana/dm-overview.json
@@ -1,5 +1,5 @@
 {
-  "title": "DM Overview",
+  "title": "DM Overview with 429s",
   "tags": [],
   "style": "dark",
   "timezone": "browser",
@@ -46,7 +46,7 @@
         "current": {
           "text": "production",
           "selected": false,
-          "value": "production"
+          "value": "production",
         },
         "query": "preview,staging,production",
         "type": "custom",
@@ -74,9 +74,9 @@
   "annotations": {
     "list": []
   },
-  "refresh": "5m",
+  "refresh": "5s",
   "schemaVersion": 13,
-  "version": 2,
+  "version": 0,
   "links": [],
   "gnetId": null,
   "alertPanelMap": {},
@@ -98,56 +98,56 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_0.samplecount:max, '0-0.025s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_0.sum:sum, '0-0.025s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_1.samplecount:max, '0.025-0.05s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_1.sum:sum, '0.025-0.05s')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_2.samplecount:max, '0.05-0.1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_2.sum:sum, '0.05-0.1s')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_3.samplecount:max, '0.1-0.25s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_3.sum:sum, '0.1-0.25s')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_4.samplecount:max, '0.25-0.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_4.sum:sum, '0.25-0.5s')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_5.samplecount:max, '0.5-1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_5.sum:sum, '0.5-1s')"
             },
             {
               "hide": false,
               "refId": "G",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_6.samplecount:max, '1-2.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_6.sum:sum, '1-2.5s')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:sum, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:sum, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:sum, '>10s')"
             }
           ],
           "fill": 1,
-          "span": 6,
+          "span": 4,
           "title": "Request counts grouped by time - $environment router",
           "tooltip": {
             "sort": 0,
@@ -237,56 +237,56 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_0.samplecount:max, '0-0.025s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_0.sum:sum, '0-0.025s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_1.samplecount:max, '0.025-0.05s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_1.sum:sum, '0.025-0.05s')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_2.samplecount:max, '0.05-0.1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_2.sum:sum, '0.05-0.1s')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_3.samplecount:max, '0.1-0.25s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_3.sum:sum, '0.1-0.25s')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_4.samplecount:max, '0.25-0.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_4.sum:sum, '0.25-0.5s')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_5.samplecount:max, '0.5-1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_5.sum:sum, '0.5-1s')"
             },
             {
               "hide": false,
               "refId": "G",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_6.samplecount:max, '1-2.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_6.sum:sum, '1-2.5s')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:sum, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:sum, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:sum, '>10s')"
             }
           ],
           "fill": 1,
-          "span": 6,
+          "span": 4,
           "title": "Request counts grouped by time - $environment api",
           "tooltip": {
             "sort": 0,
@@ -361,6 +361,77 @@
           "points": false,
           "datasource": null,
           "pointradius": 5
+        },
+        {
+          "bars": false,
+          "timeFrom": null,
+          "links": [],
+          "thresholds": [],
+          "nullPointMode": "null as zero",
+          "renderer": "flot",
+          "id": 8,
+          "linewidth": 1,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "cloudwatch.application_500s.$environment.router.500s.sum:sum"
+            }
+          ],
+          "fill": 1,
+          "span": 4,
+          "title": "5xx response count - $environment router",
+          "tooltip": {
+            "sort": 0,
+            "shared": true,
+            "value_type": "individual",
+            "msResolution": false
+          },
+          "legend": {
+            "total": false,
+            "show": true,
+            "max": false,
+            "min": false,
+            "current": false,
+            "values": false,
+            "avg": false
+          },
+          "yaxes": [
+            {
+              "logBase": 1,
+              "show": true,
+              "max": null,
+              "format": "short",
+              "min": "0",
+              "label": null
+            },
+            {
+              "logBase": 1,
+              "show": true,
+              "max": null,
+              "format": "short",
+              "min": null,
+              "label": null
+            }
+          ],
+          "xaxis": {
+            "show": true,
+            "values": [],
+            "mode": "time",
+            "name": null
+          },
+          "seriesOverrides": [],
+          "percentage": false,
+          "type": "graph",
+          "error": false,
+          "editable": true,
+          "stack": false,
+          "timeShift": null,
+          "aliasColors": {},
+          "lines": true,
+          "points": false,
+          "datasource": null,
+          "pointradius": 5
         }
       ],
       "showTitle": false,
@@ -388,17 +459,17 @@
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:sum, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:sum, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:sum, '>10s')"
             }
           ],
           "fill": 1,
@@ -492,17 +563,17 @@
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.samplecount:max, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:sum, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.samplecount:max, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:sum, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.samplecount:max, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:sum, '>10s')"
             }
           ],
           "fill": 1,
@@ -589,18 +660,18 @@
           "thresholds": [],
           "nullPointMode": "null as zero",
           "renderer": "flot",
-          "id": 8,
+          "id": 12,
           "linewidth": 1,
           "steppedLine": false,
           "targets": [
             {
               "refId": "A",
-              "target": "cloudwatch.application_500s.$environment.router.500s.samplecount"
+              "target": "cloudwatch.router_429s.$environment.router.429s.sum:sum"
             }
           ],
           "fill": 1,
           "span": 4,
-          "title": "5xx response count - $environment router",
+          "title": "429 (rate limited) responses - $environment router",
           "tooltip": {
             "sort": 0,
             "shared": true,
@@ -656,7 +727,7 @@
       ],
       "showTitle": false,
       "titleSize": "h6",
-      "height": 248,
+      "height": 252,
       "repeat": null,
       "repeatRowId": null,
       "repeatIteration": null,

--- a/grafana/dm-overview.json
+++ b/grafana/dm-overview.json
@@ -1,5 +1,5 @@
 {
-  "title": "DM Overview with 429s",
+  "title": "DM Overview",
   "tags": [],
   "style": "dark",
   "timezone": "browser",
@@ -76,7 +76,7 @@
   },
   "refresh": "5m",
   "schemaVersion": 13,
-  "version": 0,
+  "version": 3,
   "links": [],
   "gnetId": null,
   "alertPanelMap": {},

--- a/grafana/dm-overview.json
+++ b/grafana/dm-overview.json
@@ -46,7 +46,7 @@
         "current": {
           "text": "production",
           "selected": false,
-          "value": "production",
+          "value": "production"
         },
         "query": "preview,staging,production",
         "type": "custom",
@@ -74,7 +74,7 @@
   "annotations": {
     "list": []
   },
-  "refresh": "5s",
+  "refresh": "5m",
   "schemaVersion": 13,
   "version": 0,
   "links": [],
@@ -98,56 +98,56 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_0.sum:sum, '0-0.025s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_0.sum:max, '0-0.025s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_1.sum:sum, '0.025-0.05s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_1.sum:max, '0.025-0.05s')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_2.sum:sum, '0.05-0.1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_2.sum:max, '0.05-0.1s')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_3.sum:sum, '0.1-0.25s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_3.sum:max, '0.1-0.25s')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_4.sum:sum, '0.25-0.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_4.sum:max, '0.25-0.5s')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_5.sum:sum, '0.5-1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_5.sum:max, '0.5-1s')"
             },
             {
               "hide": false,
               "refId": "G",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_6.sum:sum, '1-2.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_6.sum:max, '1-2.5s')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:sum, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:sum, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:sum, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,
-          "span": 4,
+          "span": 6,
           "title": "Request counts grouped by time - $environment router",
           "tooltip": {
             "sort": 0,
@@ -237,56 +237,56 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_0.sum:sum, '0-0.025s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_0.sum:max, '0-0.025s')"
             },
             {
               "hide": false,
               "refId": "B",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_1.sum:sum, '0.025-0.05s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_1.sum:max, '0.025-0.05s')"
             },
             {
               "hide": false,
               "refId": "C",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_2.sum:sum, '0.05-0.1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_2.sum:max, '0.05-0.1s')"
             },
             {
               "hide": false,
               "refId": "D",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_3.sum:sum, '0.1-0.25s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_3.sum:max, '0.1-0.25s')"
             },
             {
               "hide": false,
               "refId": "E",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_4.sum:sum, '0.25-0.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_4.sum:max, '0.25-0.5s')"
             },
             {
               "hide": false,
               "refId": "F",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_5.sum:sum, '0.5-1s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_5.sum:max, '0.5-1s')"
             },
             {
               "hide": false,
               "refId": "G",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_6.sum:sum, '1-2.5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_6.sum:max, '1-2.5s')"
             },
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:sum, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:sum, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:sum, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,
-          "span": 4,
+          "span": 6,
           "title": "Request counts grouped by time - $environment api",
           "tooltip": {
             "sort": 0,
@@ -361,82 +361,11 @@
           "points": false,
           "datasource": null,
           "pointradius": 5
-        },
-        {
-          "bars": false,
-          "timeFrom": null,
-          "links": [],
-          "thresholds": [],
-          "nullPointMode": "null as zero",
-          "renderer": "flot",
-          "id": 8,
-          "linewidth": 1,
-          "steppedLine": false,
-          "targets": [
-            {
-              "refId": "A",
-              "target": "cloudwatch.application_500s.$environment.router.500s.sum:sum"
-            }
-          ],
-          "fill": 1,
-          "span": 4,
-          "title": "5xx response count - $environment router",
-          "tooltip": {
-            "sort": 0,
-            "shared": true,
-            "value_type": "individual",
-            "msResolution": false
-          },
-          "legend": {
-            "total": false,
-            "show": true,
-            "max": false,
-            "min": false,
-            "current": false,
-            "values": false,
-            "avg": false
-          },
-          "yaxes": [
-            {
-              "logBase": 1,
-              "show": true,
-              "max": null,
-              "format": "short",
-              "min": "0",
-              "label": null
-            },
-            {
-              "logBase": 1,
-              "show": true,
-              "max": null,
-              "format": "short",
-              "min": null,
-              "label": null
-            }
-          ],
-          "xaxis": {
-            "show": true,
-            "values": [],
-            "mode": "time",
-            "name": null
-          },
-          "seriesOverrides": [],
-          "percentage": false,
-          "type": "graph",
-          "error": false,
-          "editable": true,
-          "stack": false,
-          "timeShift": null,
-          "aliasColors": {},
-          "lines": true,
-          "points": false,
-          "datasource": null,
-          "pointradius": 5
         }
       ],
       "showTitle": false,
       "titleSize": "h6",
-      "height": 284,
+      "height": 291,
       "repeat": null,
       "repeatRowId": null,
       "repeatIteration": null,
@@ -459,17 +388,17 @@
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:sum, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:sum, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:sum, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.router.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,
@@ -563,17 +492,17 @@
             {
               "hide": false,
               "refId": "H",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:sum, '2.5-5s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_7.sum:max, '2.5-5s')"
             },
             {
               "hide": false,
               "refId": "I",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:sum, '5-10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_8.sum:max, '5-10s')"
             },
             {
               "hide": false,
               "refId": "J",
-              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:sum, '>10s')"
+              "target": "alias(cloudwatch.request_time_buckets.$environment.api.request_time_bucket_9.sum:max, '>10s')"
             }
           ],
           "fill": 1,
@@ -666,7 +595,7 @@
           "targets": [
             {
               "refId": "A",
-              "target": "cloudwatch.router_429s.$environment.router.429s.sum:sum"
+              "target": "cloudwatch.router_429s.$environment.router.429s.sum:max"
             }
           ],
           "fill": 1,
@@ -753,7 +682,7 @@
             }
           ],
           "fill": 1,
-          "span": 12,
+          "span": 6,
           "title": "Memory usage per app- $environment",
           "tooltip": {
             "sort": 0,
@@ -776,6 +705,77 @@
               "show": true,
               "max": null,
               "format": "decbytes",
+              "min": "0",
+              "label": null
+            },
+            {
+              "logBase": 1,
+              "show": true,
+              "max": null,
+              "format": "short",
+              "min": null,
+              "label": null
+            }
+          ],
+          "xaxis": {
+            "show": true,
+            "values": [],
+            "mode": "time",
+            "name": null
+          },
+          "seriesOverrides": [],
+          "percentage": false,
+          "type": "graph",
+          "error": false,
+          "editable": true,
+          "stack": false,
+          "timeShift": null,
+          "aliasColors": {},
+          "lines": true,
+          "points": false,
+          "datasource": null,
+          "pointradius": 5
+        },
+        {
+          "bars": false,
+          "timeFrom": null,
+          "links": [],
+          "thresholds": [],
+          "nullPointMode": "null as zero",
+          "renderer": "flot",
+          "id": 8,
+          "linewidth": 1,
+          "steppedLine": false,
+          "targets": [
+            {
+              "refId": "A",
+              "target": "cloudwatch.application_500s.$environment.router.500s.sum:max"
+            }
+          ],
+          "fill": 1,
+          "span": 6,
+          "title": "5xx response count - $environment router",
+          "tooltip": {
+            "sort": 0,
+            "shared": true,
+            "value_type": "individual",
+            "msResolution": false
+          },
+          "legend": {
+            "total": false,
+            "show": true,
+            "max": false,
+            "min": false,
+            "current": false,
+            "values": false,
+            "avg": false
+          },
+          "yaxes": [
+            {
+              "logBase": 1,
+              "show": true,
+              "max": null,
+              "format": "short",
               "min": "0",
               "label": null
             },

--- a/scripts/create-hosted-graphite-dashboards.py
+++ b/scripts/create-hosted-graphite-dashboards.py
@@ -2,7 +2,19 @@
 # -*- coding: utf-8 -*-
 """
 Description:
-    To add
+    This pushes dashboards defined in /grafana directory up to our hosted graphite.
+    You can get the <hosted_graphite_api_key> from the "Account Home" page of hosted graphite.
+
+    To change a dashboard a process you should follow is:
+    1. Set "editable": true in one our existing JSON files
+    2. Change the title (to avoid overwriting the existing dashboard as you try things out)
+    3. Run this script
+    4. Find the newly created dashboard in hosted graphite and make changes
+    5. Export the JSON for the new dashboard (click settings cog, "View JSON") and overwrite the existing JSON file
+    6. Set "editable": false and set the title back to the original one.  Remove the new "id" key from the exported JSON
+    7. Run this script again
+    8. Check you're happy with the new dashboard
+    9. Delete the editable "test" dashboard you created in step 3 (click settings cog, "Delete dashboard")
 
 Usage:
     scripts/create-hosted-graphite-dashboards.py <hosted_graphite_api_key>

--- a/scripts/create-hosted-graphite-dashboards.py
+++ b/scripts/create-hosted-graphite-dashboards.py
@@ -22,7 +22,7 @@ sys.path.insert(0, '.')  # noqa
 
 def generate_dashboards(api_key):
     endpoint = "https://api.hostedgraphite.com/api/v2/grafana/dashboards/"
-    path = "../grafana/"
+    path = os.path.join(os.path.dirname(__file__), "../grafana/")
 
     for filename in os.listdir(path):
         with open(path + filename) as fp:

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.6.0"
 }
 
 terraform {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.6.0"
 }
 
 terraform {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.6.0"
 }
 
 terraform {

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -284,6 +284,7 @@ resource "aws_cloudwatch_log_metric_filter" "router-500s" {
     name  = "${var.environment}-router-nginx-500s"
     namespace = "DM-500s"
     value     = "1"
+    default_value = "0"
   }
 }
 

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -296,5 +296,6 @@ resource "aws_cloudwatch_log_metric_filter" "router-429s" {
     name  = "${var.environment}-router-nginx-429s"
     namespace = "DM-429s"
     value     = "1"
+    default_value = "0"
   }
 }

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_log_metric_filter" "application-500s" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_0" {
   name  = "${var.environment}-router-request-times-0"
-  pattern        = "{$$.requestTime >= 0 && $$.requestTime < 0.025 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0 && $$.requestTime < 0.025 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_0" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_1" {
   name  = "${var.environment}-router-request-times-1"
-  pattern        = "{$$.requestTime >= 0.025 && $$.requestTime < 0.05 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0.025 && $$.requestTime < 0.05 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -181,7 +181,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_1" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_2" {
   name  = "${var.environment}-router-request-times-2"
-  pattern        = "{$$.requestTime >= 0.05 && $$.requestTime < 0.1 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0.05 && $$.requestTime < 0.1 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_2" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_3" {
   name  = "${var.environment}-router-request-times-3"
-  pattern        = "{$$.requestTime >= 0.1 && $$.requestTime < 0.25 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0.1 && $$.requestTime < 0.25 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -205,7 +205,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_3" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_4" {
   name  = "${var.environment}-router-request-times-4"
-  pattern        = "{$$.requestTime >= 0.25 && $$.requestTime < 0.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0.25 && $$.requestTime < 0.5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -217,7 +217,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_4" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_5" {
   name  = "${var.environment}-router-request-times-5"
-  pattern        = "{$$.requestTime >= 0.5 && $$.requestTime < 1 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 0.5 && $$.requestTime < 1 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -229,7 +229,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_5" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_6" {
   name  = "${var.environment}-router-request-times-6"
-  pattern        = "{$$.requestTime >= 1 && $$.requestTime < 2.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 1 && $$.requestTime < 2.5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -241,7 +241,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_6" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_7" {
   name  = "${var.environment}-router-request-times-7"
-  pattern        = "{$$.requestTime >= 2.5 && $$.requestTime < 5 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 2.5 && $$.requestTime < 5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -253,7 +253,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_7" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_8" {
   name  = "${var.environment}-router-request-times-8"
-  pattern        = "{$$.requestTime >= 5 && $$.requestTime < 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 5 && $$.requestTime < 10 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -265,7 +265,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_8" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_9" {
   name  = "${var.environment}-router-request-times-9"
-  pattern        = "{$$.requestTime >= 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
+  pattern        = "{$$.requestTime >= 10 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -283,6 +283,18 @@ resource "aws_cloudwatch_log_metric_filter" "router-500s" {
   metric_transformation {
     name  = "${var.environment}-router-nginx-500s"
     namespace = "DM-500s"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "router-429s" {
+  name  = "${var.environment}-router-429s"
+  pattern        = "{$$.status = 429}"
+  log_group_name = "${var.router_log_group_name}"
+
+  metric_transformation {
+    name  = "${var.environment}-router-nginx-429s"
+    namespace = "DM-429s"
     value     = "1"
   }
 }

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -284,7 +284,6 @@ resource "aws_cloudwatch_log_metric_filter" "router-500s" {
     name  = "${var.environment}-router-nginx-500s"
     namespace = "DM-500s"
     value     = "1"
-    default_value = "0"
   }
 }
 
@@ -297,6 +296,5 @@ resource "aws_cloudwatch_log_metric_filter" "router-429s" {
     name  = "${var.environment}-router-nginx-429s"
     namespace = "DM-429s"
     value     = "1"
-    default_value = "0"
   }
 }

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -157,7 +157,7 @@ resource "aws_cloudwatch_log_metric_filter" "application-500s" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_0" {
   name  = "${var.environment}-router-request-times-0"
-  pattern        = "{$$.requestTime >= 0 && $$.requestTime < 0.025 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0 && $$.requestTime < 0.025 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_0" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_1" {
   name  = "${var.environment}-router-request-times-1"
-  pattern        = "{$$.requestTime >= 0.025 && $$.requestTime < 0.05 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0.025 && $$.requestTime < 0.05 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -181,7 +181,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_1" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_2" {
   name  = "${var.environment}-router-request-times-2"
-  pattern        = "{$$.requestTime >= 0.05 && $$.requestTime < 0.1 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0.05 && $$.requestTime < 0.1 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_2" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_3" {
   name  = "${var.environment}-router-request-times-3"
-  pattern        = "{$$.requestTime >= 0.1 && $$.requestTime < 0.25 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0.1 && $$.requestTime < 0.25 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -205,7 +205,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_3" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_4" {
   name  = "${var.environment}-router-request-times-4"
-  pattern        = "{$$.requestTime >= 0.25 && $$.requestTime < 0.5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0.25 && $$.requestTime < 0.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -217,7 +217,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_4" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_5" {
   name  = "${var.environment}-router-request-times-5"
-  pattern        = "{$$.requestTime >= 0.5 && $$.requestTime < 1 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 0.5 && $$.requestTime < 1 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -229,7 +229,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_5" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_6" {
   name  = "${var.environment}-router-request-times-6"
-  pattern        = "{$$.requestTime >= 1 && $$.requestTime < 2.5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 1 && $$.requestTime < 2.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -241,7 +241,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_6" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_7" {
   name  = "${var.environment}-router-request-times-7"
-  pattern        = "{$$.requestTime >= 2.5 && $$.requestTime < 5 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 2.5 && $$.requestTime < 5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -253,7 +253,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_7" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_8" {
   name  = "${var.environment}-router-request-times-8"
-  pattern        = "{$$.requestTime >= 5 && $$.requestTime < 10 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 5 && $$.requestTime < 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
@@ -265,7 +265,7 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_8" {
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_9" {
   name  = "${var.environment}-router-request-times-9"
-  pattern        = "{$$.requestTime >= 10 && $$.request != \"*/_status?ignore-dependencies *\" && $$.status != 429}"
+  pattern        = "{$$.requestTime >= 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {

--- a/terraform/modules/log-streaming/subscriptions.tf
+++ b/terraform/modules/log-streaming/subscriptions.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_subscription_filter" "elasticsearch_subscription_ng
   count = "${length(var.nginx_log_groups)}"
   name = "elasticsearch-subscription-${element(var.nginx_log_groups, count.index)}"
   log_group_name = "${element(var.nginx_log_groups, count.index)}"
-  filter_pattern = "{ $.request != \"*/_status?ignore-dependencies *\" }"
+  filter_pattern = "{ $.request != \"*/_status?ignore-dependencies *\" && $.status != 429 }"
   destination_arn = "${aws_lambda_function.log_stream_lambda.arn}"
   depends_on = ["aws_lambda_permission.cloudwatch_nginx"]
 }

--- a/terraform/modules/log-streaming/subscriptions.tf
+++ b/terraform/modules/log-streaming/subscriptions.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_log_subscription_filter" "elasticsearch_subscription_ng
   count = "${length(var.nginx_log_groups)}"
   name = "elasticsearch-subscription-${element(var.nginx_log_groups, count.index)}"
   log_group_name = "${element(var.nginx_log_groups, count.index)}"
-  filter_pattern = "{ $.request != \"*/_status?ignore-dependencies *\" && $.status != 429 }"
+  filter_pattern = "{ $.request != \"*/_status?ignore-dependencies *\" }"
   destination_arn = "${aws_lambda_function.log_stream_lambda.arn}"
   depends_on = ["aws_lambda_permission.cloudwatch_nginx"]
 }


### PR DESCRIPTION
We want to start rate limiting IP addresses due to notable incidents of very high traffic from particular IPs causing us to exceed the daily storage limit on our loggit stacks.

IP rate limiting at our nginx router will generate nginx access logs, which will still clutter Kibana and use storage space - exactly what we're trying to avoid. The long term plan is to _not_ send these logs to Kibana from Cloudwatch. We _will_ still want visibility on the number of 429's (rate limited responses) we're returning however. We can do this my sending a metric to Hosted Graphite and displaying it on our dashboard, as well as setting up alerting on it.

Originally this PR was going to filter the 429's from being sent to Loggit, but we decided that for the time being we would send them, so we have better visibility in Kibana into what's happening when we switch on rate limiting. Once we're happy the right things are happening, we can start filtering them out.

This PR also switches the statistic Hosted Graphite is using from `samplecount` to `sum`. The reason for this is so we can start sending metrics with a default value of zero (if, for example, we don't have any 500's within a certain period). Currently we don't send anything in these cases so Hosted Graphite uses a null value for missing metrics. Fortunately Hosted Graphite has the ability to display null values as zero (which we are currently doing), but it would be better to provide complete data. Sending default values can only really begin once we start using the `sum` statistic on our dashboards (ie. once this PR is merged and the dashboards updated). Sending it before would skew the figures horribly for graphs still using `samplecount`.

Within Hosted Graphite, we continue to use the `max` data view. This is how Hosted Graphite displays the statistic being received from CloudWatch. `max` shows the maximal value received for the metric in the time period being displayed. This is necessary due to the way Hosted Graphite handles datapoints with the same timestamp. It aggregates them all rather than only using the latest recieved; this differs to how normal Graphite works. Every minute we send the last 10 minutes worth of metric values from CloudWatch to Hosted Graphite. This means that if we used the `sum` data view we'd show massively exaggerated values.

This is how the new DM Overview dashboard would look:

![screen shot 2018-01-03 at 12 00 20 2](https://user-images.githubusercontent.com/13836290/34520855-9dda407c-f082-11e7-9b70-cfcd0f60b4f5.png)


