### PR TITLE
Jenkins2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ in (with args; {
       pythonPackages.virtualenv
       pkgs.nodejs
       pkgs.jq
-      pkgs.aws-auth
+      ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
       pkgs.sops
       (pkgs.terraform.overrideAttrs (oldAttrs: rec {
         name = "terraform-0.11.7";

--- a/terraform/Makefile-common
+++ b/terraform/Makefile-common
@@ -17,9 +17,16 @@ init:: ## Run init
 	. .envrc && aws-auth terraform init
 
 define run_terraform
+	@set -e ;\
+	${DM_CREDENTIALS_REPO}/sops-wrapper -v > /dev/null ;\
+	PRIVATE_KEY_FILE=$$(mktemp) ;\
+	trap 'rm $$PRIVATE_KEY_FILE' EXIT ;\
+	${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem.enc > $$PRIVATE_KEY_FILE ;\
+
 	. .envrc && aws-auth terraform ${1} \
 		-var-file=<(. .envrc && aws-auth sops -d ${DM_CREDENTIALS_REPO}/terraform/${TERRAFORM_PROJECT}.json) \
 		-var-file=<(. .envrc && aws-auth sops -d ${DM_CREDENTIALS_REPO}/terraform/common.json) \
+		-var "jenkins_public_key='$$(ssh-keygen -y -f $$PRIVATE_KEY_FILE)'" \
 		${2}
 endef
 

--- a/terraform/Makefile-common
+++ b/terraform/Makefile-common
@@ -22,11 +22,10 @@ define run_terraform
 	PRIVATE_KEY_FILE=$$(mktemp) ;\
 	trap 'rm $$PRIVATE_KEY_FILE' EXIT ;\
 	${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/aws-keys/ci.pem.enc > $$PRIVATE_KEY_FILE ;\
-
 	. .envrc && aws-auth terraform ${1} \
 		-var-file=<(. .envrc && aws-auth sops -d ${DM_CREDENTIALS_REPO}/terraform/${TERRAFORM_PROJECT}.json) \
 		-var-file=<(. .envrc && aws-auth sops -d ${DM_CREDENTIALS_REPO}/terraform/common.json) \
-		-var "jenkins_public_key='$$(ssh-keygen -y -f $$PRIVATE_KEY_FILE)'" \
+		-var jenkins_public_key="$$(ssh-keygen -y -f $$PRIVATE_KEY_FILE)" \
 		${2}
 endef
 

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -59,5 +59,6 @@ module "jenkins" {
   aws_main_account_id        = "${var.aws_main_account_id}"
   aws_sub_account_ids        = "${var.aws_sub_account_ids}"
   jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
-  jenkins_public_key       = "${var.jenkins_public_key}"
+  jenkins_public_key_name    = "${var.ssh_key_name}"  # confusingly-named variable in terraform/common.json
+  jenkins_public_key         = "${var.jenkins_public_key}"
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -53,6 +53,5 @@ module "jenkins" {
   aws_main_account_id        = "${var.aws_main_account_id}"
   aws_sub_account_ids        = "${var.aws_sub_account_ids}"
   jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
-  jenkins_2_key_name         = "${var.jenkins_2_key_name}"
-  jenkins_2_public_key       = "${var.jenkins_2_public_key}"
+  jenkins_public_key       = "${var.jenkins_public_key}"
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -49,10 +49,10 @@ module "sops_credentials" {
 }
 
 module "jenkins" {
-  source              = "../../modules/jenkins"
-  aws_main_account_id = "${var.aws_main_account_id}"
-  aws_sub_account_ids = "${var.aws_sub_account_ids}"
+  source                     = "../../modules/jenkins"
+  aws_main_account_id        = "${var.aws_main_account_id}"
+  aws_sub_account_ids        = "${var.aws_sub_account_ids}"
   jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
-  jenkins_2_key_name = "${var.jenkins_2_key_name}"
-  jenkins_2_public_key = "${var.jenkins_2_public_key}"
+  jenkins_2_key_name         = "${var.jenkins_2_key_name}"
+  jenkins_2_public_key       = "${var.jenkins_2_public_key}"
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -61,14 +61,3 @@ module "jenkins" {
   jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
   jenkins_public_key       = "${var.jenkins_public_key}"
 }
-
-resource "aws_route53_record" "ci2_marketplace_team" {
-  zone_id = "ZWYYZXX20MA4S"
-  name    = "ci2.marketplace.team"
-  type    = "A"
-  ttl     = "300"
-
-  records = [
-    "52.211.70.248",
-  ]
-}

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -59,6 +59,6 @@ module "jenkins" {
   aws_main_account_id        = "${var.aws_main_account_id}"
   aws_sub_account_ids        = "${var.aws_sub_account_ids}"
   jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
-  jenkins_public_key_name    = "${var.ssh_key_name}"  # confusingly-named variable in terraform/common.json
+  jenkins_public_key_name    = "${var.ssh_key_name}"               # confusingly-named variable in terraform/common.json
   jenkins_public_key         = "${var.jenkins_public_key}"
 }

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -52,4 +52,7 @@ module "jenkins" {
   source              = "../../modules/jenkins"
   aws_main_account_id = "${var.aws_main_account_id}"
   aws_sub_account_ids = "${var.aws_sub_account_ids}"
+  jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
+  jenkins_2_key_name = "${var.jenkins_2_key_name}"
+  jenkins_2_public_key = "${var.jenkins_2_public_key}"
 }

--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -43,10 +43,11 @@ resource "aws_route53_record" "ci_marketplace_team" {
 
 resource "aws_route53_record" "ci2_marketplace_team" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
-  name = "ci2.marketplace.team"
-  type = "A"
-  ttl = "300"
+  name    = "ci2.marketplace.team"
+  type    = "A"
+  ttl     = "300"
+
   records = [
-    "${module.jenkins.jenkins_2_elastic_ip}"
+    "${module.jenkins.jenkins_2_elastic_ip}",
   ]
 }

--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -40,3 +40,13 @@ resource "aws_route53_record" "ci_marketplace_team" {
     "${var.jenkins_ip}",
   ]
 }
+
+resource "aws_route53_record" "ci2_marketplace_team" {
+  zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
+  name = "ci2.marketplace.team"
+  type = "A"
+  ttl = "300"
+  records = [
+    "${module.jenkins.jenkins_2_elastic_ip}"
+  ]
+}

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -4,6 +4,7 @@ variable "jenkins_security_group_ids" {
   type = "list"
 }
 
+variable "ssh_key_name" {}
 variable "jenkins_public_key" {}
 
 variable "dev_user_ips" {

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -1,5 +1,12 @@
 variable "jenkins_ip" {}
 
+variable "jenkins_security_group_ids" {
+  type = "list"
+}
+
+variable "jenkins_2_key_name" {}
+variable "jenkins_2_public_key" {}
+
 variable "dev_user_ips" {
   type = "list"
 }

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -4,8 +4,7 @@ variable "jenkins_security_group_ids" {
   type = "list"
 }
 
-variable "jenkins_2_key_name" {}
-variable "jenkins_2_public_key" {}
+variable "jenkins_public_key" {}
 
 variable "dev_user_ips" {
   type = "list"

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -24,7 +24,7 @@ resource "aws_eip_association" "jenkins2_eip_assoc" {
 }
 
 resource "aws_key_pair" "jenkins" {
-  key_name   = "${var.ssh_key_name}"
+  key_name   = "${var.jenkins_public_key_name}"
   public_key = "${var.jenkins_public_key}"  # injected by Makefile-common
 }
 

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -24,8 +24,8 @@ resource "aws_eip_association" "jenkins2_eip_assoc" {
 }
 
 resource "aws_key_pair" "jenkins2_2" {
-  key_name   = "${var.jenkins_2_key_name}"
-  public_key = "${var.jenkins_2_public_key}"
+  key_name   = "${var.ssh_key_name}"
+  public_key = "${var.jenkins_public_key}"  # injected by Makefile-common
 }
 
 resource "aws_ebs_volume" "jenkins2_volume" {

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -3,20 +3,19 @@ provider "aws" {
 }
 
 resource "aws_instance" "jenkins2" {
-  ami           = "ami-785db401"
-  instance_type = "t2.large"
-  iam_instance_profile = "${aws_iam_instance_profile.jenkins.name}"
-  key_name = "${aws_key_pair.jenkins2_2.key_name}"
+  ami                    = "ami-785db401"
+  instance_type          = "t2.large"
+  iam_instance_profile   = "${aws_iam_instance_profile.jenkins.name}"
+  key_name               = "${aws_key_pair.jenkins2_2.key_name}"
   vpc_security_group_ids = "${var.jenkins_security_group_ids}"
 
   tags {
     Name = "Jenkins2"
   }
-
 }
 
 resource "aws_eip" "jenkins2" {
-  vpc      = true
+  vpc = true
 }
 
 resource "aws_eip_association" "jenkins2_eip_assoc" {
@@ -30,9 +29,9 @@ resource "aws_key_pair" "jenkins2_2" {
 }
 
 resource "aws_ebs_volume" "jenkins2_volume" {
-    availability_zone = "${aws_instance.jenkins2.availability_zone}"
-    type = "gp2"
-    size = 100
+  availability_zone = "${aws_instance.jenkins2.availability_zone}"
+  type              = "gp2"
+  size              = 100
 }
 
 resource "aws_volume_attachment" "jenkins2_ebs_att" {

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "jenkins2" {
-  ami                    = "ami-785db401"
+  ami                    = "ami-2a7d75c0"
   instance_type          = "t2.large"
   iam_instance_profile   = "${aws_iam_instance_profile.jenkins.name}"
   key_name               = "${aws_key_pair.jenkins.key_name}"

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -25,7 +25,7 @@ resource "aws_eip_association" "jenkins2_eip_assoc" {
 
 resource "aws_key_pair" "jenkins" {
   key_name   = "${var.jenkins_public_key_name}"
-  public_key = "${var.jenkins_public_key}"  # injected by Makefile-common
+  public_key = "${var.jenkins_public_key}"      # injected by Makefile-common
 }
 
 resource "aws_ebs_volume" "jenkins2_volume" {

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_instance" "jenkins2" {
+  ami           = "ami-785db401"
+  instance_type = "t2.large"
+  iam_instance_profile = "${aws_iam_instance_profile.jenkins.name}"
+  key_name = "${aws_key_pair.jenkins2_2.key_name}"
+  vpc_security_group_ids = "${var.jenkins_security_group_ids}"
+
+  tags {
+    Name = "Jenkins2"
+  }
+
+}
+
+resource "aws_eip" "jenkins2" {
+  vpc      = true
+}
+
+resource "aws_eip_association" "jenkins2_eip_assoc" {
+  instance_id   = "${aws_instance.jenkins2.id}"
+  allocation_id = "${aws_eip.jenkins2.id}"
+}
+
+resource "aws_key_pair" "jenkins2_2" {
+  key_name   = "${var.jenkins_2_key_name}"
+  public_key = "${var.jenkins_2_public_key}"
+}
+
+resource "aws_ebs_volume" "jenkins2_volume" {
+    availability_zone = "${aws_instance.jenkins2.availability_zone}"
+    type = "gp2"
+    size = 100
+}
+
+resource "aws_volume_attachment" "jenkins2_ebs_att" {
+  device_name = "/dev/xvdf"
+  volume_id   = "${aws_ebs_volume.jenkins2_volume.id}"
+  instance_id = "${aws_instance.jenkins2.id}"
+}

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "jenkins2" {
   ami                    = "ami-785db401"
   instance_type          = "t2.large"
   iam_instance_profile   = "${aws_iam_instance_profile.jenkins.name}"
-  key_name               = "${aws_key_pair.jenkins2_2.key_name}"
+  key_name               = "${aws_key_pair.jenkins.key_name}"
   vpc_security_group_ids = "${var.jenkins_security_group_ids}"
 
   tags {
@@ -23,7 +23,7 @@ resource "aws_eip_association" "jenkins2_eip_assoc" {
   allocation_id = "${aws_eip.jenkins2.id}"
 }
 
-resource "aws_key_pair" "jenkins2_2" {
+resource "aws_key_pair" "jenkins" {
   key_name   = "${var.ssh_key_name}"
   public_key = "${var.jenkins_public_key}"  # injected by Makefile-common
 }

--- a/terraform/modules/jenkins/outputs.tf
+++ b/terraform/modules/jenkins/outputs.tf
@@ -1,0 +1,3 @@
+output "jenkins_2_elastic_ip" {
+  value = "${aws_eip.jenkins2.public_ip}"
+}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -3,3 +3,8 @@ variable "aws_main_account_id" {}
 variable "aws_sub_account_ids" {
   type = "list"
 }
+variable "jenkins_security_group_ids" {
+  type = "list"
+}
+variable "jenkins_2_key_name" {}
+variable "jenkins_2_public_key" {}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -8,4 +8,5 @@ variable "jenkins_security_group_ids" {
   type = "list"
 }
 
+variable "jenkins_public_key_name" {}
 variable "jenkins_public_key" {}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -8,5 +8,4 @@ variable "jenkins_security_group_ids" {
   type = "list"
 }
 
-variable "jenkins_2_key_name" {}
-variable "jenkins_2_public_key" {}
+variable "jenkins_public_key" {}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -3,8 +3,10 @@ variable "aws_main_account_id" {}
 variable "aws_sub_account_ids" {
   type = "list"
 }
+
 variable "jenkins_security_group_ids" {
   type = "list"
 }
+
 variable "jenkins_2_key_name" {}
 variable "jenkins_2_public_key" {}


### PR DESCRIPTION
This is the set-up required for a fresh Jenkins box, named here "jenkins2" in order to not interfere with our existing systems.

I guess from here-on in, major changes will probably require that number to be incremented, I can't imagine we would want to rename everything, although perhaps we would set up a cname to point from `ci.marketplace.team` to `ci2.marketplace.team` so that we can have an HTTP redirect. Thinking about rolling this out may be getting ahead of myself at this point anyway!

https://trello.com/c/sTRy9inU/410-be-able-to-recreate-jenkins-entirely-infrastructure-as-code

Having deleted the jenkins2 box, this is what the `make plan` gives us as a change on the AWS infrastructure resulting from this PR.

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  ~ aws_route53_record.ci2_marketplace_team
      records.#:                         "" => <computed>

  + module.jenkins.aws_ebs_volume.jenkins2_volume
      id:                                <computed>
      arn:                               <computed>
      availability_zone:                 "${aws_instance.jenkins2.availability_zone}"
      encrypted:                         <computed>
      iops:                              <computed>
      kms_key_id:                        <computed>
      size:                              "100"
      snapshot_id:                       <computed>
      type:                              "gp2"

  + module.jenkins.aws_eip.jenkins2
      id:                                <computed>
      allocation_id:                     <computed>
      association_id:                    <computed>
      domain:                            <computed>
      instance:                          <computed>
      network_interface:                 <computed>
      private_ip:                        <computed>
      public_ip:                         <computed>
      vpc:                               "true"

  + module.jenkins.aws_eip_association.jenkins2_eip_assoc
      id:                                <computed>
      allocation_id:                     "${aws_eip.jenkins2.id}"
      instance_id:                       "${aws_instance.jenkins2.id}"
      network_interface_id:              <computed>
      private_ip_address:                <computed>
      public_ip:                         <computed>

  + module.jenkins.aws_instance.jenkins2
      id:                                <computed>
      ami:                               "ami-2a7d75c0"
      associate_public_ip_address:       <computed>
      availability_zone:                 <computed>
      ebs_block_device.#:                <computed>
      ephemeral_block_device.#:          <computed>
      iam_instance_profile:              "jenkins-ci-InstanceProfile-AOFDQ580SQSK"
      instance_state:                    <computed>
      instance_type:                     "t2.large"
      ipv6_address_count:                <computed>
      ipv6_addresses.#:                  <computed>
      key_name:                          "jenkins"
      network_interface.#:               <computed>
      network_interface_id:              <computed>
      placement_group:                   <computed>
      primary_network_interface_id:      <computed>
      private_dns:                       <computed>
      private_ip:                        <computed>
      public_dns:                        <computed>
      public_ip:                         <computed>
      root_block_device.#:               <computed>
      security_groups.#:                 <computed>
      source_dest_check:                 "true"
      subnet_id:                         <computed>
      tags.%:                            "1"
      tags.Name:                         "Jenkins2"
      tenancy:                           <computed>
      volume_tags.%:                     <computed>
      vpc_security_group_ids.#:          "1"
      vpc_security_group_ids.3375772446: "sg-89f20aed"

  + module.jenkins.aws_key_pair.jenkins
      id:                                <computed>
      fingerprint:                       <computed>
      key_name:                          "jenkins"
      public_key:                        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDoykMWRRFoEX+LqSIJ8Ri8/2sgNN5LZH27qU7UqCZ05FiSqsvgToGEpD9Fqkv7SuxvgnQkJbBR4+pFjSjDbo34VZwZurbjIsoeA/7Z7qLWABM8dggU6NyyuASruQrpExFewXZ/jj1JgeyCBGm8pddm5+ia1BBwDyBDMdbF7WMGQ3LvHyomLY42G0iF6alwg41HLZENkVLzut9IgA2kSpgCmc/MzK0eOOHzF5Kp/TjZH9wYLHjafRTZJDcE1axmTgczaIzGAc5t3TsHSLTftb3UgQbbz5vUXHLrvqvBLADRwBLFIrT35g0E/5rJfDLzEBL7+cu8LaYkejag2Q9KXQ/RfOPBLGY1xSeA9XaFLHnnlNXiK/9mVUTPVxyB/OFeqpx7Gqo4Cyr6dI68l008uPQ6HcUlO0Q5dZAOmO24RVaCayo4zhQskkkYCuSxX2SRWNzJEdCOFeg4fUGJSTSMQztQI3Nd84CJSbzG0ybzgt5axjti0m4v8OHOdKiz3lfTZweQivyZjbfu6kY4H/aqEQleb5HIDddsVZGF+csrw7SxujEdALynhlTsOe4uapQ/Gv281E8qJDwdXZLsNxzHbGRPnBvXDlTHDu1SuE1oDBVNnEwzFJtapJ629cD+RKv4o71VPvT1xL2w0PD6ZnFAC38YCLxQsSACTeY0mGMkR9P9gQ=="

  + module.jenkins.aws_volume_attachment.jenkins2_ebs_att
      id:                                <computed>
      device_name:                       "/dev/xvdf"
      instance_id:                       "${aws_instance.jenkins2.id}"
      volume_id:                         "${aws_ebs_volume.jenkins2_volume.id}"


Plan: 6 to add, 1 to change, 0 to destroy.

------------------------------------------------------------------------
```