### PR TITLE
Update metric alert timing from 10min to 15min

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,11 @@
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # D203: 1 blank line required before class docstring
+# E402: module level import not at top of file
 # F401: 'identifier' imported but unused
 # W503: line break before binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
-ignore = D203,W503
+ignore = D203,W503,E402
 max-complexity = 12
 max-line-length = 120
 putty-ignore =

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,12 @@ test-unit: virtualenv
 	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
 
 .PHONY: requirements
-requirements: virtualenv ## Install requirements
+requirements: virtualenv requirements.txt
 	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
+
+.PHONY: requirements-dev
+requirements-dev: virtualenv requirements-dev.txt
+	${VIRTUALENV_ROOT}/bin/pip install -r requirements-dev.txt
 
 .PHONY: virtualenv
 virtualenv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist

--- a/dmaws/hosted_graphite/create_alerts.py
+++ b/dmaws/hosted_graphite/create_alerts.py
@@ -104,23 +104,26 @@ have inconsistencies. See HG alerting API for details""".format(app)
     return data
 
 
-def create_missing_logs_alerts(api_key):
-    # No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
-    # pipeline and also production
-    ENVIRONMENTS = ["preview", "production"]
-    APPS = ["api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
-            "router", "supplier-frontend", "user-frontend"]
-
-    for environment in ENVIRONMENTS:
-        for app in APPS:
-            print("Creating missing logs alert for {} {}".format(environment, app))
-            create_alert(api_key, get_missing_logs_alert_json(environment, app))
-
-
 def create_alert(api_key, alert):
     endpoint = "https://api.hostedgraphite.com/v2/alerts/"
     resp = requests.post(endpoint, auth=(api_key, ''), data=json.dumps(alert))
     resp.raise_for_status()
+
+
+# No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
+# pipeline and also production
+ALERT_ENVIRONMENTS = ["preview", "production"]
+ALERT_APPS = [
+    "api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
+    "router", "supplier-frontend", "user-frontend"
+]
+
+
+def create_missing_logs_alerts(api_key):
+    for environment in ALERT_ENVIRONMENTS:
+        for app in ALERT_APPS:
+            print("Creating missing logs alert for {} {}".format(environment, app))
+            create_alert(api_key, get_missing_logs_alert_json(environment, app))
 
 
 def create_alerts(api_key):

--- a/dmaws/hosted_graphite/create_alerts.py
+++ b/dmaws/hosted_graphite/create_alerts.py
@@ -1,0 +1,129 @@
+import json
+import requests
+
+
+ALERTS = [
+    {
+        "name": "Production Router 500s",
+        "metric": "cloudwatch.application_500s.production.router.500s.sum",
+        "alert_criteria": {
+            "type": "above",
+            "above_value": 0
+        },
+        "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
+        "notification_type": ["every", 60],
+        "info": "500s have occured"
+    },
+    {
+        "name": "Production Router 429s",
+        "metric": "cloudwatch.router_429s.production.router.429s.sum",
+        "alert_criteria": {
+            "type": "above",
+            "above_value": 0
+        },
+        "notification_channels": ["Notify DM 2ndline"],
+        "notification_type": ["every", 60],
+        "info": """429s responses being returned from the production router. Check CloudWatch for the IP address to make
+sure this is a crawler rather than a legitimate request"""
+    },
+    {
+        "name": "Production Router slow requests (10+ seconds)",
+        "metric": "cloudwatch.request_time_buckets.production.router.request_time_bucket_9.sum",
+        "alert_criteria": {
+            "type": "above",
+            "above_value": 5
+        },
+        "notification_channels": ["Notify DM 2ndline"],
+        "notification_type": ["every", 60],
+        "info": "5+ requests taking 10+ seconds from the production router in the last minute"
+    },
+    {
+        "name": "Production Router slow requests (5-10 seconds)",
+        "metric": "cloudwatch.request_time_buckets.production.router.request_time_bucket_8.sum",
+        "alert_criteria": {
+            "type": "above",
+            "above_value": 5
+        },
+        "notification_channels": ["Notify DM 2ndline"],
+        "notification_type": ["every", 60],
+        "info": "5+ requests taking 5-10 seconds from the production router in the last minute"
+    },
+]
+
+
+def get_missing_logs_alert_json(environment, app):
+    """
+    For a given environment and application, return the JSON required to set up an alert that will trigger if either
+    no nginx log event metrics or no application log event metrics are received for 15 minutes.
+
+    We use an OR statement for either nginx or application logs so we can save on the number of alerts we are using. A
+    developer seeing this alert will need to manually diagnose if it is just one or both of the log types that have
+    stopped. Note, the router app only has nginx logs so we do not need to do this for the router.
+
+    These alerts are not editable through the Hosted Graphite GUI as referenced in the API documentation at time of
+    writing:
+
+    `Our UI doesn’t fully support composites at the moment. As a result, composite alerts cannot be edited via the UI -
+    it needs to be done via the API. The alert overview page (when you click the eye button on an alert) will only
+    display one metric for the alert instead of all the metrics associated. However the alert notifications are working
+    and will display the graph of the last metric that breached the alert threshold. So for example, if the alert is
+    a && b, and a breaches the threshold, then a few minutes later b breaches it’s threshold, the alert notification
+    will show the metric graph for b`
+
+    Time period for alerting missing logs is set to 15 minutes. The smoke tests run every 5 minutes, this allows
+    some wiggle room to avoid false positives arising from a delay in shipping the metrics from Cloudwatch.
+    """
+    data = {
+        "name": "{} {} missing logs".format(environment, app),
+        "metric": "cloudwatch.incoming_log_events.{}.{}.nginx_logs.sum".format(environment, app),
+        "alert_criteria": {
+            "type": "missing",
+            "time_period": 15,
+        },
+        "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
+        "notification_type": ["every", 60],
+        "info": """No incoming log events metrics for the last 10 minutes for the {} app. This could be either the \
+application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
+Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
+have inconsistencies. See HG alerting API for details""".format(app)
+    }
+
+    if app != "router":
+        # The router app does not have application logs
+        data.update({
+            "additional_criteria": {
+                "b": {
+                    "metric": "cloudwatch.incoming_log_events.{}.{}.application_logs.sum".format(environment, app),
+                    "type": "missing",
+                    "time_period": 15,
+                }
+            },
+            "expression": "a || b",
+        })
+
+    return data
+
+
+def create_missing_logs_alerts(api_key):
+    # No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
+    # pipeline and also production
+    ENVIRONMENTS = ["preview", "production"]
+    APPS = ["api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
+            "router", "supplier-frontend", "user-frontend"]
+
+    for environment in ENVIRONMENTS:
+        for app in APPS:
+            print("Creating missing logs alert for {} {}".format(environment, app))
+            create_alert(api_key, get_missing_logs_alert_json(environment, app))
+
+
+def create_alert(api_key, alert):
+    endpoint = "https://api.hostedgraphite.com/v2/alerts/"
+    resp = requests.post(endpoint, auth=(api_key, ''), data=json.dumps(alert))
+    resp.raise_for_status()
+
+
+def create_alerts(api_key):
+    for alert in ALERTS:
+        print("Creating alert for {}".format(alert["name"]))
+        create_alert(api_key, alert)

--- a/dmaws/hosted_graphite/create_alerts.py
+++ b/dmaws/hosted_graphite/create_alerts.py
@@ -71,8 +71,8 @@ def get_missing_logs_alert_json(environment, app):
     a && b, and a breaches the threshold, then a few minutes later b breaches it’s threshold, the alert notification
     will show the metric graph for b`
 
-    Time period for alerting missing logs is set to 15 minutes. The smoke tests run every 5 minutes, this allows
-    some wiggle room to avoid false positives arising from a delay in shipping the metrics from Cloudwatch.
+    Time period for alerting missing logs is set to 15 minutes. This allows some wiggle room to avoid false positives
+    arising from a delay in shipping the metrics from Cloudwatch (the smoke tests run every 5 minutes).
     """
     data = {
         "name": "{} {} missing logs".format(environment, app),
@@ -111,19 +111,10 @@ def create_alert(api_key, alert):
     resp.raise_for_status()
 
 
-# No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
-# pipeline and also production
-ALERT_ENVIRONMENTS = ["preview", "production"]
-ALERT_APPS = [
-    "api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
-    "router", "supplier-frontend", "user-frontend"
-]
-
-
-def create_missing_logs_alerts(api_key):
+def create_missing_logs_alerts(api_key, environments, apps):
     # TODO: Log any 409 failures (alert already present) and continue with next alert
-    for environment in ALERT_ENVIRONMENTS:
-        for app in ALERT_APPS:
+    for environment in environments:
+        for app in apps:
             print("Creating missing logs alert for {} {}".format(environment, app))
             create_alert(api_key, get_missing_logs_alert_json(environment, app))
 

--- a/dmaws/hosted_graphite/create_alerts.py
+++ b/dmaws/hosted_graphite/create_alerts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 import requests
 
@@ -82,7 +83,7 @@ def get_missing_logs_alert_json(environment, app):
         },
         "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
         "notification_type": ["every", 60],
