### PR TITLE
Enforce formatting on terraform files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ python:
   - "2.7"
   - "3.6"
 env:
-  - TERRAFORM_VERSION=0.11.7 TERRAFORM_DOWNLOAD_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+  - TERRAFORM_VERSION=0.11.7 TERRAFORM_FILE_NAME=terraform_${TERRAFORM_VERSION}_linux_amd64.zip TERRAFORM_DOWNLOAD_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_FILE_NAME}
 install:
   - wget ${TERRAFORM_DOWNLOAD_URL}
-  - tar -xzf elasticsearch-${TERRAFORM_VERSION}.tar.gz
-  - ./elasticsearch-${TERRAFORM_VERSION}/bin/elasticsearch > /dev/null &
-  - make requirements-dev
-install:
+  - unzip -o ${TERRAFORM_FILE_NAME} -d /tmp
+  - export PATH=/tmp:${PATH}
   - pip install --no-use-wheel -r requirements-dev.txt
 script:
   - make terraformat

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,17 @@ language: python
 python:
   - "2.7"
   - "3.6"
+env:
+  - TERRAFORM_VERSION=0.11.7 TERRAFORM_DOWNLOAD_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+install:
+  - wget ${TERRAFORM_DOWNLOAD_URL}
+  - tar -xzf elasticsearch-${TERRAFORM_VERSION}.tar.gz
+  - ./elasticsearch-${TERRAFORM_VERSION}/bin/elasticsearch > /dev/null &
+  - make requirements-dev
 install:
   - pip install --no-use-wheel -r requirements-dev.txt
 script:
+  - make terraformat
   - make test
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ test: test-flake8 test-unit
 terraformat:
 	./scripts/check-terraform-formatting.sh
 
+.PHONY: terraformat-apply
+terraformat-apply:
+	terraform fmt -list=true -diff=true -write=true terraform
+
 .PHONY: test-flake8
 test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ help:
 .PHONY: test
 test: test-flake8 test-unit
 
+.PHONY: terraformat
+terraformat:
+	./scripts/check-terraform-formatting.sh
+
 .PHONY: test-flake8
 test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .

--- a/scripts/check-terraform-formatting.sh
+++ b/scripts/check-terraform-formatting.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+LINT_OUTPUT=$(terraform fmt -write=false -list=true -diff=true terraform)
+if [ ! -z "${LINT_OUTPUT}" ]; then
+  echo "${LINT_OUTPUT}"
+  echo "Terraform formatting check has FAILED. Fix formatting issues with \`terraform fmt -write=true -list=true -diff=true terraform\` from the root of the repository."
+  exit 1
+fi
+
+echo "Terraform formatting check has PASSED."

--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -1,20 +1,20 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-development"
-    key = "accounts/development/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-development"
+    key     = "accounts/development/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "aws_env" {
-  source = "../../modules/aws-env"
-  dev_user_ips = "${var.dev_user_ips}"
+  source              = "../../modules/aws-env"
+  dev_user_ips        = "${var.dev_user_ips}"
   aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id = "${var.aws_dev_account_id}"
+  aws_dev_account_id  = "${var.aws_dev_account_id}"
 }

--- a/terraform/accounts/development/s3_buckets.tf
+++ b/terraform/accounts/development/s3_buckets.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "dev_uploads_s3_bucket" {
   bucket = "digitalmarketplace-dev-uploads"
   acl    = "private"
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",

--- a/terraform/accounts/main/ci.tf
+++ b/terraform/accounts/main/ci.tf
@@ -1,38 +1,38 @@
 resource "aws_security_group" "ci_sg" {
-  name = "jenkins-ci-InstanceSecurityGroup-1N45R6TJPJ1YJ"
+  name        = "jenkins-ci-InstanceSecurityGroup-1N45R6TJPJ1YJ"
   description = "Main instance security group"
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_security_group_rule" "allow_ssh_to_ci" {
   security_group_id = "${aws_security_group.ci_sg.id}"
-  type = "ingress"
-  from_port = 22
-  to_port = 22
-  protocol = "tcp"
-  cidr_blocks = ["${var.dev_user_ips}"]
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.dev_user_ips}"]
 }
 
 resource "aws_security_group_rule" "allow_https_to_ci" {
   security_group_id = "${aws_security_group.ci_sg.id}"
-  type = "ingress"
-  from_port = 443
-  to_port = 443
-  protocol = "tcp"
-  cidr_blocks = ["${var.dev_user_ips}"]
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.dev_user_ips}"]
 }
 
 resource "aws_security_group_rule" "allow_letsencrypt_check" {
   security_group_id = "${aws_security_group.ci_sg.id}"
-  type = "ingress"
-  from_port = 80
-  to_port = 80
-  protocol = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -1,52 +1,55 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-main"
-    key = "accounts/main/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-main"
+    key     = "accounts/main/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "iam_common" {
-  source = "../../modules/iam-common"
-  dev_user_ips = "${var.dev_user_ips}"
+  source              = "../../modules/iam-common"
+  dev_user_ips        = "${var.dev_user_ips}"
   aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id = "${var.aws_dev_account_id}"
+  aws_dev_account_id  = "${var.aws_dev_account_id}"
 }
 
 module "iam_users" {
-  source = "../../modules/iam-users"
-  admins = "${var.admins}"
-  developers = "${var.developers}"
-  dev_s3_only_users = "${var.dev_s3_only_users}"
-  prod_developers = "${var.prod_developers}"
-  dev_infrastructure_users = "${var.dev_infrastructure_users}"
-  prod_infrastructure_users = "${var.prod_infrastructure_users}"
+  source                          = "../../modules/iam-users"
+  admins                          = "${var.admins}"
+  developers                      = "${var.developers}"
+  dev_s3_only_users               = "${var.dev_s3_only_users}"
+  prod_developers                 = "${var.prod_developers}"
+  dev_infrastructure_users        = "${var.dev_infrastructure_users}"
+  prod_infrastructure_users       = "${var.prod_infrastructure_users}"
   ip_restricted_access_policy_arn = "${module.iam_common.aws_iam_policy_ip_restricted_access_arn}"
-  iam_manage_account_policy_arn = "${module.iam_common.aws_iam_policy_iam_manage_account_arn}"
-  admin_policy_arn = "${module.iam_common.aws_iam_policy_admin_arn}"
-  developer_policy_arn = "${module.iam_common.aws_iam_policy_developer_arn}"
-  aws_dev_account_id = "${var.aws_dev_account_id}"
-  aws_prod_account_id = "${var.aws_prod_account_id}"
+  iam_manage_account_policy_arn   = "${module.iam_common.aws_iam_policy_iam_manage_account_arn}"
+  admin_policy_arn                = "${module.iam_common.aws_iam_policy_admin_arn}"
+  developer_policy_arn            = "${module.iam_common.aws_iam_policy_developer_arn}"
+  aws_dev_account_id              = "${var.aws_dev_account_id}"
+  aws_prod_account_id             = "${var.aws_prod_account_id}"
 }
 
 module "sops_credentials" {
   source = "../../modules/sops-credentials"
+
   # Make sure you update the count here (see https://github.com/hashicorp/terraform/issues/1497 for more info)
   sops_credentials_access_iam_groups_count = 1
+
   sops_credentials_access_iam_groups = [
-    "${module.iam_users.developers_group_name}"
+    "${module.iam_users.developers_group_name}",
   ]
+
   aws_account_ids = "${concat(list(var.aws_main_account_id), var.aws_sub_account_ids)}"
 }
 
 module "jenkins" {
-  source = "../../modules/jenkins"
+  source              = "../../modules/jenkins"
   aws_main_account_id = "${var.aws_main_account_id}"
   aws_sub_account_ids = "${var.aws_sub_account_ids}"
 }

