### PR TITLE
Give Jenkins role permissions for prod submissions bucket

### DIFF
--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -85,6 +85,21 @@ resource "aws_iam_role_policy" "jenkins" {
         "s3:PutObject"
       ],
       "Resource": "arn:aws:s3:::digitalmarketplace-database-backups/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::digitalmarketplace-submissions-production-production"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::digitalmarketplace-submissions-production-production/*"
     }
   ]
 }


### PR DESCRIPTION
We'd like Jenkins to run the virus scanning job for uploaded files. The
Jenkins role needs the correct permissions to do this.

The other part of this adding permissions on the bucket to allow Jenkins
to list it. We don't currently manage those buckets via Terraform so
this has been done through the GUI via the S3 Access Control List.