-        "info": """No incoming log events metrics for the last 10 minutes for the {} app. This could be either the \
+        "info": """No incoming log events metrics for the last 15 minutes for the {} app. This could be either the \
 application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
 Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
 have inconsistencies. See HG alerting API for details""".format(app)
@@ -120,6 +121,7 @@ ALERT_APPS = [
 
 
 def create_missing_logs_alerts(api_key):
+    # TODO: Log any 409 failures (alert already present) and continue with next alert
     for environment in ALERT_ENVIRONMENTS:
         for app in ALERT_APPS:
             print("Creating missing logs alert for {} {}".format(environment, app))
@@ -127,6 +129,7 @@ def create_missing_logs_alerts(api_key):
 
 
 def create_alerts(api_key):
+    # TODO: Log any 409 failures (alert already present) and continue with next alert
     for alert in ALERTS:
         print("Creating alert for {}".format(alert["name"]))
         create_alert(api_key, alert)

--- a/dmaws/hosted_graphite/create_dashboards.py
+++ b/dmaws/hosted_graphite/create_dashboards.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+import requests
+
+sys.path.insert(0, '.')  # noqa
+
+
+def generate_dashboards(api_key):
+    endpoint = "https://api.hostedgraphite.com/api/v2/grafana/dashboards/"
+    path = os.path.join(os.path.dirname(__file__), "../grafana/")
+
+    for filename in os.listdir(path):
+        with open(path + filename) as fp:
+            resp = requests.put(endpoint, auth=(api_key, ''), data=fp.read())
+            resp.raise_for_status()

--- a/dmaws/hosted_graphite/create_dashboards.py
+++ b/dmaws/hosted_graphite/create_dashboards.py
@@ -6,9 +6,13 @@ import requests
 sys.path.insert(0, '.')  # noqa
 
 
+def get_grafana_dashboard_folder():
+    return os.path.join(os.path.dirname(__file__), "../grafana/")
+
+
 def generate_dashboards(api_key):
     endpoint = "https://api.hostedgraphite.com/api/v2/grafana/dashboards/"
-    path = os.path.join(os.path.dirname(__file__), "../grafana/")
+    path = get_grafana_dashboard_folder()
 
     for filename in os.listdir(path):
         with open(path + filename) as fp:

--- a/dmaws/hosted_graphite/create_dashboards.py
+++ b/dmaws/hosted_graphite/create_dashboards.py
@@ -1,9 +1,6 @@
 import os
-import sys
 
 import requests
-
-sys.path.insert(0, '.')  # noqa
 
 
 def get_grafana_dashboard_folder():

--- a/scripts/create-hosted-graphite-alerts.py
+++ b/scripts/create-hosted-graphite-alerts.py
@@ -16,137 +16,13 @@ Usage:
 Example:
     scripts/create-hosted-graphite-alerts.py apikey
 """
