### PR TITLE
Add '--single-transaction' flag to db restore

### DIFF
--- a/scripts/import-and-clean-db-dump.sh
+++ b/scripts/import-and-clean-db-dump.sh
@@ -16,4 +16,4 @@ echo -n $($DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/gpg/database
 gpg2 --list-secret-keys --with-colons --fingerprint | grep fpr | cut -c 13-52 | xargs -n1 gpg2 --batch --delete-secret-key
 rm "${LATEST_PROD_DUMP}"
 
-psql --variable bcrypt_password="'$(${VIRTUALENV_ROOT}/bin/python ./scripts/generate-bcrypt-hashed-password.py Password1234 12)'" "${POSTGRES_URI}" < ./scripts/clean-db-dump.sql
+psql --variable --single-transaction bcrypt_password="'$(${VIRTUALENV_ROOT}/bin/python ./scripts/generate-bcrypt-hashed-password.py Password1234 12)'" "${POSTGRES_URI}" < ./scripts/clean-db-dump.sql


### PR DESCRIPTION
https://trello.com/c/0vtBEhdx/55-make-db-restore-job-run-in-transaction

This flag creates a transaction for the session 

https://stackoverflow.com/a/38378603/3967444

https://stackoverflow.com/questions/1651219/how-to-check-for-pending-operations-in-a-postgresql-transaction/28802471#28802471

Tested with:
```
(venv) benvandersteen@gds5077:~/gds/branches/digitalmarketplace/digitalmarketplace-jenkins$ echo "select txid_current(); begin; select txid_current(); commit;" | psql --single-transaction -d digitalmarketplace
 txid_current 
--------------
      1384807
(1 row)

WARNING:  there is already a transaction in progress
BEGIN
 txid_current 
--------------
      1384807
(1 row)

COMMIT
WARNING:  there is no transaction in progress
(venv) benvandersteen@gds5077:~/gds/branches/digitalmarketplace/digitalmarketplace-jenkins$ echo "select txid_current(); begin; select txid_current(); commit;" | psql -d digitalmarketplace
 txid_current 
--------------
      1384808
(1 row)

BEGIN
 txid_current 
--------------
      1384809
(1 row)

COMMIT
```