### PR TITLE
Increase staging instance counts to match prod

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,6 +1,15 @@
 ---
 domain: staging.marketplace.team
-instances: 2
+instances: 5
+
+router:
+  instances: 3
 
 api:
   memory: 2GB
+
+user-frontend:
+  instances: 2
+
+admin-frontend:
+  instances: 2


### PR DESCRIPTION
We want to run some load tests against staging. We should have matching
instance counts/sizes between staging and prod for this.