### PR TITLE
Add metric whitelist so we only ship metrics we use

### DIFF
--- a/vars/metric-exporter.yml
+++ b/vars/metric-exporter.yml
@@ -5,6 +5,7 @@
 API_ENDPOINT: https://api.cloud.service.gov.uk
 DEBUG: false
 METRIC_TEMPLATE: {{.Space}}.{{.App}}.{{.Instance}}.{{.Metric}}
+METRIC_WHITELIST: cpu,diskBytes,memoryBytes
 SKIP_SSL_VALIDATION: false
 UPDATE_FREQUENCY: 60
 STATSD_ENDPOINT: statsd_endpoint_to_be_replaced


### PR DESCRIPTION
To save on our limit of metrics that Hosted Graphite can store,
we will only ship PaaS application metrics that we are actually
using in Hosted Graphite. This will save us lots of unused metrics
such as `requests` and `responseTime` that we are not using.

https://github.com/alphagov/paas-metric-exporter#metric-whitelist