### PR TITLE
Scale to 15 instances

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,7 +13,7 @@ router:
 
 api:
   memory: 2GB
-  instances: 20
+  instances: 15
 
 user-frontend:
   instances: 2
@@ -22,5 +22,5 @@ admin-frontend:
   instances: 2
 
 supplier-frontend:
-  memory: 1G
-  instances: 20
+  memory: 750MB
+  instances: 15


### PR DESCRIPTION
 ## Summary
We hit our PaaS quotas when trying to scale to 20 instances, so we'll
stick to 15 and reduce the supplier-fe quota slightly.

 ## Ticket
https://trello.com/c/VJ9MdlsQ/310