### PR TITLE
Use sandbox emails when cleaning dump

### DIFF
--- a/scripts/clean-db-dump.sql
+++ b/scripts/clean-db-dump.sql
@@ -34,7 +34,7 @@ WHERE awarded_at IS NULL;
 -- Sanitise personal data in awarded brief responses
 \echo 'Update brief responses'
 UPDATE brief_responses
-SET data = data::jsonb || '{"respondToEmailAddress": "cleaned-example-email@gov.uk"}'::jsonb
+SET data = data::jsonb || '{"respondToEmailAddress": "cleaned-example-email@example.gov.uk"}'::jsonb
 WHERE data::TEXT != '{}';
 
 \echo 'Delete draft briefs'
@@ -168,7 +168,7 @@ SELECT
         END ||
         '"availability": "09/09/17", ' ||
         '"essentialRequirementsMet": true, ' ||
-        '"respondToEmailAddress": "example-email@gov.uk"' ||
+        '"respondToEmailAddress": "example-email@example.gov.uk"' ||
       '}'
     )::JSON,
     eligible_brief_supplier_pairings.brief_id,


### PR DESCRIPTION
 ## Summary
When running functional tests against our test environments, we have a
wrapper around our call to Notify that translates certain email domains
to other domains which will generate successful test responses from
Notify. `@gov.uk` is not one of these and feels too generic to blacklist
in case we actually block legitimate emails out. `@example.gov.uk` feels
safer, so let's use this when cleaning up the data.

The sandbox email addresses are defined in the `config.py` of each frontend app.

At the moment we have a load of emails stuck in Notify's queue from our tests that they keep trying to deliver. We're bad people if we keep asking them to send emails to addresses that we know are not real.