### PR TITLE
Put Jenkins3 behind ELB

### DIFF
--- a/terraform/accounts/main/route53.tf
+++ b/terraform/accounts/main/route53.tf
@@ -45,9 +45,10 @@ resource "aws_route53_record" "ci3_marketplace_team" {
   zone_id = "${aws_route53_zone.marketplace_team.zone_id}"
   name    = "ci3.marketplace.team"
   type    = "A"
-  ttl     = "300"
 
-  records = [
-    "${module.jenkins.jenkins_3_elastic_ip}",
-  ]
+  alias {
+    name                   = "${module.jenkins.jenkins_elb_dns_name}"
+    zone_id                = "${module.jenkins.jenkins_elb_zone_id}"
+    evaluate_target_health = true
+  }
 }

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -7,7 +7,7 @@ resource "aws_instance" "jenkins3" {
   instance_type          = "t2.large"
   iam_instance_profile   = "${aws_iam_instance_profile.jenkins.name}"
   key_name               = "${aws_key_pair.jenkins.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.jenkins_security_group.id}"]
+  vpc_security_group_ids = ["${aws_security_group.jenkins_instance_security_group.id}"]
 
   tags {
     Name = "Jenkins3"

--- a/terraform/modules/jenkins/elb.tf
+++ b/terraform/modules/jenkins/elb.tf
@@ -1,0 +1,64 @@
+resource "aws_elb" "jenkins_elb" {
+  name            = "Jenkins-ELB"
+  subnets         = ["${aws_instance.jenkins3.subnet_id}"]
+  instances       = ["${aws_instance.jenkins3.id}"]
+  security_groups = ["${aws_security_group.jenkins_elb_security_group.id}"]
+
+  listener {
+    instance_port      = 80
+    instance_protocol  = "http"
+    lb_port            = 443
+    lb_protocol        = "https"
+    ssl_certificate_id = "${aws_acm_certificate.jenkins_elb_certificate.arn}"
+  }
+
+  listener {
+    instance_port     = 22
+    instance_protocol = "tcp"
+    lb_port           = 22
+    lb_protocol       = "tcp"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    target              = "TCP:22"
+    interval            = 30
+  }
+
+  tags {
+    Name = "Jenkins ELB"
+  }
+}
+
+resource "aws_acm_certificate" "jenkins_elb_certificate" {
+  domain_name       = "ci3.marketplace.team"
+  validation_method = "DNS"
+
+  tags {
+    Name = "Jenkins ELB certificate"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_route53_zone" "marketplace_team" {
+  name         = "marketplace.team"
+  private_zone = false
+}
+
+resource "aws_route53_record" "jenkins_elb_cert_validation" {
+  name    = "${aws_acm_certificate.jenkins_elb_certificate.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.jenkins_elb_certificate.domain_validation_options.0.resource_record_type}"
+  zone_id = "${data.aws_route53_zone.marketplace_team.id}"
+  records = ["${aws_acm_certificate.jenkins_elb_certificate.domain_validation_options.0.resource_record_value}"]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "jenkins_elb_certificate" {
+  certificate_arn         = "${aws_acm_certificate.jenkins_elb_certificate.arn}"
+  validation_record_fqdns = ["${aws_route53_record.jenkins_elb_cert_validation.fqdn}"]
+}

--- a/terraform/modules/jenkins/outputs.tf
+++ b/terraform/modules/jenkins/outputs.tf
@@ -1,3 +1,7 @@
-output "jenkins_3_elastic_ip" {
-  value = "${aws_eip.jenkins3.public_ip}"
+output "jenkins_elb_dns_name" {
+  value = "${aws_elb.jenkins_elb.dns_name}"
+}
+
+output "jenkins_elb_zone_id" {
+  value = "${aws_elb.jenkins_elb.zone_id}"
 }

--- a/terraform/modules/jenkins/security_group.tf
+++ b/terraform/modules/jenkins/security_group.tf
@@ -1,17 +1,12 @@
-resource "aws_security_group" "jenkins_security_group" {
-  name        = "jenkins_security_group"
-  description = "Security group for Jenkins"
+# Jenkins ELB security group/rules
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group" "jenkins_elb_security_group" {
+  name        = "jenkins_elb_security_group"
+  description = "Security group for Jenkins ELB"
 }
 
-resource "aws_security_group_rule" "allow_ssh_to_jenkins" {
-  security_group_id = "${aws_security_group.jenkins_security_group.id}"
+resource "aws_security_group_rule" "jenkins_elb_allow_ssh_from_whitelisted_ips" {
+  security_group_id = "${aws_security_group.jenkins_elb_security_group.id}"
   type              = "ingress"
   from_port         = 22
   to_port           = 22
@@ -19,8 +14,8 @@ resource "aws_security_group_rule" "allow_ssh_to_jenkins" {
   cidr_blocks       = ["${var.dev_user_ips}"]
 }
 
-resource "aws_security_group_rule" "allow_https_to_jenkins" {
-  security_group_id = "${aws_security_group.jenkins_security_group.id}"
+resource "aws_security_group_rule" "jenkins_elb_allow_https_from_whitelisted_ips" {
+  security_group_id = "${aws_security_group.jenkins_elb_security_group.id}"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
@@ -28,11 +23,54 @@ resource "aws_security_group_rule" "allow_https_to_jenkins" {
   cidr_blocks       = ["${var.dev_user_ips}", "${aws_eip.jenkins3.public_ip}/32"]
 }
 
-resource "aws_security_group_rule" "allow_letsencrypt_check" {
-  security_group_id = "${aws_security_group.jenkins_security_group.id}"
-  type              = "ingress"
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
+resource "aws_security_group_rule" "jenkins_elb_allow_http_to_jenkins_instance" {
+  security_group_id        = "${aws_security_group.jenkins_elb_security_group.id}"
+  type                     = "egress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.jenkins_instance_security_group.id}"
+}
+
+resource "aws_security_group_rule" "jenkins_elb_allow_ssh_to_jenkins_instance" {
+  security_group_id        = "${aws_security_group.jenkins_elb_security_group.id}"
+  type                     = "egress"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.jenkins_instance_security_group.id}"
+}
+
+# Jenkins Instance security groups/rules
+
+resource "aws_security_group" "jenkins_instance_security_group" {
+  name        = "jenkins_instance_security_group"
+  description = "Security group for Jenkins Instance"
+}
+
+resource "aws_security_group_rule" "jenkins_instance_allow_http_from_jenkins_elb" {
+  security_group_id        = "${aws_security_group.jenkins_instance_security_group.id}"
+  type                     = "ingress"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.jenkins_elb_security_group.id}"
+}
+
+resource "aws_security_group_rule" "jenkins_instance_allow_ssh_from_jenkins_elb" {
+  security_group_id        = "${aws_security_group.jenkins_instance_security_group.id}"
+  type                     = "ingress"
+  from_port                = 22
+  to_port                  = 22
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.jenkins_elb_security_group.id}"
+}
+
+resource "aws_security_group_rule" "jenkins_instance_allow_egress_everywhere" {
+  security_group_id = "${aws_security_group.jenkins_instance_security_group.id}"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
This was done to get a free certificate, rather than having to get one
from letsencrypt. The main motivation was I kept bumping in to the
letsencrypt rate limit on issuing certificates of 20 per week.

This code sets up an CNAME record for ci3.market.... which points to the
DNS name of the elb. The elb terminates our tls and proxies the request
on to the Jenkins instance via http. This is all within our VPC and
subnet.

The ELB also passes tcp connections through port 22 to allow ssh access.

There are two security groups - one for the ELB with all our usual
whitelisted IP address as the only allowed ingress, and one for the
instance itself, which only allowed ingress from the ELB.