### PR TITLE
Force destroy IAM users if we delete them

### DIFF
--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -1,55 +1,69 @@
 resource "aws_iam_user" "andrew_chong" {
   name = "andrewchong"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "ben_vandersteen" {
   name = "benvandersteen"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "brendan_barber" {
   name = "brendanbutler"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "chris_wynne" {
   name = "chriswynne"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "david_mcdonald" {
   name = "davidmcdonald"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "dilwoar_hussain" {
   name = "dilwoarhussain"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "george_lund" {
   name = "georgelund"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "kat_stevens" {
   name = "katstevens"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "laurence_berry" {
   name = "laurenceberry"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "louise_ryan" {
   name = "louiseryan"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "murilo_dal_ri" {
   name = "murilodalri"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "pea_tyczynska" {
   name = "peatyczynska"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "robert_scott" {
   name = "robertscott"
+  force_destroy = true
 }
 
 resource "aws_iam_user" "samuel_williams" {
   name = "samuelwilliams"
+  force_destroy = true
 }


### PR DESCRIPTION
We recently ran into a problem when trying to remove an IAM user.
It would complain that terraform couldn't remove the user because
they had existing login-profiles that needed to be deleted first.
This may be because login profiles were set up manually.

The solution to this is for our users to be marked as `force_destroy`
so that if we choose to delete them, terraform will also destroy
any of their related login profiles and keys.

https://www.terraform.io/docs/providers/aws/r/iam_user.html#force_destroy

https://github.com/hashicorp/terraform/issues/5908