--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -4,9 +4,10 @@ resource "aws_route53_zone" "marketplace_team" {
 
 resource "aws_route53_record" "preview_ns" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
-  name = "preview.marketplace.team"
-  type = "NS"
-  ttl = "3600"
+  name    = "preview.marketplace.team"
+  type    = "NS"
+  ttl     = "3600"
+
   records = [
     "ns-389.awsdns-48.com",
     "ns-2018.awsdns-60.co.uk",
@@ -17,9 +18,10 @@ resource "aws_route53_record" "preview_ns" {
 
 resource "aws_route53_record" "staging_ns" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
-  name = "staging.marketplace.team"
-  type = "NS"
-  ttl = "3600"
+  name    = "staging.marketplace.team"
+  type    = "NS"
+  ttl     = "3600"
+
   records = [
     "ns-175.awsdns-21.com",
     "ns-781.awsdns-33.net",
@@ -30,10 +32,11 @@ resource "aws_route53_record" "staging_ns" {
 
 resource "aws_route53_record" "ci_marketplace_team" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
-  name = "ci.marketplace.team"
-  type = "A"
-  ttl = "300"
+  name    = "ci.marketplace.team"
+  type    = "A"
+  ttl     = "300"
+
   records = [
-    "${var.jenkins_ip}"
+    "${var.jenkins_ip}",
   ]
 }

--- a/terraform/accounts/main/s3_buckets.tf
+++ b/terraform/accounts/main/s3_buckets.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "database_backups_s3_bucket" {
   acl    = "private"
 
   versioning {
-    enabled = true
+    enabled    = true
     mfa_delete = true
   }
 }

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -1,30 +1,38 @@
 variable "jenkins_ip" {}
+
 variable "dev_user_ips" {
   type = "list"
 }
 
 variable "aws_main_account_id" {}
+
 variable "aws_sub_account_ids" {
   type = "list"
 }
+
 variable "aws_dev_account_id" {}
 variable "aws_prod_account_id" {}
 
 variable "admins" {
   type = "list"
 }
+
 variable "developers" {
   type = "list"
 }
+
 variable "prod_developers" {
   type = "list"
 }
+
 variable "dev_s3_only_users" {
   type = "list"
 }
+
 variable "dev_infrastructure_users" {
   type = "list"
 }
+
 variable "prod_infrastructure_users" {
   type = "list"
 }

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -1,20 +1,20 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-production"
-    key = "accounts/production/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-production"
+    key     = "accounts/production/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "aws_env" {
-  source = "../../modules/aws-env"
-  dev_user_ips = "${var.dev_user_ips}"
+  source              = "../../modules/aws-env"
+  dev_user_ips        = "${var.dev_user_ips}"
   aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id = "${var.aws_dev_account_id}"
+  aws_dev_account_id  = "${var.aws_dev_account_id}"
 }

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -1,53 +1,53 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-development"
-    key = "environments/preview/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-development"
+    key     = "environments/preview/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "preview_router" {
   source = "../../modules/router"
-  name = "preview-router"
+  name   = "preview-router"
 
   domain = "preview.marketplace.team"
 
   log_retention_days = "180"
 
-  cname_domain = "d3eyi6749eogkv.cloudfront.net"
-  www_acme_challenge = "10BxG5sYBrsXy9nTFn4U2dn90v0ic7yFGkf5egYYzvM"
-  api_acme_challenge = "dTEB4iW45IMydD38YUCjjwtbaX1V-tXki-J1dZ4IIK4"
+  cname_domain              = "d3eyi6749eogkv.cloudfront.net"
+  www_acme_challenge        = "10BxG5sYBrsXy9nTFn4U2dn90v0ic7yFGkf5egYYzvM"
+  api_acme_challenge        = "dTEB4iW45IMydD38YUCjjwtbaX1V-tXki-J1dZ4IIK4"
   search_api_acme_challenge = "mn-kwBxpLeqkLBenVhQYZIoX02iIaMPaAiYw1ndiKy4"
-  assets_acme_challenge = "nml3dVZaOkLIUql5v6rxPb-vHy2PoXbJ6oFGzMB8SrY"
+  assets_acme_challenge     = "nml3dVZaOkLIUql5v6rxPb-vHy2PoXbJ6oFGzMB8SrY"
 }
 
 module "application_logs" {
   source = "../../modules/application-logs"
 
-  environment = "preview"
+  environment       = "preview"
   retention_in_days = "180"
 }
 
 module "log_streaming" {
   source = "../../modules/log-streaming"
 
-  name = "preview-log-stream-lambda"
-  elasticsearch_url = "${var.logs_elasticsearch_url}"
+  name                  = "preview-log-stream-lambda"
+  elasticsearch_url     = "${var.logs_elasticsearch_url}"
   elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
-  nginx_log_groups = ["${concat(module.preview_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
+  nginx_log_groups       = ["${concat(module.preview_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
   application_log_groups = ["${module.application_logs.application_log_groups}"]
 }
 
 module "log_metrics" {
-  source = "../../modules/log-metrics"
-  environment = "preview"
-  app_names = ["${module.application_logs.app_names}"]
+  source                = "../../modules/log-metrics"
+  environment           = "preview"
+  app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.preview_router.json_log_groups, 0)}"
 }

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -3,9 +3,11 @@ variable "aws_main_account_id" {}
 variable "admin_user_ips" {
   type = "list"
 }
+
 variable "dev_user_ips" {
   type = "list"
 }
+
 variable "user_ips" {
   type = "list"
 }

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,53 +1,53 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-production"
-    key = "environments/production/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-production"
+    key     = "environments/production/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "production_router" {
   source = "../../modules/router"
-  name = "production-router"
+  name   = "production-router"
 
   domain = "digitalmarketplace.service.gov.uk"
 
   log_retention_days = "3653"
 
-  cname_domain = "d3pp9vxqezcjw2.cloudfront.net"
-  www_acme_challenge = "6R2Srug_clrhWCdEv-BXP9bbZY88cBSk_d5B9CFaiDM"
-  api_acme_challenge = "eovwGgagiCUwdb-NlbZndlV6JIukpZtK2MJQcXtb5ec"
+  cname_domain              = "d3pp9vxqezcjw2.cloudfront.net"
+  www_acme_challenge        = "6R2Srug_clrhWCdEv-BXP9bbZY88cBSk_d5B9CFaiDM"
+  api_acme_challenge        = "eovwGgagiCUwdb-NlbZndlV6JIukpZtK2MJQcXtb5ec"
   search_api_acme_challenge = "6BF1gcDwKfuLc_xCP1Se8PIjXjL8Ayk8QFgDxqsX8qw"
-  assets_acme_challenge = "qFDTBZVXxuuaMqgm1c-D5wX4iRJogcnTEaJdhDSG-rw"
+  assets_acme_challenge     = "qFDTBZVXxuuaMqgm1c-D5wX4iRJogcnTEaJdhDSG-rw"
 }
 
 module "application_logs" {
   source = "../../modules/application-logs"
 
-  environment = "production"
+  environment       = "production"
   retention_in_days = "3653"
 }
 
 module "log_streaming" {
   source = "../../modules/log-streaming"
 
-  name = "production-log-stream-lambda"
-  elasticsearch_url = "${var.logs_elasticsearch_url}"
+  name                  = "production-log-stream-lambda"
+  elasticsearch_url     = "${var.logs_elasticsearch_url}"
   elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
-  nginx_log_groups = ["${concat(module.production_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
+  nginx_log_groups       = ["${concat(module.production_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
   application_log_groups = ["${module.application_logs.application_log_groups}"]
 }
 
 module "log_metrics" {
-  source = "../../modules/log-metrics"
-  environment = "production"
-  app_names = ["${module.application_logs.app_names}"]
+  source                = "../../modules/log-metrics"
+  environment           = "production"
+  app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.production_router.json_log_groups, 0)}"
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -3,9 +3,11 @@ variable "aws_main_account_id" {}
 variable "admin_user_ips" {
   type = "list"
 }
+
 variable "dev_user_ips" {
   type = "list"
 }
+
 variable "user_ips" {
   type = "list"
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,53 +1,53 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = "eu-west-1"
   version = "1.9.0"
 }
 
 terraform {
   backend "s3" {
-    bucket = "digitalmarketplace-terraform-state-production"
-    key = "environments/staging/terraform.tfstate"
-    region = "eu-west-1"
-    encrypt =  "true"
+    bucket  = "digitalmarketplace-terraform-state-production"
+    key     = "environments/staging/terraform.tfstate"
+    region  = "eu-west-1"
+    encrypt = "true"
   }
 }
 
 module "staging_router" {
   source = "../../modules/router"
-  name = "staging-router"
+  name   = "staging-router"
 
   domain = "staging.marketplace.team"
 
   log_retention_days = "180"
 
-  cname_domain = "d316z22457q6mz.cloudfront.net"
-  www_acme_challenge = "gAvnidL435OgRSEbsmaRao8t6h556S7pR579scyWidY"
-  api_acme_challenge = "PnHbLO52oob6u-vDm1oLuO6eYA6jhZNSPZHRAwkPQSk"
+  cname_domain              = "d316z22457q6mz.cloudfront.net"
+  www_acme_challenge        = "gAvnidL435OgRSEbsmaRao8t6h556S7pR579scyWidY"
+  api_acme_challenge        = "PnHbLO52oob6u-vDm1oLuO6eYA6jhZNSPZHRAwkPQSk"
   search_api_acme_challenge = "CBejAeUi-c-88fyngXwAd9Q45ivBiPqbXm4wnD9-7nY"
-  assets_acme_challenge = "qHoJDoj_Fckc061F_DZ7BhQRhMv4EV3BYZ9hKGoew84"
+  assets_acme_challenge     = "qHoJDoj_Fckc061F_DZ7BhQRhMv4EV3BYZ9hKGoew84"
 }
 
 module "application_logs" {
   source = "../../modules/application-logs"
 
-  environment = "staging"
+  environment       = "staging"
   retention_in_days = "180"
 }
 
 module "log_streaming" {
   source = "../../modules/log-streaming"
 
-  name = "staging-log-stream-lambda"
-  elasticsearch_url = "${var.logs_elasticsearch_url}"
+  name                  = "staging-log-stream-lambda"
+  elasticsearch_url     = "${var.logs_elasticsearch_url}"
   elasticsearch_api_key = "${var.logs_elasticsearch_api_key}"
 
-  nginx_log_groups = ["${concat(module.staging_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
+  nginx_log_groups       = ["${concat(module.staging_router.json_log_groups, module.application_logs.nginx_log_groups)}"]
   application_log_groups = ["${module.application_logs.application_log_groups}"]
 }
 
 module "log_metrics" {
-  source = "../../modules/log-metrics"
-  environment = "staging"
-  app_names = ["${module.application_logs.app_names}"]
+  source                = "../../modules/log-metrics"
+  environment           = "staging"
+  app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.staging_router.json_log_groups, 0)}"
 }

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -3,9 +3,11 @@ variable "aws_main_account_id" {}
 variable "admin_user_ips" {
   type = "list"
 }
+
 variable "dev_user_ips" {
   type = "list"
 }
+
 variable "user_ips" {
   type = "list"
 }

--- a/terraform/modules/application-logs/main.tf
+++ b/terraform/modules/application-logs/main.tf
@@ -1,11 +1,11 @@
 resource "aws_cloudwatch_log_group" "application_logs" {
-  count = "${length(var.app_names)}"
-  name = "${var.environment}-${element(var.app_names, count.index)}-application"
+  count             = "${length(var.app_names)}"
+  name              = "${var.environment}-${element(var.app_names, count.index)}-application"
   retention_in_days = "${var.retention_in_days}"
 }
 
 resource "aws_cloudwatch_log_group" "nginx_logs" {
-  count = "${length(var.app_names)}"
-  name = "${var.environment}-${element(var.app_names, count.index)}-nginx"
+  count             = "${length(var.app_names)}"
+  name              = "${var.environment}-${element(var.app_names, count.index)}-nginx"
   retention_in_days = "${var.retention_in_days}"
 }

--- a/terraform/modules/application-logs/variables.tf
+++ b/terraform/modules/application-logs/variables.tf
@@ -1,7 +1,9 @@
 variable "environment" {}
 variable "retention_in_days" {}
+
 variable "app_names" {
   type = "list"
+
   default = [
     "buyer-frontend",
     "supplier-frontend",
@@ -10,6 +12,6 @@ variable "app_names" {
     "search-api",
     "briefs-frontend",
     "brief-responses-frontend",
-    "user-frontend"
+    "user-frontend",
   ]
 }

--- a/terraform/modules/aws-env/main.tf
+++ b/terraform/modules/aws-env/main.tf
@@ -1,16 +1,16 @@
 module "iam_common" {
-  source = "../../modules/iam-common"
-  dev_user_ips = "${var.dev_user_ips}"
+  source              = "../../modules/iam-common"
+  dev_user_ips        = "${var.dev_user_ips}"
   aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id = "${var.aws_dev_account_id}"
+  aws_dev_account_id  = "${var.aws_dev_account_id}"
 }
 
 module "switch_roles" {
-  source = "../../modules/switch-roles"
+  source                          = "../../modules/switch-roles"
   ip_restricted_access_policy_arn = "${module.iam_common.aws_iam_policy_ip_restricted_access_arn}"
-  iam_manage_account_policy_arn = "${module.iam_common.aws_iam_policy_iam_manage_account_arn}"
-  developer_policy_arn = "${module.iam_common.aws_iam_policy_developer_arn}"
-  aws_main_account_id = "${var.aws_main_account_id}"
+  iam_manage_account_policy_arn   = "${module.iam_common.aws_iam_policy_iam_manage_account_arn}"
+  developer_policy_arn            = "${module.iam_common.aws_iam_policy_developer_arn}"
+  aws_main_account_id             = "${var.aws_main_account_id}"
 }
 
 module "paas" {

--- a/terraform/modules/iam-common/admin.tf
+++ b/terraform/modules/iam-common/admin.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_policy" "admin" {
   name = "Admin"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -40,6 +41,7 @@ EOF
 
 resource "aws_iam_role" "admins" {
   name = "admins"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -62,6 +64,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "admins_admin" {
-  role = "${aws_iam_role.admins.name}"
+  role       = "${aws_iam_role.admins.name}"
   policy_arn = "${aws_iam_policy.admin.arn}"
 }

--- a/terraform/modules/iam-common/common_policies.tf
+++ b/terraform/modules/iam-common/common_policies.tf
@@ -1,6 +1,7 @@
 resource "aws_iam_policy" "ip_restricted_access" {
-  name = "IPRestrictedAccess"
+  name        = "IPRestrictedAccess"
   description = "Require requests to come from one of the Office IPs or admin servers (e.g. Jenkins)"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -23,6 +24,7 @@ EOF
 
 resource "aws_iam_policy" "iam_manage_account" {
   name = "IAMManageAccount"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/terraform/modules/iam-common/developers.tf
+++ b/terraform/modules/iam-common/developers.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_policy" "developer" {
   name = "Developer"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/terraform/modules/iam-common/infrastructure.tf
+++ b/terraform/modules/iam-common/infrastructure.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_policy" "infrastructure" {
   name = "infrastructure"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -36,6 +37,7 @@ EOF
 
 resource "aws_iam_role" "infrastructure" {
   name = "infrastructure"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -53,6 +55,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "infrastructure_infrastructure" {
-  role = "${aws_iam_role.infrastructure.id}"
+  role       = "${aws_iam_role.infrastructure.id}"
   policy_arn = "${aws_iam_policy.infrastructure.arn}"
 }

--- a/terraform/modules/iam-common/outputs.tf
+++ b/terraform/modules/iam-common/outputs.tf
@@ -1,15 +1,19 @@
 output "aws_iam_policy_developer_arn" {
   value = "${aws_iam_policy.developer.arn}"
 }
+
 output "aws_iam_policy_ip_restricted_access_arn" {
   value = "${aws_iam_policy.ip_restricted_access.arn}"
 }
+
 output "aws_iam_policy_admin_arn" {
   value = "${aws_iam_policy.admin.arn}"
 }
+
 output "aws_iam_policy_iam_manage_account_arn" {
   value = "${aws_iam_policy.iam_manage_account.arn}"
 }
+
 output "aws_iam_role_packer_arn" {
   value = "${aws_iam_role.packer.arn}"
 }

--- a/terraform/modules/iam-common/packer.tf
+++ b/terraform/modules/iam-common/packer.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_policy" "packer" {
   name = "Packer"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -94,6 +95,7 @@ EOF
 
 resource "aws_iam_role" "packer" {
   name = "packer"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -111,11 +113,11 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "packer_ip_restriced" {
-  role = "${aws_iam_role.packer.name}"
+  role       = "${aws_iam_role.packer.name}"
   policy_arn = "${aws_iam_policy.ip_restricted_access.arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "packer_packer" {
-  role = "${aws_iam_role.packer.id}"
+  role       = "${aws_iam_role.packer.id}"
   policy_arn = "${aws_iam_policy.packer.arn}"
 }

--- a/terraform/modules/iam-common/password_policy.tf
+++ b/terraform/modules/iam-common/password_policy.tf
@@ -1,8 +1,8 @@
 resource "aws_iam_account_password_policy" "policy" {
-  minimum_password_length = 12
-  require_lowercase_characters = true
-  require_numbers = true
-  require_uppercase_characters = true
-  require_symbols = false
+  minimum_password_length        = 12
+  require_lowercase_characters   = true
+  require_numbers                = true
+  require_uppercase_characters   = true
+  require_symbols                = false
   allow_users_to_change_password = true
 }

--- a/terraform/modules/iam-common/variables.tf
+++ b/terraform/modules/iam-common/variables.tf
@@ -1,5 +1,6 @@
 variable "dev_user_ips" {
   type = "list"
 }
+
 variable "aws_main_account_id" {}
 variable "aws_dev_account_id" {}

--- a/terraform/modules/iam-users/admins.tf
+++ b/terraform/modules/iam-users/admins.tf
@@ -3,23 +3,23 @@ resource "aws_iam_group" "admins" {
 }
 
 resource "aws_iam_group_policy_attachment" "admins_admin" {
-  group = "${aws_iam_group.admins.name}"
+  group      = "${aws_iam_group.admins.name}"
   policy_arn = "${var.admin_policy_arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admins_ip_restriced" {
-  group = "${aws_iam_group.admins.name}"
+  group      = "${aws_iam_group.admins.name}"
   policy_arn = "${var.ip_restricted_access_policy_arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admins_dev_uploads_s3" {
-  group = "${aws_iam_group.admins.name}"
+  group      = "${aws_iam_group.admins.name}"
   policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
 }
 
 resource "aws_iam_group_membership" "admins" {
-  name = "Admins"
-  users = ["${var.admins}"]
-  group = "${aws_iam_group.admins.name}"
+  name       = "Admins"
+  users      = ["${var.admins}"]
+  group      = "${aws_iam_group.admins.name}"
   depends_on = ["module.users"]
 }

--- a/terraform/modules/iam-users/developers.tf
+++ b/terraform/modules/iam-users/developers.tf
@@ -3,8 +3,9 @@ resource "aws_iam_group" "developers" {
 }
 
 resource "aws_iam_group_policy" "developers" {
-  name = "Developers"
+  name  = "Developers"
   group = "${aws_iam_group.developers.name}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -36,19 +37,19 @@ EOF
 }
 
 resource "aws_iam_group_policy_attachment" "developers_ip_restriced" {
-  group = "${aws_iam_group.developers.name}"
+  group      = "${aws_iam_group.developers.name}"
   policy_arn = "${var.ip_restricted_access_policy_arn}"
 }
 
 resource "aws_iam_group_membership" "developers" {
-  name = "developers"
-  users = ["${var.developers}"]
-  group = "${aws_iam_group.developers.name}"
+  name       = "developers"
+  users      = ["${var.developers}"]
+  group      = "${aws_iam_group.developers.name}"
   depends_on = ["module.users"]
 }
 
 resource "aws_iam_group_policy_attachment" "developers_iam_manage_account" {
-  group = "${aws_iam_group.developers.name}"
+  group      = "${aws_iam_group.developers.name}"
   policy_arn = "${var.iam_manage_account_policy_arn}"
 }
 
@@ -57,8 +58,9 @@ resource "aws_iam_group" "prod_developers" {
 }
 
 resource "aws_iam_group_policy" "switch_to_prod_developer" {
-  name = "SwitchToProdDeveloper"
+  name  = "SwitchToProdDeveloper"
   group = "${aws_iam_group.prod_developers.name}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -76,9 +78,9 @@ EOF
 }
 
 resource "aws_iam_group_membership" "prod_developers" {
-  name = "prod_developers"
-  users = ["${var.prod_developers}"]
-  group = "${aws_iam_group.prod_developers.name}"
+  name       = "prod_developers"
+  users      = ["${var.prod_developers}"]
+  group      = "${aws_iam_group.prod_developers.name}"
   depends_on = ["module.users"]
 }
 
@@ -87,24 +89,25 @@ resource "aws_iam_group" "dev_s3_only" {
 }
 
 resource "aws_iam_group_policy_attachment" "dev_s3_only" {
-  group = "${aws_iam_group.dev_s3_only.name}"
+  group      = "${aws_iam_group.dev_s3_only.name}"
   policy_arn = "${var.ip_restricted_access_policy_arn}"
 }
 
 resource "aws_iam_group_membership" "dev_s3_only" {
-  name = "dev_s3_only"
-  users = ["${var.dev_s3_only_users}"]
-  group = "${aws_iam_group.dev_s3_only.name}"
+  name       = "dev_s3_only"
+  users      = ["${var.dev_s3_only_users}"]
+  group      = "${aws_iam_group.dev_s3_only.name}"
   depends_on = ["module.users"]
 }
 
 resource "aws_iam_group_policy_attachment" "dev_s3_only_iam_manage_account" {
-  group = "${aws_iam_group.dev_s3_only.name}"
+  group      = "${aws_iam_group.dev_s3_only.name}"
   policy_arn = "${var.iam_manage_account_policy_arn}"
 }
 
 resource "aws_iam_policy" "dev_uploads_s3_access" {
   name = "devUploadsS3Access"
+
   policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -129,11 +132,11 @@ POLICY
 }
 
 resource "aws_iam_group_policy_attachment" "developers_dev_uploads_s3" {
-  group = "${aws_iam_group.developers.name}"
+  group      = "${aws_iam_group.developers.name}"
   policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "dev_s3_only_dev_uploads_s3" {
-  group = "${aws_iam_group.dev_s3_only.name}"
+  group      = "${aws_iam_group.dev_s3_only.name}"
   policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
 }

--- a/terraform/modules/iam-users/infrastructure.tf
+++ b/terraform/modules/iam-users/infrastructure.tf
@@ -3,8 +3,9 @@ resource "aws_iam_group" "dev_infrastructure" {
 }
 
 resource "aws_iam_group_policy" "dev_infrastructure" {
-  name = "DevInfrastructure"
+  name  = "DevInfrastructure"
   group = "${aws_iam_group.dev_infrastructure.name}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -25,9 +26,9 @@ EOF
 }
 
 resource "aws_iam_group_membership" "dev_infrastructure" {
-  name = "dev_infrastructure"
-  users = ["${var.dev_infrastructure_users}"]
-  group = "${aws_iam_group.dev_infrastructure.name}"
+  name       = "dev_infrastructure"
+  users      = ["${var.dev_infrastructure_users}"]
+  group      = "${aws_iam_group.dev_infrastructure.name}"
   depends_on = ["module.users"]
 }
 
@@ -36,8 +37,9 @@ resource "aws_iam_group" "prod_infrastructure" {
 }
 
 resource "aws_iam_group_policy" "prod_infrastructure" {
-  name = "ProdInfrastructure"
+  name  = "ProdInfrastructure"
   group = "${aws_iam_group.prod_infrastructure.name}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -58,8 +60,8 @@ EOF
 }
 
 resource "aws_iam_group_membership" "prod_infrastructure" {
-  name = "prod_infrastructure"
-  users = ["${var.prod_infrastructure_users}"]
-  group = "${aws_iam_group.prod_infrastructure.name}"
+  name       = "prod_infrastructure"
+  users      = ["${var.prod_infrastructure_users}"]
+  group      = "${aws_iam_group.prod_infrastructure.name}"
   depends_on = ["module.users"]
 }

--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -1,59 +1,59 @@
 resource "aws_iam_user" "andrew_chong" {
-  name = "andrewchong"
+  name          = "andrewchong"
   force_destroy = true
 }
 
 resource "aws_iam_user" "ben_vandersteen" {
-  name = "benvandersteen"
+  name          = "benvandersteen"
   force_destroy = true
 }
 
 resource "aws_iam_user" "brendan_barber" {
-  name = "brendanbutler"
+  name          = "brendanbutler"
   force_destroy = true
 }
 
 resource "aws_iam_user" "chris_wynne" {
-  name = "chriswynne"
+  name          = "chriswynne"
   force_destroy = true
 }
 
 resource "aws_iam_user" "dilwoar_hussain" {
-  name = "dilwoarhussain"
+  name          = "dilwoarhussain"
   force_destroy = true
 }
 
 resource "aws_iam_user" "george_lund" {
-  name = "georgelund"
+  name          = "georgelund"
   force_destroy = true
 }
 
 resource "aws_iam_user" "kat_stevens" {
-  name = "katstevens"
+  name          = "katstevens"
   force_destroy = true
 }
 
 resource "aws_iam_user" "laurence_berry" {
-  name = "laurenceberry"
+  name          = "laurenceberry"
   force_destroy = true
 }
 
 resource "aws_iam_user" "louise_ryan" {
-  name = "louiseryan"
+  name          = "louiseryan"
   force_destroy = true
 }
 
 resource "aws_iam_user" "pea_tyczynska" {
-  name = "peatyczynska"
+  name          = "peatyczynska"
   force_destroy = true
 }
 
 resource "aws_iam_user" "robert_scott" {
-  name = "robertscott"
+  name          = "robertscott"
   force_destroy = true
 }
 
 resource "aws_iam_user" "samuel_williams" {
-  name = "samuelwilliams"
+  name          = "samuelwilliams"
   force_destroy = true
 }

--- a/terraform/modules/iam-users/variables.tf
+++ b/terraform/modules/iam-users/variables.tf
@@ -1,12 +1,15 @@
 variable "admins" {
   type = "list"
 }
+
 variable "developers" {
   type = "list"
 }
+
 variable "prod_developers" {
   type = "list"
 }
+
 variable "dev_s3_only_users" {
   type = "list"
 }

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "jenkins" {
   name = "jenkins-ci-IAMRole-1FIPDG9DE2CWJ"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -27,6 +28,7 @@ resource "aws_iam_instance_profile" "jenkins" {
 resource "aws_iam_role_policy" "jenkins" {
   name = "Jenkins"
   role = "${aws_iam_role.jenkins.id}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -1,4 +1,5 @@
 variable "aws_main_account_id" {}
+
 variable "aws_sub_account_ids" {
   type = "list"
 }

--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -8,9 +8,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_0" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-0"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-0"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -23,9 +23,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_1" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-1"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-1"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -38,9 +38,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_2" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-2"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-2"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -53,9 +53,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_3" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-3"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-3"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -68,9 +68,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_4" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-4"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-4"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -83,9 +83,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_5" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-5"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-5"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -98,9 +98,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_6" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-6"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-6"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -113,9 +113,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_7" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-7"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-7"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -128,9 +128,9 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_8" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-8"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-8"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -143,23 +143,23 @@ resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_9" {
   log_group_name = "${var.environment}-${var.app_names[count.index]}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${var.app_names[count.index]}-request-times-9"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-${var.app_names[count.index]}-request-times-9"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "application-500s" {
-  count = "${length(var.app_names)}"
-  name  = "${var.environment}-${element(var.app_names, count.index)}-500s"
+  count          = "${length(var.app_names)}"
+  name           = "${var.environment}-${element(var.app_names, count.index)}-500s"
   pattern        = "{$$.status = 5*}"
   log_group_name = "${var.environment}-${element(var.app_names, count.index)}-nginx"
 
   metric_transformation {
-    name  = "${var.environment}-${element(var.app_names, count.index)}-nginx-500s"
-    namespace = "DM-500s"
-    value     = "1"
+    name          = "${var.environment}-${element(var.app_names, count.index)}-nginx-500s"
+    namespace     = "DM-500s"
+    value         = "1"
     default_value = "0"
   }
 }
@@ -167,157 +167,157 @@ resource "aws_cloudwatch_log_metric_filter" "application-500s" {
 # Main nginx log buckets
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_0" {
-  name  = "${var.environment}-router-request-times-0"
+  name           = "${var.environment}-router-request-times-0"
   pattern        = "{$$.requestTime >= 0 && $$.requestTime < 0.025 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-0"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-0"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_1" {
-  name  = "${var.environment}-router-request-times-1"
+  name           = "${var.environment}-router-request-times-1"
   pattern        = "{$$.requestTime >= 0.025 && $$.requestTime < 0.05 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-1"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-1"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_2" {
-  name  = "${var.environment}-router-request-times-2"
+  name           = "${var.environment}-router-request-times-2"
   pattern        = "{$$.requestTime >= 0.05 && $$.requestTime < 0.1 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-2"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-2"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_3" {
-  name  = "${var.environment}-router-request-times-3"
+  name           = "${var.environment}-router-request-times-3"
   pattern        = "{$$.requestTime >= 0.1 && $$.requestTime < 0.25 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-3"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-3"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_4" {
-  name  = "${var.environment}-router-request-times-4"
+  name           = "${var.environment}-router-request-times-4"
   pattern        = "{$$.requestTime >= 0.25 && $$.requestTime < 0.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-4"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-4"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_5" {
-  name  = "${var.environment}-router-request-times-5"
+  name           = "${var.environment}-router-request-times-5"
   pattern        = "{$$.requestTime >= 0.5 && $$.requestTime < 1 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-5"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-5"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_6" {
-  name  = "${var.environment}-router-request-times-6"
+  name           = "${var.environment}-router-request-times-6"
   pattern        = "{$$.requestTime >= 1 && $$.requestTime < 2.5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-6"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-6"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_7" {
-  name  = "${var.environment}-router-request-times-7"
+  name           = "${var.environment}-router-request-times-7"
   pattern        = "{$$.requestTime >= 2.5 && $$.requestTime < 5 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-7"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-7"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_8" {
-  name  = "${var.environment}-router-request-times-8"
+  name           = "${var.environment}-router-request-times-8"
   pattern        = "{$$.requestTime >= 5 && $$.requestTime < 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-8"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-8"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_router_9" {
-  name  = "${var.environment}-router-request-times-9"
+  name           = "${var.environment}-router-request-times-9"
   pattern        = "{$$.requestTime >= 10 && $$.request != \"*/_status?ignore-dependencies *\"}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-request-times-9"
-    namespace = "DM-RequestTimeBuckets"
-    value     = "1"
+    name          = "${var.environment}-router-request-times-9"
+    namespace     = "DM-RequestTimeBuckets"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "router-500s" {
-  name  = "${var.environment}-router-500s"
+  name           = "${var.environment}-router-500s"
   pattern        = "{$$.status = 5*}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-nginx-500s"
-    namespace = "DM-500s"
-    value     = "1"
+    name          = "${var.environment}-router-nginx-500s"
+    namespace     = "DM-500s"
+    value         = "1"
     default_value = "0"
   }
 }
 
 resource "aws_cloudwatch_log_metric_filter" "router-429s" {
-  name  = "${var.environment}-router-429s"
+  name           = "${var.environment}-router-429s"
   pattern        = "{$$.status = 429}"
   log_group_name = "${var.router_log_group_name}"
 
   metric_transformation {
-    name  = "${var.environment}-router-nginx-429s"
-    namespace = "DM-429s"
-    value     = "1"
+    name          = "${var.environment}-router-nginx-429s"
+    namespace     = "DM-429s"
+    value         = "1"
     default_value = "0"
   }
 }

--- a/terraform/modules/log-metrics/variables.tf
+++ b/terraform/modules/log-metrics/variables.tf
@@ -1,5 +1,7 @@
 variable "environment" {}
+
 variable "app_names" {
-	type="list"
+  type = "list"
 }
+
 variable "router_log_group_name" {}

--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -1,17 +1,17 @@
 data "archive_file" "lambda_zip" {
-  type = "zip"
-  source_dir = "../../modules/log-streaming/src"
+  type        = "zip"
+  source_dir  = "../../modules/log-streaming/src"
   output_path = "../../modules/log-streaming/lambda.zip"
 }
 
 resource "aws_cloudwatch_log_group" "lambda_logs" {
-  name = "/aws/lambda/${var.name}"
+  name              = "/aws/lambda/${var.name}"
   retention_in_days = 7
 }
 
-
 resource "aws_iam_role" "lambda" {
   name = "${var.name}"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -28,10 +28,10 @@ resource "aws_iam_role" "lambda" {
 EOF
 }
 
-
 resource "aws_iam_role_policy" "lambda_logging" {
   name = "${var.name}"
   role = "${aws_iam_role.lambda.id}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -53,19 +53,19 @@ EOF
 }
 
 resource "aws_lambda_function" "log_stream_lambda" {
-  function_name = "${var.name}"
-  description = "Stream CloudWatch Logs to Elasticsearch"
-  filename = "../../modules/log-streaming/lambda.zip"
+  function_name    = "${var.name}"
+  description      = "Stream CloudWatch Logs to Elasticsearch"
+  filename         = "../../modules/log-streaming/lambda.zip"
   source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
-  role = "${aws_iam_role.lambda.arn}"
-  handler = "main.handler"
-  runtime = "nodejs6.10"
-  memory_size = 128
-  timeout = 10
+  role             = "${aws_iam_role.lambda.arn}"
+  handler          = "main.handler"
+  runtime          = "nodejs6.10"
+  memory_size      = 128
+  timeout          = 10
 
   environment {
     variables = {
-      ELASTICSEARCH_URL = "${var.elasticsearch_url}"
+      ELASTICSEARCH_URL     = "${var.elasticsearch_url}"
       ELASTICSEARCH_API_KEY = "${var.elasticsearch_api_key}"
     }
   }

--- a/terraform/modules/log-streaming/subscriptions.tf
+++ b/terraform/modules/log-streaming/subscriptions.tf
@@ -1,40 +1,39 @@
-data "aws_region" "current" {
-}
+data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
 resource "aws_lambda_permission" "cloudwatch_nginx" {
-  count = "${length(var.nginx_log_groups)}"
-  statement_id = "cloudwatch-lambda-${element(var.nginx_log_groups, count.index)}"
-  action = "lambda:InvokeFunction"
+  count         = "${length(var.nginx_log_groups)}"
+  statement_id  = "cloudwatch-lambda-${element(var.nginx_log_groups, count.index)}"
+  action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.log_stream_lambda.arn}"
-  principal = "logs.${data.aws_region.current.name}.amazonaws.com"
-  source_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${element(var.nginx_log_groups, count.index)}:*"
+  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${element(var.nginx_log_groups, count.index)}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "elasticsearch_subscription_nginx" {
-  count = "${length(var.nginx_log_groups)}"
-  name = "elasticsearch-subscription-${element(var.nginx_log_groups, count.index)}"
-  log_group_name = "${element(var.nginx_log_groups, count.index)}"
-  filter_pattern = "{ $.request != \"*/_status?ignore-dependencies *\" }"
+  count           = "${length(var.nginx_log_groups)}"
+  name            = "elasticsearch-subscription-${element(var.nginx_log_groups, count.index)}"
+  log_group_name  = "${element(var.nginx_log_groups, count.index)}"
+  filter_pattern  = "{ $.request != \"*/_status?ignore-dependencies *\" }"
   destination_arn = "${aws_lambda_function.log_stream_lambda.arn}"
-  depends_on = ["aws_lambda_permission.cloudwatch_nginx"]
+  depends_on      = ["aws_lambda_permission.cloudwatch_nginx"]
 }
 
 resource "aws_lambda_permission" "cloudwatch_application" {
-  count = "${length(var.application_log_groups)}"
-  statement_id = "cloudwatch-lambda-${element(var.application_log_groups, count.index)}"
-  action = "lambda:InvokeFunction"
+  count         = "${length(var.application_log_groups)}"
+  statement_id  = "cloudwatch-lambda-${element(var.application_log_groups, count.index)}"
+  action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.log_stream_lambda.arn}"
-  principal = "logs.${data.aws_region.current.name}.amazonaws.com"
-  source_arn = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${element(var.application_log_groups, count.index)}:*"
+  principal     = "logs.${data.aws_region.current.name}.amazonaws.com"
+  source_arn    = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${element(var.application_log_groups, count.index)}:*"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "elasticsearch_subscription_application" {
-  count = "${length(var.application_log_groups)}"
-  name = "elasticsearch-subscription-${element(var.application_log_groups, count.index)}"
-  log_group_name = "${element(var.application_log_groups, count.index)}"
-  filter_pattern = "{ $.url NOT EXISTS || $.url != \"*/_status?ignore-dependencies\" }"
+  count           = "${length(var.application_log_groups)}"
+  name            = "elasticsearch-subscription-${element(var.application_log_groups, count.index)}"
+  log_group_name  = "${element(var.application_log_groups, count.index)}"
+  filter_pattern  = "{ $.url NOT EXISTS || $.url != \"*/_status?ignore-dependencies\" }"
   destination_arn = "${aws_lambda_function.log_stream_lambda.arn}"
-  depends_on = ["aws_lambda_permission.cloudwatch_application"]
+  depends_on      = ["aws_lambda_permission.cloudwatch_application"]
 }

--- a/terraform/modules/log-streaming/variables.tf
+++ b/terraform/modules/log-streaming/variables.tf
@@ -5,6 +5,7 @@ variable "elasticsearch_api_key" {}
 variable "nginx_log_groups" {
   type = "list"
 }
+
 variable "application_log_groups" {
   type = "list"
 }

--- a/terraform/modules/paas/iam.tf
+++ b/terraform/modules/paas/iam.tf
@@ -5,6 +5,7 @@ resource "aws_iam_user" "paas_app" {
 resource "aws_iam_user_policy" "paas_app_policy" {
   user = "${aws_iam_user.paas_app.name}"
   name = "PaaSAppPolicy"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -49,6 +50,7 @@ resource "aws_iam_user" "paas_metrics_collector" {
 resource "aws_iam_user_policy" "grafana" {
   user = "${aws_iam_user.paas_metrics_collector.name}"
   name = "Grafana"
+
   policy = <<EOF
 {
     "Statement": [

--- a/terraform/modules/router/logs.tf
+++ b/terraform/modules/router/logs.tf
@@ -1,4 +1,4 @@
 resource "aws_cloudwatch_log_group" "json_logs" {
-  name = "${var.name}-nginx"
+  name              = "${var.name}-nginx"
   retention_in_days = "${var.log_retention_days}"
 }

--- a/terraform/modules/router/route53.tf
+++ b/terraform/modules/router/route53.tf
@@ -4,92 +4,92 @@ resource "aws_route53_zone" "root" {
 
 resource "aws_route53_record" "www_acme_challenge" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "_acme-challenge.www.${var.domain}"
-  type = "TXT"
-  ttl = "120",
+  name    = "_acme-challenge.www.${var.domain}"
+  type    = "TXT"
+  ttl     = "120"
 
   records = [
-    "${var.www_acme_challenge}"
+    "${var.www_acme_challenge}",
   ]
 }
 
 resource "aws_route53_record" "api_acme_challenge" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "_acme-challenge.api.${var.domain}"
-  type = "TXT"
-  ttl = "120",
+  name    = "_acme-challenge.api.${var.domain}"
+  type    = "TXT"
+  ttl     = "120"
 
   records = [
-    "${var.api_acme_challenge}"
+    "${var.api_acme_challenge}",
   ]
 }
 
 resource "aws_route53_record" "search_api_acme_challenge" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "_acme-challenge.search-api.${var.domain}"
-  type = "TXT"
-  ttl = "120",
+  name    = "_acme-challenge.search-api.${var.domain}"
+  type    = "TXT"
+  ttl     = "120"
 
   records = [
-    "${var.search_api_acme_challenge}"
+    "${var.search_api_acme_challenge}",
   ]
 }
 
 resource "aws_route53_record" "assets_acme_challenge" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "_acme-challenge.assets.${var.domain}"
-  type = "TXT"
-  ttl = "120",
+  name    = "_acme-challenge.assets.${var.domain}"
+  type    = "TXT"
+  ttl     = "120"
 
   records = [
-    "${var.assets_acme_challenge}"
+    "${var.assets_acme_challenge}",
   ]
 }
 
 resource "aws_route53_record" "www" {
-  count = "${length(var.cname_domain) == 0 ? 0 : 1}"
+  count   = "${length(var.cname_domain) == 0 ? 0 : 1}"
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "www.${var.domain}"
-  type = "CNAME"
-  ttl = "600",
+  name    = "www.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
 
   records = [
-    "${var.cname_domain}"
+    "${var.cname_domain}",
   ]
 }
 
 resource "aws_route53_record" "api" {
-  count = "${length(var.cname_domain) == 0 ? 0 : 1}"
+  count   = "${length(var.cname_domain) == 0 ? 0 : 1}"
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "api.${var.domain}"
-  type = "CNAME"
-  ttl = "600",
+  name    = "api.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
 
   records = [
-    "${var.cname_domain}"
+    "${var.cname_domain}",
   ]
 }
 
 resource "aws_route53_record" "search_api" {
-  count = "${length(var.cname_domain) == 0 ? 0 : 1}"
+  count   = "${length(var.cname_domain) == 0 ? 0 : 1}"
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "search-api.${var.domain}"
-  type = "CNAME"
-  ttl = "600",
+  name    = "search-api.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
 
   records = [
-    "${var.cname_domain}"
+    "${var.cname_domain}",
   ]
 }
 
 resource "aws_route53_record" "assets" {
-  count = "${length(var.cname_domain) == 0 ? 0 : 1}"
+  count   = "${length(var.cname_domain) == 0 ? 0 : 1}"
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name = "assets.${var.domain}"
-  type = "CNAME"
-  ttl = "600",
+  name    = "assets.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
 
   records = [
-    "${var.cname_domain}"
+    "${var.cname_domain}",
   ]
 }

--- a/terraform/modules/router/variables.tf
+++ b/terraform/modules/router/variables.tf
@@ -1,5 +1,6 @@
 variable "name" {}
 variable "domain" {}
+
 variable "cname_domain" {
   default = ""
 }

--- a/terraform/modules/sops-credentials/iam.tf
+++ b/terraform/modules/sops-credentials/iam.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_policy" "sops_credentials_access" {
   name = "SOPSCredentialsAccess"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -32,6 +33,7 @@ EOF
 
 resource "aws_iam_role" "sops_credentials_access" {
   name = "sops-credentials-access"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -49,12 +51,13 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "sops_credentials_access" {
-  role = "${aws_iam_role.sops_credentials_access.name}"
+  role       = "${aws_iam_role.sops_credentials_access.name}"
   policy_arn = "${aws_iam_policy.sops_credentials_access.arn}"
 }
 
 resource "aws_iam_policy" "assume_sops_credentials_access" {
   name = "AssumeSOPSCredentialsAccess"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -77,7 +80,7 @@ EOF
 }
 
 resource "aws_iam_group_policy_attachment" "iam_group_assume_sops_credentials_access" {
-  count = "${var.sops_credentials_access_iam_groups_count}"
-  group = "${element(var.sops_credentials_access_iam_groups, count.index)}"
+  count      = "${var.sops_credentials_access_iam_groups_count}"
+  group      = "${element(var.sops_credentials_access_iam_groups, count.index)}"
   policy_arn = "${aws_iam_policy.assume_sops_credentials_access.arn}"
 }

--- a/terraform/modules/sops-credentials/kms.tf
+++ b/terraform/modules/sops-credentials/kms.tf
@@ -1,5 +1,6 @@
 resource "aws_kms_key" "sops_credentials_primary" {
   description = "Key for encrypting/decrypting secrets in the digitalmarketplace-credentials repo using Mozilla SOPS"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -29,13 +30,14 @@ EOF
 }
 
 resource "aws_kms_alias" "sops_credentials_primary" {
-  name = "alias/sops-credentials"
+  name          = "alias/sops-credentials"
   target_key_id = "${aws_kms_key.sops_credentials_primary.key_id}"
 }
 
 resource "aws_kms_key" "sops_credentials_secondary" {
-  provider = "aws.london"
+  provider    = "aws.london"
   description = "Key for encrypting/decrypting secrets in the digitalmarketplace-credentials repo using Mozilla SOPS"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -65,7 +67,7 @@ EOF
 }
 
 resource "aws_kms_alias" "sops_credentials_secondary" {
-  provider = "aws.london"
-  name = "alias/sops-credentials"
+  provider      = "aws.london"
+  name          = "alias/sops-credentials"
   target_key_id = "${aws_kms_key.sops_credentials_secondary.key_id}"
 }

--- a/terraform/modules/sops-credentials/main.tf
+++ b/terraform/modules/sops-credentials/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias = "london"
+  alias  = "london"
   region = "eu-west-2"
 }
 

--- a/terraform/modules/sops-credentials/variables.tf
+++ b/terraform/modules/sops-credentials/variables.tf
@@ -1,7 +1,9 @@
 variable "sops_credentials_access_iam_groups_count" {}
+
 variable "sops_credentials_access_iam_groups" {
   type = "list"
 }
+
 variable "aws_account_ids" {
   type = "list"
 }

--- a/terraform/modules/switch-roles/developers.tf
+++ b/terraform/modules/switch-roles/developers.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "developers" {
   name = "developers"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -22,16 +23,16 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "developers_ip_restriced" {
-  role = "${aws_iam_role.developers.name}"
+  role       = "${aws_iam_role.developers.name}"
   policy_arn = "${var.ip_restricted_access_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "developers_developer" {
-  role = "${aws_iam_role.developers.id}"
+  role       = "${aws_iam_role.developers.id}"
   policy_arn = "${var.developer_policy_arn}"
 }
 
 resource "aws_iam_role_policy_attachment" "developers_iam_manage_account" {
-  role = "${aws_iam_role.developers.name}"
+  role       = "${aws_iam_role.developers.name}"
   policy_arn = "${var.iam_manage_account_policy_arn}"
 }


### PR DESCRIPTION
 ## Summary
Start enforcing consistent formatting of Terraform configuration files through
Travis with a new `Makefile` step that runs `terraform fmt` on Pull Requests.
Also applies an initial sweep of re-formatting, which is mostly about aligning
variable values with correct spacing.

## Ticket
https://trello.com/c/ubqlb6pm/412-enforce-terraform-code-style