### PR TITLE
Reduce staging instance counts

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,16 +1,7 @@
 ---
 domain: staging.marketplace.team
 maintenance_mode: live
-instances: 5
-
-router:
-  instances: 3
+instances: 2
 
 api:
   memory: 2GB
-
-user-frontend:
-  instances: 2
-
-admin-frontend:
-  instances: 2


### PR DESCRIPTION
See this PR for context: https://github.com/alphagov/digitalmarketplace-aws/pull/376

We increase the instance counts on staging to match prod. This was for
load testing in the run up to opening G-10 applications. The load
testing is complete so we can reduce the counts back to their original
levels.