### PR TITLE
Give Jenkins role permissions on s3 buckets

### DIFF
--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -92,7 +92,12 @@ resource "aws_iam_role_policy" "jenkins" {
         "s3:ListBucket",
         "s3:GetBucketLocation"
       ],
-      "Resource": "arn:aws:s3:::digitalmarketplace-submissions-production-production"
+      "Resource": [
+        "arn:aws:s3:::digitalmarketplace-submissions-production-production",
+        "arn:aws:s3:::digitalmarketplace-documents-production-production",
+        "arn:aws:s3:::digitalmarketplace-documents-staging-staging",
+        "arn:aws:s3:::digitalmarketplace-documents-preview-preview"
+      ]
     },
     {
       "Effect": "Allow",
@@ -109,8 +114,12 @@ resource "aws_iam_role_policy" "jenkins" {
             "s3:PutObjectAcl"
         ],
         "Resource": [
+          "arn:aws:s3:::digitalmarketplace-agreements-production-production/*",
           "arn:aws:s3:::digitalmarketplace-communications-production-production/*",
-          "arn:aws:s3:::digitalmarketplace-communications-preview-preview/*"
+          "arn:aws:s3:::digitalmarketplace-communications-preview-preview/*",
+          "arn:aws:s3:::digitalmarketplace-documents-production-production/*",
+          "arn:aws:s3:::digitalmarketplace-documents-staging-staging/*",
+          "arn:aws:s3:::digitalmarketplace-documents-preview-preview/*"
         ]
     }
   ]

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -100,6 +100,18 @@ resource "aws_iam_role_policy" "jenkins" {
         "s3:GetObject"
       ],
       "Resource": "arn:aws:s3:::digitalmarketplace-submissions-production-production/*"
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:PutObjectAcl"
+        ],
+        "Resource": [
+          "arn:aws:s3:::digitalmarketplace-communications-production-production/*",
+          "arn:aws:s3:::digitalmarketplace-communications-preview-preview/*"
+        ]
     }
   ]
 }


### PR DESCRIPTION
See these supporting PR:
https://github.com/alphagov/digitalmarketplace-credentials/pull/119
https://github.com/alphagov/digitalmarketplace-jenkins/pull/90
https://github.com/alphagov/digitalmarketplace-scripts/pull/233

We have a job on Jenkins that runs daily that uploads a csv of DOS
opportunity details to the preview and production communications
buckets.

### Give Jenkins role permissions on comms buckets
Currently, the script that does this is having AWS credentials injected
into it as env variables. These creds are coming from the jenkins users
aws config file. That config file is a template populated by Ansible,
which gets the creds from the jenkins vars file in the credentials
repo.

The AWS creds in the credentials repo are for an AWS user we have set up
called `deploy`. This user is a hangover from when we used to use
ElasticBeanstalk, and actually has quite a lot or permissions to do
stuff. We should get rid of it, as this script appears to be the only
thing using it.

The script doesn't actually need env variables injecting in, as boto can
use the Jenkins instance profile. We just need to give the jenkins role
the correct permissions, which is what this is doing.

We need `GetObject`, as the file being uploaded is overwriting an already
existing file and it reads it's metadata via the `HeadObject` operation.
We need `PutObjectAcl` as the objects permissions are set to public.

The other part of this is updating the buckets permissons to allow
`PutObject` from the Jenkins role. Currently we don't manage these
buckets through Terraform, so I will do it by hand. But we should think
about bringing those buckets into the Terraform fold.

### Give Jenkins permissions on further s3 buckets
There were a couple more jenkins jobs which ran scripts that used the
`deploy` user credentials. They were:

`make-g-cloud-live.py` - This script gets all the suppliers submitted
docs from the submissions bucket and uploads them to the documents
bucket - hence the extra documents bucket permission.

`upload-counterpart-agreements.py` - This uploads pdfs to the agreements
bucket - hence the permissions on the agreements bucket