### PR TITLE
Jenkins2 becomes Jenkins3. And some tweaks.

### DIFF
--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -55,10 +55,10 @@ module "sops_credentials" {
 }
 
 module "jenkins" {
-  source                     = "../../modules/jenkins"
-  aws_main_account_id        = "${var.aws_main_account_id}"
-  aws_sub_account_ids        = "${var.aws_sub_account_ids}"
-  jenkins_security_group_ids = "${var.jenkins_security_group_ids}"
-  jenkins_public_key_name    = "${var.ssh_key_name}"               # confusingly-named variable in terraform/common.json
-  jenkins_public_key         = "${var.jenkins_public_key}"
+  source                  = "../../modules/jenkins"
+  aws_main_account_id     = "${var.aws_main_account_id}"
+  aws_sub_account_ids     = "${var.aws_sub_account_ids}"
+  dev_user_ips            = "${var.dev_user_ips}"
+  jenkins_public_key_name = "${var.ssh_key_name}"        # confusingly-named variable in terraform/common.json
+  jenkins_public_key      = "${var.jenkins_public_key}"
 }

--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -41,13 +41,13 @@ resource "aws_route53_record" "ci_marketplace_team" {
   ]
 }
 
-resource "aws_route53_record" "ci2_marketplace_team" {
+resource "aws_route53_record" "ci3_marketplace_team" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
-  name    = "ci2.marketplace.team"
+  name    = "ci3.marketplace.team"
   type    = "A"
   ttl     = "300"
 
   records = [
-    "${module.jenkins.jenkins_2_elastic_ip}",
+    "${module.jenkins.jenkins_3_elastic_ip}",
   ]
 }

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -2,25 +2,25 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-resource "aws_instance" "jenkins2" {
+resource "aws_instance" "jenkins3" {
   ami                    = "ami-2a7d75c0"
   instance_type          = "t2.large"
   iam_instance_profile   = "${aws_iam_instance_profile.jenkins.name}"
   key_name               = "${aws_key_pair.jenkins.key_name}"
-  vpc_security_group_ids = "${var.jenkins_security_group_ids}"
+  vpc_security_group_ids = ["${aws_security_group.jenkins_security_group.id}"]
 
   tags {
-    Name = "Jenkins2"
+    Name = "Jenkins3"
   }
 }
 
-resource "aws_eip" "jenkins2" {
+resource "aws_eip" "jenkins3" {
   vpc = true
 }
 
-resource "aws_eip_association" "jenkins2_eip_assoc" {
-  instance_id   = "${aws_instance.jenkins2.id}"
-  allocation_id = "${aws_eip.jenkins2.id}"
+resource "aws_eip_association" "jenkins3_eip_assoc" {
+  instance_id   = "${aws_instance.jenkins3.id}"
+  allocation_id = "${aws_eip.jenkins3.id}"
 }
 
 resource "aws_key_pair" "jenkins" {
@@ -28,14 +28,14 @@ resource "aws_key_pair" "jenkins" {
   public_key = "${var.jenkins_public_key}"      # injected by Makefile-common
 }
 
-resource "aws_ebs_volume" "jenkins2_volume" {
-  availability_zone = "${aws_instance.jenkins2.availability_zone}"
+resource "aws_ebs_volume" "jenkins3_volume" {
+  availability_zone = "${aws_instance.jenkins3.availability_zone}"
   type              = "gp2"
   size              = 100
 }
 
-resource "aws_volume_attachment" "jenkins2_ebs_att" {
+resource "aws_volume_attachment" "jenkins3_ebs_att" {
   device_name = "/dev/xvdf"
-  volume_id   = "${aws_ebs_volume.jenkins2_volume.id}"
-  instance_id = "${aws_instance.jenkins2.id}"
+  volume_id   = "${aws_ebs_volume.jenkins3_volume.id}"
+  instance_id = "${aws_instance.jenkins3.id}"
 }

--- a/terraform/modules/jenkins/outputs.tf
+++ b/terraform/modules/jenkins/outputs.tf
@@ -1,3 +1,3 @@
-output "jenkins_2_elastic_ip" {
-  value = "${aws_eip.jenkins2.public_ip}"
+output "jenkins_3_elastic_ip" {
+  value = "${aws_eip.jenkins3.public_ip}"
 }

--- a/terraform/modules/jenkins/security_group.tf
+++ b/terraform/modules/jenkins/security_group.tf
@@ -1,0 +1,38 @@
+resource "aws_security_group" "jenkins_security_group" {
+  name        = "jenkins_security_group"
+  description = "Security group for Jenkins"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "allow_ssh_to_jenkins" {
+  security_group_id = "${aws_security_group.jenkins_security_group.id}"
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.dev_user_ips}"]
+}
+
+resource "aws_security_group_rule" "allow_https_to_jenkins" {
+  security_group_id = "${aws_security_group.jenkins_security_group.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["${var.dev_user_ips}", "${aws_eip.jenkins3.public_ip}/32"]
+}
+
+resource "aws_security_group_rule" "allow_letsencrypt_check" {
+  security_group_id = "${aws_security_group.jenkins_security_group.id}"
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -4,7 +4,7 @@ variable "aws_sub_account_ids" {
   type = "list"
 }
 
-variable "jenkins_security_group_ids" {
+variable "dev_user_ips" {
   type = "list"
 }
 


### PR DESCRIPTION
Change jenkins2 to jenkins3. This is due to running into the letsencrypt rate limit for certificates of 20 per week. Using a different subdomain allowed me to continue developing. After new Jenkins is out we can point the original domain at the new box so it shoudn't be too much of an issue.

This also adds a security group file to the Jenkins module - this is mostly just a straight copy of the jenkins security account defined in the main account (which we can drop after the move). The main difference is the programatic inclusion of the jenkins elastic ip address in the inbound https rule. This just means we don't need to update the terraform credentials file with the new ip address.

The new ec2 instance definition programatically pulls in the new security group rather than hard coding the id of the existing security group. Better.