-import json
-
-import requests
 from docopt import docopt
-
-ALERTS = [
-    {
-        "name": "Production Router 500s",
-        "metric": "cloudwatch.application_500s.production.router.500s.sum",
-        "alert_criteria": {
-            "type": "above",
-            "above_value": 0
-        },
-        "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
-        "notification_type": ["every", 60],
-        "info": "500s have occured"
-    },
-    {
-        "name": "Production Router 429s",
-        "metric": "cloudwatch.router_429s.production.router.429s.sum",
-        "alert_criteria": {
-            "type": "above",
-            "above_value": 0
-        },
-        "notification_channels": ["Notify DM 2ndline"],
-        "notification_type": ["every", 60],
-        "info": """429s responses being returned from the production router. Check CloudWatch for the IP address to make
-sure this is a crawler rather than a legitimate request"""
-    },
-    {
-        "name": "Production Router slow requests (10+ seconds)",
-        "metric": "cloudwatch.request_time_buckets.production.router.request_time_bucket_9.sum",
-        "alert_criteria": {
-            "type": "above",
-            "above_value": 5
-        },
-        "notification_channels": ["Notify DM 2ndline"],
-        "notification_type": ["every", 60],
-        "info": "5+ requests taking 10+ seconds from the production router in the last minute"
-    },
-    {
-        "name": "Production Router slow requests (5-10 seconds)",
-        "metric": "cloudwatch.request_time_buckets.production.router.request_time_bucket_8.sum",
-        "alert_criteria": {
-            "type": "above",
-            "above_value": 5
-        },
-        "notification_channels": ["Notify DM 2ndline"],
-        "notification_type": ["every", 60],
-        "info": "5+ requests taking 5-10 seconds from the production router in the last minute"
-    },
-]
-
-
-def get_missing_logs_alert_json(environment, app):
-    """
-    For a given environment and application, return the JSON required to set up an alert that will trigger if either
-    no nginx log event metrics or no application log event metrics are received for 15 minutes.
-
-    We use an OR statement for either nginx or application logs so we can save on the number of alerts we are using. A
-    developer seeing this alert will need to manually diagnose if it is just one or both of the log types that have
-    stopped. Note, the router app only has nginx logs so we do not need to do this for the router.
-
-    These alerts are not editable through the Hosted Graphite GUI as referenced in the API documentation at time of
-    writing:
-
-    `Our UI doesn’t fully support composites at the moment. As a result, composite alerts cannot be edited via the UI -
-    it needs to be done via the API. The alert overview page (when you click the eye button on an alert) will only
-    display one metric for the alert instead of all the metrics associated. However the alert notifications are working
-    and will display the graph of the last metric that breached the alert threshold. So for example, if the alert is
-    a && b, and a breaches the threshold, then a few minutes later b breaches it’s threshold, the alert notification
-    will show the metric graph for b`
-
-    Time period for alerting missing logs is set to 15 minutes. The smoke tests run every 5 minutes, this allows
-    some wiggle room to avoid false positives arising from a delay in shipping the metrics from Cloudwatch.
-    """
-    data = {
-        "name": "{} {} missing logs".format(environment, app),
-        "metric": "cloudwatch.incoming_log_events.{}.{}.nginx_logs.sum".format(environment, app),
-        "alert_criteria": {
-            "type": "missing",
-            "time_period": 15,
-        },
-        "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
-        "notification_type": ["every", 60],
-        "info": """No incoming log events metrics for the last 10 minutes for the {} app. This could be either the \
-application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
-Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
-have inconsistencies. See HG alerting API for details""".format(app)
-    }
-
-    if app != "router":
-        # The router app does not have application logs
-        data.update({
-            "additional_criteria": {
-                "b": {
-                    "metric": "cloudwatch.incoming_log_events.{}.{}.application_logs.sum".format(environment, app),
-                    "type": "missing",
-                    "time_period": 15,
-                }
-            },
-            "expression": "a || b",
-        })
-
-    return data
-
-
-def create_missing_logs_alerts(api_key):
-    # No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
-    # pipeline and also production
-    ENVIRONMENTS = ["preview", "production"]
-    APPS = ["api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
-            "router", "supplier-frontend", "user-frontend"]
-
-    for environment in ENVIRONMENTS:
-        for app in APPS:
-            print("Creating missing logs alert for {} {}".format(environment, app))
-            create_alert(api_key, get_missing_logs_alert_json(environment, app))
-
-
-def create_alert(api_key, alert):
-    endpoint = "https://api.hostedgraphite.com/v2/alerts/"
-    resp = requests.post(endpoint, auth=(api_key, ''), data=json.dumps(alert))
-    resp.raise_for_status()
+from dmaws.hosted_graphite.create_alerts import create_alerts, create_missing_logs_alerts
 
 
 if __name__ == "__main__":
     api_key = docopt(__doc__)["<hosted_graphite_api_key>"]
 
