### PR TITLE
Add Jenkins_2

### DIFF
--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -48,4 +48,7 @@ module "jenkins" {
   source = "../../modules/jenkins"
   aws_main_account_id = "${var.aws_main_account_id}"
   aws_sub_account_ids = "${var.aws_sub_account_ids}"
+  jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
+  jenkins_2_key_name = "${var.jenkins_2_key_name}"
+  jenkins_2_public_key = "${var.jenkins_2_public_key}"
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -37,3 +37,13 @@ resource "aws_route53_record" "ci_marketplace_team" {
     "${var.jenkins_ip}"
   ]
 }
+
+resource "aws_route53_record" "ci2_marketplace_team" {
+  zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
+  name = "ci2.marketplace.team"
+  type = "A"
+  ttl = "300"
+  records = [
+    "${module.jenkins.jenkins_2_elastic_ip}"
+  ]
+}

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -1,4 +1,9 @@
 variable "jenkins_ip" {}
+variable "jenkins_security_group_ids" {
+  type = "list"
+}
+variable "jenkins_2_key_name" {}
+variable "jenkins_2_public_key" {}
 variable "dev_user_ips" {
   type = "list"
 }

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
-  version = "1.6.0"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
-  version = "1.6.0"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region = "eu-west-1"
-  version = "1.6.0"
+  version = "1.9.0"
 }
 
 terraform {

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_instance" "jenkins2" {
+  ami           = "ami-785db401"
+  instance_type = "t2.large"
+  iam_instance_profile = "${aws_iam_instance_profile.jenkins.name}"
+  key_name = "${aws_key_pair.jenkins2_2.key_name}"
+  vpc_security_group_ids = "${var.jenkins_security_group_ids}"
+
+  tags {
+    Name = "Jenkins2"
+  }
+
+}
+
+resource "aws_eip" "jenkins2" {
+  vpc      = true
+}
+
+resource "aws_eip_association" "jenkins2_eip_assoc" {
+  instance_id   = "${aws_instance.jenkins2.id}"
+  allocation_id = "${aws_eip.jenkins2.id}"
+}
+
+resource "aws_key_pair" "jenkins2_2" {
+  key_name   = "${var.jenkins_2_key_name}"
+  public_key = "${var.jenkins_2_public_key}"
+}
+
+resource "aws_ebs_volume" "jenkins2_volume" {
+    availability_zone = "${aws_instance.jenkins2.availability_zone}"
+    type = "gp2"
+    size = 100
+}
+
+resource "aws_volume_attachment" "jenkins2_ebs_att" {
+  device_name = "/dev/xvdf"
+  volume_id   = "${aws_ebs_volume.jenkins2_volume.id}"
+  instance_id = "${aws_instance.jenkins2.id}"
+}

--- a/terraform/modules/jenkins/outputs.tf
+++ b/terraform/modules/jenkins/outputs.tf
@@ -1,0 +1,3 @@
+output "jenkins_2_elastic_ip" {
+  value = "${aws_eip.jenkins2.public_ip}"
+}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -2,3 +2,8 @@ variable "aws_main_account_id" {}
 variable "aws_sub_account_ids" {
   type = "list"
 }
+variable "jenkins_security_group_ids" {
+  type = "list"
+}
+variable "jenkins_2_key_name" {}
+variable "jenkins_2_public_key" {}

--- a/terraform/modules/log-streaming/subscriptions.tf
+++ b/terraform/modules/log-streaming/subscriptions.tf
@@ -1,5 +1,4 @@
 data "aws_region" "current" {
-  current = true
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This adds the Terraform code to spin up a new instance for a new Jenkins
box. This is being done to allow pen testers to test a Jenkins instance
that isn't our actual instance. It will be provisioned via Ansiible to
be a similar as we can get it.

This Terraform code uses the existing security group that is applied to
our current box, and the same instance profile.

There is an extra security group applied, which is to allow access to
the box from Cyberis's IP's.

This could lay the groundwork for a new, upgraded Jenkins box which
could be built in the future. Alternatively, this Terraform could be
scrapped and we could move Jenkins to the PaaS.