### PR TITLE
Notify for 500's on state_change

### DIFF
--- a/dmaws/hosted_graphite/create_alerts.py
+++ b/dmaws/hosted_graphite/create_alerts.py
@@ -12,7 +12,7 @@ ALERTS = [
             "above_value": 0
         },
         "notification_channels": ["Notify DM 2ndline"],  # Hardcoded name, channel had been set up manually already
-        "notification_type": ["every", 60],
+        "notification_type": "state_change",
         "info": "500s have occured"
     },
     {


### PR DESCRIPTION
By only alerting every 60 minutes we would miss some 500s if they
occurred within an hour or the original alert.

By changing to `state_change` we should see alerts for all 500s.

This is already actually the setup we're using. I changed it through the hosted graphite GUI without realising it should also be updated here.