### PR TITLE
Scale up+out for supplier applications

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,7 +13,7 @@ router:
 
 api:
   memory: 2GB
-  instances: 10
+  instances: 20
 
 user-frontend:
   instances: 2
@@ -22,4 +22,5 @@ admin-frontend:
   instances: 2
 
 supplier-frontend:
-  instances: 10
+  memory: 1G
+  instances: 20


### PR DESCRIPTION
 ## Summary
Bump the number of API and Supplier-FE instances to 20 each, and give
the Supplier-FE 1GB of memory each for the remaining application period.

 ## Ticket
https://trello.com/c/VJ9MdlsQ/310