### PR TITLE
Add script to create missing log alerts in Hosted Graphite

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There are a few independent tools we're using that are configured and run from t
 
 * [Terraform](https://www.terraform.io/) (modules and configuration files in `terraform/`) is used
   to create and manage AWS resources (DNS records, CloudWatch logs, S3 buckets etc.)
-* `scripts` contains executable scripts we use to manage our PaaS environments
+* `scripts` contains executable scripts we use to manage our PaaS environments and Hosted Graphite
 * `dmaws` contains some helper python functions used by some of the scripts
 * `paas` contains PaaS manifest templates that are rendered by `make generate-manifest`
 * `vars` contains environment specific variables used in the PaaS manifest generation

--- a/scripts/create-hosted-graphite-alerts.py
+++ b/scripts/create-hosted-graphite-alerts.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Description:
+    Sets up alerts for missing logs for our applications using the Hosted Graphite alerting API
+
+    https://www.hostedgraphite.com/docs/alerting/alerting_api.html
+
+    Note, this script has been used as a one off to create alerts. If a user wishes to edit existing alerts than this
+    will likely not work as there will be a 409 (conflict) response returned. As this is likely a rare process, it is
+    advised to manually delete alerts that you wish to replace before rerunning this script.
+
+Usage:
+    scripts/create-hosted-graphite-alerts.py <hosted_graphite_api_key>
+
+Example:
+    scripts/create-hosted-graphite-alerts.py apikey
+"""
+import json
+
+import requests
+from docopt import docopt
+
+
+# No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
+# pipeline and also production
+ENVIRONMENTS = ["preview", "production"]
+
+APPS = ["api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
+        "router", "supplier-frontend", "user-frontend"]
+
+
+def get_alert_json(environment, app):
+    """
+    For a given environment and application, return the JSON required to set up an alert that will trigger if either
+    no nginx log event metrics or no application log event metrics are received for 10 minutes.
+
+    We use an OR statement for either nginx or application logs so we can save on the number of alerts we are using. A
+    developer seeing this alert will need to manually diagnose if it is just one or both of the log types that have
+    stopped. Note, the router app only has nginx logs so we do not need to do this for the router.
+
+    These alerts are not editable through the Hosted Graphite GUI as referenced in the API documentation at time of
+    writing:
+
+    `Our UI doesn’t fully support composites at the moment. As a result, composite alerts cannot be edited via the UI -
+    it needs to be done via the API. The alert overview page (when you click the eye button on an alert) will only
+    display one metric for the alert instead of all the metrics associated. However the alert notifications are working
+    and will display the graph of the last metric that breached the alert threshold. So for example, if the alert is
+    a && b, and a breaches the threshold, then a few minutes later b breaches it’s threshold, the alert notification
+    will show the metric graph for b`
+    """
+    data = {
+        "name": "{} {} missing logs".format(environment, app),
+        "metric": "cloudwatch.incoming_log_events.{}.{}.nginx_logs.sum".format(environment, app),
+        "alert_criteria": {
+            "type": "missing",
+            "time_period": 10,  # 10 minutes chosen as smoke tests should be triggering logs every 5 minutes
+        },
+        "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
+        "notification_type": ["every", 60],
+        "info": """No incoming log events metrics for the last 10 minutes for the {} app. This could be either the \
+application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
+Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
+have inconsistencies. See HG alerting API for details""".format(app)
+    }
+
+    if app != "router":
+        # The router app does not have application logs
+        data.update({
+            "additional_criteria": {
+                "b": {
+                    "metric": "cloudwatch.incoming_log_events.{}.{}.application_logs.sum".format(environment, app),
+                    "type": "missing",
+                    "time_period": 10,
+                }
+            },
+            "expression": "a || b",
+        })
+
+    return data
+
+
+def generate_alerts(api_key):
+    endpoint = "https://api.hostedgraphite.com/v2/alerts/"
+    for environment in ENVIRONMENTS:
+        for app in APPS:
+            print("Creating missing logs alert for {} {}".format(environment, app))
+            alert = get_alert_json(environment, app)
+            resp = requests.post(endpoint, auth=(api_key, ''), data=json.dumps(alert))
+            resp.raise_for_status()
+
+
+if __name__ == "__main__":
+    arguments = docopt(__doc__)
+    generate_alerts(arguments['<hosted_graphite_api_key>'])


### PR DESCRIPTION
https://trello.com/c/tZghClQt/354-add-a-hosted-graphite-alert-for-missing-logs

We want to know if our logging infrastructure breaks. We can do
this by monitoring AWS `incomingLogEvents` metrics. If no logs
are being added to AWS Cloudwatch log groups for a period of time
then we can trigger an alert.

Note, we looked into setting these up as AWS Cloudwatch alerts
but ended up not going down that path. This was because
- it would be another type of infrastructure to use
- slack alerts would be extra work to set up than emails which
differs from our current alerts
- terraform doesn't let you set up cloudwatch alerts that go to
an email address (email is an unsupported protocol as described
https://www.terraform.io/docs/providers/aws/r/sns_topic_subscription.html)
unless the email alert is set up manually without using terraform

Relies on metric shipping PR - https://github.com/alphagov/digitalmarketplace-cloudwatch-to-graphite/pull/7

Note, this is currently live on preview as part of my testing but not for staging/production.

I have also taken this opportunity to put into code the current 4 alerts that we have on Hosted Graphite already.
