### PR TITLE
Bump aws cli to 1.15.67

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click==6.6
 Jinja2==2.8
 PyYAML==3.11
 six==1.10.0
-awscli==1.11.44
+awscli==1.15.67
 requests==2.14.2
 boto3==1.4.4
 docopt==0.6.2


### PR DESCRIPTION
aws-auth, the tool we use for temporary credentials, has been updated to
work only with the new file name format generated by aws cli for
temporary credentials. This changed in version 1.14

This version works.