### PR TITLE
Fix bug with retries reporting

### DIFF
--- a/grafana/dm-overview.json
+++ b/grafana/dm-overview.json
@@ -822,7 +822,7 @@
             {
               "hide": false,
               "refId": "A",
-              "target": "sumSeries(cloudwatch.apiclient_retries.$environment.*.retries.sum:sum)"
+              "target": "sumSeries(cloudwatch.apiclient_retries.$environment.*.retries.sum:max)"
             }
           ],
           "fill": 1,
@@ -896,5 +896,6 @@
       "repeatIteration": null,
       "collapse": false
     }
-  ]
+  ],
+  "editMode": false
 }


### PR DESCRIPTION
One retry would appear as 9 previously. Now it's just the one.

![screen shot 2018-07-24 at 13 35 43](https://user-images.githubusercontent.com/13836290/43142483-664e8b5a-8f50-11e8-8551-41aff0d006cd.png)
