### PR TITLE
Increase api and supplier instance counts for g10 applications

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,9 +13,13 @@ router:
 
 api:
   memory: 2GB
+  instances: 10
 
 user-frontend:
   instances: 2
 
 admin-frontend:
   instances: 2
+
+supplier-frontend:
+  instances: 10


### PR DESCRIPTION
Applications for a framework are our busiest period. Suppliers
submitting declarations and services puts a high load on the
supplier-frontend and the api. We have load tested to ensure that with
this level of instance counts we can handle approximately 2.5X the
expected traffic.