### PR TITLE
Scale for last day of applications

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,7 +13,7 @@ router:
 
 api:
   memory: 2GB
-  instances: 10
+  instances: 15
 
 user-frontend:
   instances: 2
@@ -23,4 +23,4 @@ admin-frontend:
 
 supplier-frontend:
   memory: 750MB
-  instances: 15
+  instances: 20


### PR DESCRIPTION
 ## Summary
We have a larger quota now, so we can scale the api and the
supplier-frontend a bit more generously to give us a greater level of
confidence in handling the anticipated final spike in traffic.