### PR TITLE
Antivirus SNS notifications

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -53,7 +53,13 @@ module "log_metrics" {
 }
 
 module "antivirus-sns" {
-  source = "../../modules/antivirus-sns"
+  source      = "../../modules/antivirus-sns"
   environment = "preview"
-  account_id = "${var.aws_dev_account_id}"
+  account_id  = "${var.aws_dev_account_id}"
+
+  bucket_ids = [
+    "${aws_s3_bucket.agreements_bucket.id}",
+    "${aws_s3_bucket.communications_bucket.id}",
+    "${aws_s3_bucket.documents_bucket.id}",
+  ]
 }

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -51,3 +51,9 @@ module "log_metrics" {
   app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.preview_router.json_log_groups, 0)}"
 }
+
+module "antivirus-sns" {
+  source = "../../modules/antivirus-sns"
+  environment = "preview"
+  account_id = "${var.aws_dev_account_id}"
+}

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -53,9 +53,11 @@ module "log_metrics" {
 }
 
 module "antivirus-sns" {
-  source      = "../../modules/antivirus-sns"
-  environment = "preview"
-  account_id  = "${var.aws_dev_account_id}"
+  source                   = "../../modules/antivirus-sns"
+  environment              = "preview"
+  account_id               = "${var.aws_dev_account_id}"
+  antivirus_api_host       = "${var.antivirus_api_host}"
+  antivirus_api_basic_auth = "${var.antivirus_api_basic_auth}"
 
   bucket_ids = [
     "${aws_s3_bucket.agreements_bucket.id}",

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -24,6 +24,8 @@ variable "submissions_s3_url" {}
 variable "api_url" {}
 variable "search_api_url" {}
 variable "frontend_url" {}
+variable "antivirus_api_host" {}
+variable "antivirus_api_basic_auth" {}
 
 variable "app_auth" {}
 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -53,9 +53,11 @@ module "log_metrics" {
 }
 
 module "antivirus-sns" {
-  source      = "../../modules/antivirus-sns"
-  environment = "production"
-  account_id  = "${var.aws_prod_account_id}"
+  source                   = "../../modules/antivirus-sns"
+  environment              = "production"
+  account_id               = "${var.aws_prod_account_id}"
+  antivirus_api_host       = "${var.antivirus_api_host}"
+  antivirus_api_basic_auth = "${var.antivirus_api_basic_auth}"
 
   bucket_ids = [
     "${aws_s3_bucket.agreements_bucket.id}",

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -51,3 +51,15 @@ module "log_metrics" {
   app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.production_router.json_log_groups, 0)}"
 }
+
+module "antivirus-sns" {
+  source      = "../../modules/antivirus-sns"
+  environment = "production"
+  account_id  = "${var.aws_prod_account_id}"
+
+  bucket_ids = [
+    "${aws_s3_bucket.agreements_bucket.id}",
+    "${aws_s3_bucket.communications_bucket.id}",
+    "${aws_s3_bucket.documents_bucket.id}",
+  ]
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -24,6 +24,8 @@ variable "submissions_s3_url" {}
 variable "api_url" {}
 variable "search_api_url" {}
 variable "frontend_url" {}
+variable "antivirus_api_host" {}
+variable "antivirus_api_basic_auth" {}
 
 variable "app_auth" {}
 

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -51,3 +51,15 @@ module "log_metrics" {
   app_names             = ["${module.application_logs.app_names}"]
   router_log_group_name = "${element(module.staging_router.json_log_groups, 0)}"
 }
+
+module "antivirus-sns" {
+  source      = "../../modules/antivirus-sns"
+  environment = "staging"
+  account_id  = "${var.aws_prod_account_id}"
+
+  bucket_ids = [
+    "${aws_s3_bucket.agreements_bucket.id}",
+    "${aws_s3_bucket.communications_bucket.id}",
+    "${aws_s3_bucket.documents_bucket.id}",
+  ]
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -53,9 +53,11 @@ module "log_metrics" {
 }
 
 module "antivirus-sns" {
-  source      = "../../modules/antivirus-sns"
-  environment = "staging"
-  account_id  = "${var.aws_prod_account_id}"
+  source                   = "../../modules/antivirus-sns"
+  environment              = "staging"
+  account_id               = "${var.aws_prod_account_id}"
+  antivirus_api_host       = "${var.antivirus_api_host}"
+  antivirus_api_basic_auth = "${var.antivirus_api_basic_auth}"
 
   bucket_ids = [
     "${aws_s3_bucket.agreements_bucket.id}",

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,4 +1,5 @@
 variable "aws_main_account_id" {}
+variable "aws_prod_account_id" {}
 
 variable "admin_user_ips" {
   type = "list"

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -24,6 +24,8 @@ variable "submissions_s3_url" {}
 variable "api_url" {}
 variable "search_api_url" {}
 variable "frontend_url" {}
+variable "antivirus_api_host" {}
+variable "antivirus_api_basic_auth" {}
 
 variable "app_auth" {}
 

--- a/terraform/modules/antivirus-sns/iam.tf
+++ b/terraform/modules/antivirus-sns/iam.tf
@@ -147,10 +147,11 @@ data "aws_iam_policy_document" "s3_file_upload_notification_topic_policy" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = [
-          "arn:aws:s3:::${var.bucket_ids[0]}",
-          "arn:aws:s3:::${var.bucket_ids[1]}",
-          "arn:aws:s3:::${var.bucket_ids[2]}"
+
+      values = [
+        "arn:aws:s3:::${var.bucket_ids[0]}",
+        "arn:aws:s3:::${var.bucket_ids[1]}",
+        "arn:aws:s3:::${var.bucket_ids[2]}",
       ]
     }
 

--- a/terraform/modules/antivirus-sns/iam.tf
+++ b/terraform/modules/antivirus-sns/iam.tf
@@ -1,0 +1,135 @@
+resource "aws_iam_role" "sns_success_feedback" {
+  name = "sns_success_feedback"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "sns.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "sns_success_feedback_sns_feedback" {
+  role       = "${aws_iam_role.sns_success_feedback.name}"
+  policy_arn = "${aws_iam_policy.sns_feedback.arn}"
+}
+
+resource "aws_iam_role" "sns_failure_feedback" {
+  name = "sns_failure_feedback"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "sns.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "sns_failure_feedback_sns_feedback" {
+  role       = "${aws_iam_role.sns_failure_feedback.name}"
+  policy_arn = "${aws_iam_policy.sns_feedback.arn}"
+}
+
+resource "aws_iam_policy" "sns_feedback" {
+  name = "sns_feedback"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Effect": "Allow",
+          "Action": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:PutLogEvents",
+              "logs:PutMetricFilter",
+              "logs:PutRetentionPolicy"
+          ],
+          "Resource": [
+              "*"
+          ]
+      }
+  ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "s3_file_upload_notification_policy" {
+  policy_id = "__default_policy_ID"
+
+  statement {
+    sid = "sns_permissions"
+
+    actions = [
+      "SNS:Publish",
+      "SNS:RemovePermission",
+      "SNS:SetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:Receive",
+      "SNS:AddPermission",
+      "SNS:Subscribe"
+    ]
+
+    condition {
+      test = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        "${var.account_id}",
+      ]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${aws_sns_topic.s3_file_upload_notification.arn}"
+    ]
+  }
+
+  statement {
+    sid = "sns_https_only"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:Receive"
+    ]
+
+    condition {
+      test = "StringEquals"
+      variable = "SNS:Protocol"
+      values = [
+        "https"
+      ]
+    }
+
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${aws_sns_topic.s3_file_upload_notification.arn}"
+    ]
+  }
+}

--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -1,8 +1,9 @@
 resource "aws_sns_topic" "s3_file_upload_notification" {
-  name = "s3_file_upload_notification-${var.environment}"
-  http_success_feedback_role_arn = "${aws_iam_role.sns_success_feedback.arn}"
+  name                              = "s3_file_upload_notification_${var.environment}"
+  http_success_feedback_role_arn    = "${aws_iam_role.sns_success_feedback.arn}"
   http_success_feedback_sample_rate = 100
-  http_failure_feedback_role_arn =  "${aws_iam_role.sns_failure_feedback.arn}"
+  http_failure_feedback_role_arn    = "${aws_iam_role.sns_failure_feedback.arn}"
+
   delivery_policy = <<EOF
 {
   "http": {
@@ -22,6 +23,6 @@ EOF
 }
 
 resource "aws_sns_topic_policy" "s3_file_upload_notification_policy_attachment" {
-  arn = "${aws_sns_topic.s3_file_upload_notification.arn}"
-  policy = "${data.aws_iam_policy_document.s3_file_upload_notification_policy.json}"
+  arn    = "${aws_sns_topic.s3_file_upload_notification.arn}"
+  policy = "${data.aws_iam_policy_document.s3_file_upload_notification_topic_policy.json}"
 }

--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -1,0 +1,27 @@
+resource "aws_sns_topic" "s3_file_upload_notification" {
+  name = "s3_file_upload_notification-${var.environment}"
+  http_success_feedback_role_arn = "${aws_iam_role.sns_success_feedback.arn}"
+  http_success_feedback_sample_rate = 100
+  http_failure_feedback_role_arn =  "${aws_iam_role.sns_failure_feedback.arn}"
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 1,
+      "maxDelayTarget": 3,
+      "numRetries": 5,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 1,
+      "numMinDelayRetries": 1,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": true
+  }
+}
+EOF
+}
+
+resource "aws_sns_topic_policy" "s3_file_upload_notification_policy_attachment" {
+  arn = "${aws_sns_topic.s3_file_upload_notification.arn}"
+  policy = "${data.aws_iam_policy_document.s3_file_upload_notification_policy.json}"
+}

--- a/terraform/modules/antivirus-sns/s3-notifications.tf
+++ b/terraform/modules/antivirus-sns/s3-notifications.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  count  = "${length(var.bucket_ids)}"
+  bucket = "${var.bucket_ids[count.index]}"
+
+  topic {
+    topic_arn = "${aws_sns_topic.s3_file_upload_notification.arn}"
+    events    = ["s3:ObjectCreated:*"]
+  }
+}

--- a/terraform/modules/antivirus-sns/subscriptions.tf
+++ b/terraform/modules/antivirus-sns/subscriptions.tf
@@ -1,0 +1,6 @@
+resource "aws_sns_topic_subscription" "antivirus_to_s3_file_upload_notification_topic" {
+  topic_arn              = "${aws_sns_topic.s3_file_upload_notification.arn}"
+  protocol               = "https"
+  endpoint               = "https://${var.antivirus_api_basic_auth}@${var.antivirus_api_host}/sns/s3/uploaded"
+  endpoint_auto_confirms = "true"
+}

--- a/terraform/modules/antivirus-sns/variables.tf
+++ b/terraform/modules/antivirus-sns/variables.tf
@@ -1,2 +1,5 @@
 variable "account_id" {}
 variable "environment" {}
+variable "bucket_ids" {
+  type = "list"
+}

--- a/terraform/modules/antivirus-sns/variables.tf
+++ b/terraform/modules/antivirus-sns/variables.tf
@@ -1,0 +1,2 @@
+variable "account_id" {}
+variable "environment" {}

--- a/terraform/modules/antivirus-sns/variables.tf
+++ b/terraform/modules/antivirus-sns/variables.tf
@@ -1,5 +1,9 @@
 variable "account_id" {}
 variable "environment" {}
+
 variable "bucket_ids" {
   type = "list"
 }
+
+variable "antivirus_api_host" {}
+variable "antivirus_api_basic_auth" {}


### PR DESCRIPTION
For [this trello ticket](https://trello.com/c/DwwT9fw5).

### Add antivirus-sns module  …
The module sets up an SNS topic for sending notifications to the
antivirus app.

### Add S3 notifications and format  …
We need to set up notifications for the S3 buckets we want to monitor
for file uploads. These notifications will publish a message to the file
upload topic whenever a file is created in any of them. That published
message is then distributed to all subscriptions. That's next.

### Add sns topic subscription  …
This adds a subscription to the file upload topic for an endpoint on the
antivirus api. The api will be using basic auth which is included in the
endpoint described here. The creds are in the creds repo.

The endpoint _has_ to be able to autoconfirm the subscription request
that is sent to it or this code will not apply.