### PR TITLE
brief-responses-frontend: Remove Mandrill and use Notify

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -8,7 +8,7 @@
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
-      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
       SECRET_KEY: {{ shared_tokens.password_key }}
 

--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -9,6 +9,7 @@
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
+      DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
 
       SECRET_KEY: {{ shared_tokens.password_key }}
 


### PR DESCRIPTION
alphagov/digitalmarketplace-brief-responses-frontend#75 changed the service provider for emails from the brief-responses-frontend app.

This commit changes the template for the app so that the Notify API key is in its environment when it is started.

Once this change has been merged the app will need to be rebuilt on preview so that it can pick up the Notify key. This will then the functional tests should pass on preview.

The manifest at the top of this PR includes both the Mandrill and Notify API keys; when migration has been completed the commit e9526ee55237d0990df68e9be98c00f0c841ac7c can be reverted.

This is to finish off [this][ticket] tech debt ticket.

[ticket]: https://trello.com/c/jESNKsXH