### PR TITLE
Scale supplier and api for DOS3 applications

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,9 +13,14 @@ router:
 
 api:
   memory: 2GB
+  instances: 15
 
 user-frontend:
   instances: 2
 
 admin-frontend:
   instances: 2
+
+supplier-frontend:
+  memory: 750MB
+  instances: 20


### PR DESCRIPTION
For [this trello ticket.](https://trello.com/c/gdIMHCCq)

This increases the supplier frontend and api instance counts to match
what we were running for G-Cloud 10 applications.

We currently have a 200GB memory limit on PaaS of which we're currently
using about 26GB (across all spaces). This bump will add at most an extra 64GB of memory use
(if we were to release both applications at the same time), so we should
still be well within limits.