-    for alert in ALERTS:
-        print("Creating alert for {}".format(alert["name"]))
-        create_alert(api_key, alert)
+    create_alerts(api_key)
 
     create_missing_logs_alerts(api_key)

--- a/scripts/create-hosted-graphite-alerts.py
+++ b/scripts/create-hosted-graphite-alerts.py
@@ -16,7 +16,12 @@ Usage:
 Example:
     scripts/create-hosted-graphite-alerts.py apikey
 """
+import sys
+
 from docopt import docopt
+
+sys.path.insert(0, '.')
+
 from dmaws.hosted_graphite.create_alerts import create_alerts, create_missing_logs_alerts
 
 

--- a/scripts/create-hosted-graphite-alerts.py
+++ b/scripts/create-hosted-graphite-alerts.py
@@ -28,6 +28,16 @@ from dmaws.hosted_graphite.create_alerts import create_alerts, create_missing_lo
 if __name__ == "__main__":
     api_key = docopt(__doc__)["<hosted_graphite_api_key>"]
 
+    # 500, 429 and slow request alerts
     create_alerts(api_key)
 
-    create_missing_logs_alerts(api_key)
+    # Missing log alerts.
+    # No staging alert as we have a limit on how many alerts we can have and this will cover both the first step of our
+    # pipeline and also production
+    environments = ["preview", "production"]
+    apps = [
+        "api", "search-api", "admin-frontend", "buyer-frontend", "briefs-frontend", "brief-responses-frontend",
+        "router", "supplier-frontend", "user-frontend"
+    ]
+
+    create_missing_logs_alerts(api_key, environments, apps)

--- a/scripts/create-hosted-graphite-dashboards.py
+++ b/scripts/create-hosted-graphite-dashboards.py
@@ -22,25 +22,8 @@ Usage:
 Example:
     scripts/create-hosted-graphite-dashboards.py apikey
 """
