### PR TITLE
Add extra environment variables required for metric-exporter app

### DIFF
--- a/vars/metric-exporter.yaml
+++ b/vars/metric-exporter.yaml
@@ -1,0 +1,13 @@
+# Variables to be added to the environment variables for the metric-exporter app manifest
+# Some variables are left to be replaced by the user as they use secret values
+# Further detail available in the Digital Marketplace manual
+---
+API_ENDPOINT: https://api.cloud.service.gov.uk
+DEBUG: false
+METRIC_TEMPLATE: {{.Space}}.{{.App}}.{{.Instance}}.{{.Metric}}
+SKIP_SSL_VALIDATION: false
+UPDATE_FREQUENCY: 60
+STATSD_ENDPOINT: statsd_endpoint_to_be_replaced
+STATSD_PREFIX: statsd_prefix_to_be_replaced_to_be_replaced
+USERNAME: monitoring_account_cloud_foundry_username_to_be_replaced
+PASSWORD: monitoring_account_cloud_foundry_password_to_be_replaced


### PR DESCRIPTION
We deploy a paas metric exporter app -
https://github.com/alphagov/paas-metric-exporter - on to the paas.
As part of this we must provide environment variables for the
metric exporter app such as config and credentials. This new
file stores stores all the extra configuration we need plus
gaps for credentials which are also required for deployment. Either
a developer can manually copy these into the paas-metric-exporter
manifest or they can be set using the Cloud Foundry CLI.

Note, credentials have been left with dummy vars so a developer
will need to find these credentials for deployment. I did not go
to the trouble of building a templating solution which will pull
them in from the credentials repo because it is very rare we will
need to deploy the application and I believe our current templating
code in this repo is very much tied to variables being linked to an
environment (preview, staging, prod) which is not the case for
this monitoring app.