### PR TITLE
Ignore mkdir error

### DIFF
--- a/scripts/apply-cleaned-db-to-target.sh
+++ b/scripts/apply-cleaned-db-to-target.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 echo "Target is: ${TARGET}"
 
-mkdir ./dumps
+mkdir -p ./dumps
 LATEST_PROD_DUMP=$(aws s3 ls digitalmarketplace-database-backups | grep production | sort -r | head -1 | awk '{print $4}')
 pg_dump --no-acl --no-owner --clean postgres://postgres:@localhost:63306/postgres | gzip > ./dumps/cleaned-"${LATEST_PROD_DUMP%.*}"
 


### PR DESCRIPTION
## Summary
This week's re-index of staging failed because the week before also failed, leaving a 'dumps' directory around. When the script came to create the 'dumps' directory again with `mkdir dumps`, it broke the whole pipeline. By adding the `-p` flag, `mkdir` will ignore directories that already exist and allow the script to continue.