-
-import os
-import sys
-
-import requests
-from docopt import docopt
-
-sys.path.insert(0, '.')  # noqa
-
-
-def generate_dashboards(api_key):
-    endpoint = "https://api.hostedgraphite.com/api/v2/grafana/dashboards/"
-    path = os.path.join(os.path.dirname(__file__), "../grafana/")
-
-    for filename in os.listdir(path):
-        with open(path + filename) as fp:
-            resp = requests.put(endpoint, auth=(api_key, ''), data=fp.read())
-            resp.raise_for_status()
-
+import docopt
+from dmaws.hosted_graphite.create_dashboards import generate_dashboards
 
 if __name__ == "__main__":
     arguments = docopt(__doc__)

--- a/scripts/create-hosted-graphite-dashboards.py
+++ b/scripts/create-hosted-graphite-dashboards.py
@@ -22,7 +22,12 @@ Usage:
 Example:
     scripts/create-hosted-graphite-dashboards.py apikey
 """
+import sys
+
 import docopt
+
+sys.path.insert(0, '.')
+
 from dmaws.hosted_graphite.create_dashboards import generate_dashboards
 
 if __name__ == "__main__":

--- a/tests/test_hosted_graphite_scripts.py
+++ b/tests/test_hosted_graphite_scripts.py
@@ -1,0 +1,69 @@
+import mock
+import pytest
+import requests
+import requests_mock
+
+from dmaws.hosted_graphite.create_alerts import create_alert, create_alerts, ALERTS
+
+
+@pytest.yield_fixture
+def rmock():
+    with requests_mock.mock() as rmock:
+        yield rmock
+
+
+@mock.patch('dmaws.hosted_graphite.create_alerts.create_alert')
+def test_create_alerts_calls_create_alert_for_each_alert(create_alert):
+    create_alerts('api_key')
+    assert create_alert.call_args_list == [
+        mock.call('api_key', alert) for alert in ALERTS
+    ]
+
+
+def test_create_alert_posts_to_hosted_graphite_api(rmock):
+    rmock.request(
+        "POST", 'https://api.hostedgraphite.com/v2/alerts/',
+        json={"id": 1}, status_code=201
+    )
+
+    create_alert('api_key', ALERTS[0])
+
+    assert rmock.last_request.json() == {
+        "name": "Production Router 500s",
+        "metric": "cloudwatch.application_500s.production.router.500s.sum",
+        "alert_criteria": {
+            "type": "above",
+            "above_value": 0
+        },
+        "notification_channels": ["Notify DM 2ndline"],
+        "notification_type": ["every", 60],
+        "info": "500s have occured"
+    }
+
+
+def test_create_alert_raises_for_status_on_error(rmock):
+    rmock.request(
+        "POST", 'https://api.hostedgraphite.com/v2/alerts/',
+        status_code=500,
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError) as exc:
+        create_alert('api_key', ALERTS[0])
+
+    assert str(exc.value) == '500 Server Error: None for url: https://api.hostedgraphite.com/v2/alerts/'
+
+
+def test_get_missing_logs_alert_json_has_additional_criteria_for_frontend_and_api_apps():
+    pass
+
+
+def test_get_missing_logs_alert_json_does_not_have_additional_criteria_for_router_app():
+    pass
+
+
+def test_create_missing_logs_alerts_creates_alerts():
+    pass
+
+
+def test_generate_dashboards():
+    pass

--- a/tests/test_hosted_graphite_scripts.py
+++ b/tests/test_hosted_graphite_scripts.py
@@ -1,4 +1,7 @@
-import builtins
+try:
+    import __builtin__ as builtins
+except ImportError:
+    import builtins
 import mock
 import pytest
 import requests
@@ -68,7 +71,7 @@ def test_get_missing_logs_alert_json_has_additional_criteria_for_non_router_apps
         },
         "notification_channels": ["Notify DM 2ndline"],
         "notification_type": ["every", 60],
-        "info": """No incoming log events metrics for the last 10 minutes for the api app. This could be either the \
+        "info": """No incoming log events metrics for the last 15 minutes for the api app. This could be either the \
 application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
 Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
 have inconsistencies. See HG alerting API for details""",
@@ -94,7 +97,7 @@ def test_get_missing_logs_alert_json_does_not_have_additional_criteria_for_route
         },
         "notification_channels": ["Notify DM 2ndline"],
         "notification_type": ["every", 60],
-        "info": """No incoming log events metrics for the last 10 minutes for the router app. This could be either the \
+        "info": """No incoming log events metrics for the last 15 minutes for the router app. This could be either the \
 application logs or the nginx logs or both. This could indicate either a problem with metric shipping to Hosted \
 Graphite or that the logs are not being created.\nDO NOT MANUALLY EDIT - Set up through Hosted Graphite API so GUI may \
 have inconsistencies. See HG alerting API for details"""


### PR DESCRIPTION
Changes the missing log alert threshold from 10 minutes to 15 minutes.

While looking at this, I realised a) I didn't fully understand the Hosted Graphite scripts b) the only way to test them was to actually run them for real. So I wrote some tests! This meant moving most of their code into new modules within the `dmaws` folder (the top level scripts remain where they are, so the paths won't have changed).

Also there was no `make requirements-dev` command for this repo, so I added one 👼 