### PR TITLE
nix fun

### DIFF
--- a/aws-auth.nix
+++ b/aws-auth.nix
@@ -1,0 +1,27 @@
+{ stdenv, fetchFromGitHub, makeWrapper, jq, awscli, openssl }:
+
+stdenv.mkDerivation rec {
+  version = "unstable-2018-04-04";
+  name = "aws-auth-${version}";
+
+  src = fetchFromGitHub {
+    owner = "alphagov";
+    repo = "aws-auth";
+    rev = "03e3eb2a0e89c6d55f0721462a6bc077aa4668bf";
+    sha256 = "0r89kvkcjsz6v9r2pk45v82v623y334b0hfvdvzfnls3j7d23m2p";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # copy script and set $PATH
+  installPhase = ''
+    install -D $src/aws-auth.sh $out/bin/aws-auth
+    wrapProgram $out/bin/aws-auth \
+      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq openssl ]}
+  '';
+
+  meta = {
+    homepage = https://github.com/alphagov/aws-auth;
+    description = "AWS authentication wrapper to handle MFA and IAM roles";
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,6 @@ in (with args; {
       pythonPackages.virtualenv
       pkgs.nodejs
       pkgs.jq
-      pkgs.aws-auth
       pkgs.sops
       (pkgs.terraform.overrideAttrs (oldAttrs: rec {
         name = "terraform-0.11.7";
@@ -28,6 +27,7 @@ in (with args; {
       }))
       pkgs.libyaml
       pkgs.cloudfoundry-cli
+      ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
     ] ++ pkgs.stdenv.lib.optionals forDev ([
       ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isDarwin [
       ]


### PR DESCRIPTION
nix: switch aws-auth package back to being fully internalized as it has disappeared from upstream.

Equiv to 07b5d on the credentials repo.