### PR TITLE
Add metric filter for apiclient retries

### DIFF
--- a/terraform/modules/log-metrics/main.tf
+++ b/terraform/modules/log-metrics/main.tf
@@ -321,3 +321,20 @@ resource "aws_cloudwatch_log_metric_filter" "router-429s" {
     default_value = "0"
   }
 }
+
+# App specific metrics for apiclient retries
+
+resource "aws_cloudwatch_log_metric_filter" "apiclient-retries" {
+  count = "${length(var.app_names)}"
+  name  = "${var.environment}-${var.app_names[count.index]}-apiclient-retries"
+
+  pattern        = "{$$.name = urllib3.util.retry}"
+  log_group_name = "${var.environment}-${var.app_names[count.index]}-application"
+
+  metric_transformation {
+    name          = "${var.environment}-${var.app_names[count.index]}-apiclient-retries"
+    namespace     = "DM-APIClient-Retries"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
Now that we're retrying requests by the apiclient if they fail for some
reason (most often a connection error), we're no longer getting the
alerts for the 500s that resulted. This is good, but we have no insight
into when we're having to retry stuff.

We can create a metric for the log messages for urllib3.util.retry which
will let us measure how often we need to retry stuff.