### PR TITLE
Allow disabling MFA

### DIFF
--- a/terraform/modules/iam-common/common_policies.tf
+++ b/terraform/modules/iam-common/common_policies.tf
@@ -40,6 +40,7 @@ resource "aws_iam_policy" "iam_manage_account" {
       "Action": [
         "iam:ChangePassword",
         "iam:EnableMFADevice",
+        "iam:DeactivateMFADevice",
         "iam:ResyncMFADevice",
         "iam:GetUser",
         "iam:ListMFADevices"
@@ -49,7 +50,8 @@ resource "aws_iam_policy" "iam_manage_account" {
     {
       "Effect": "Allow",
       "Action": [
-        "iam:CreateVirtualMFADevice"
+        "iam:CreateVirtualMFADevice",
+        "iam:DeleteVirtualMFADevice"
       ],
       "Resource": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:mfa/$${aws:username}"
     },


### PR DESCRIPTION
 ## Summary
I have a new phone and I can't change my MFA in the console as it needs
me to disable my existing MFA before I can, presumably, setup my new
one. So everyone needs permission to disable their own MFA.