### PR TITLE
Bump instance size

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -12,7 +12,7 @@ applications:
 {% endif %}
     instances: {{ instances|default(1) }}
     memory: {{ memory|default('512M') }}
-    disk_quota: {{ disk_quota|default('1024M') }}
+    disk_quota: {{ disk_quota|default('2G') }}
     env:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}


### PR DESCRIPTION
## Summary
Bump instance sizes to 2G as we are getting 500s on buyer-frontend due to disk full. This will need further work from 2ndline and should only be considered a stopgap measure.

## Ticket
https://trello.com/c/hWPgbVc8/210