### PR TITLE
Move maintenance mode variable

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,6 +1,4 @@
 ---
-maintenance_mode: live
-
 router:
   routes:
     - www.{env}.marketplace.team

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -1,5 +1,6 @@
 ---
 domain: preview.marketplace.team
+maintenance_mode: live
 
 api:
   memory: 2GB

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -1,5 +1,6 @@
 ---
 domain: "digitalmarketplace.service.gov.uk"
+maintenance_mode: live
 instances: 5
 
 router:

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,5 +1,6 @@
 ---
 domain: staging.marketplace.team
+maintenance_mode: live
 instances: 5
 
 router:


### PR DESCRIPTION
## Summary
Rather than defining maintenance mode in the common vars, which will
make it affect all environments simultaneously, we should define it on a
per-environment basis so that we are able to toggle it for specific
environments without the risk of accidentally also turning it on for
production.

This will allow us to more safely have a job that can toggle maintenance
mode on/off.