### PR TITLE
Fix bugs with grafana dashboard script

### DIFF
--- a/dmaws/hosted_graphite/create_dashboards.py
+++ b/dmaws/hosted_graphite/create_dashboards.py
@@ -4,7 +4,7 @@ import requests
 
 
 def get_grafana_dashboard_folder():
-    return os.path.join(os.path.dirname(__file__), "../grafana/")
+    return os.path.join(os.path.dirname(__file__), "../../grafana/")
 
 
 def generate_dashboards(api_key):

--- a/scripts/create-hosted-graphite-dashboards.py
+++ b/scripts/create-hosted-graphite-dashboards.py
@@ -24,7 +24,7 @@ Example:
 """
 import sys
 
-import docopt
+from docopt import docopt
 
 sys.path.insert(0, '.')
 


### PR DESCRIPTION
docopt needs to be imported from docopt, otherwise you get a `module not
callable` error.

The path to the json files also needed an extra `..`