### PR TITLE
Fix "Add '--single-transaction' flag to db restore"

### DIFF
--- a/scripts/import-and-clean-db-dump.sh
+++ b/scripts/import-and-clean-db-dump.sh
@@ -16,4 +16,4 @@ echo -n $($DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/gpg/database
 gpg2 --list-secret-keys --with-colons --fingerprint | grep fpr | cut -c 13-52 | xargs -n1 gpg2 --batch --delete-secret-key
 rm "${LATEST_PROD_DUMP}"
 
-psql --variable --single-transaction bcrypt_password="'$(${VIRTUALENV_ROOT}/bin/python ./scripts/generate-bcrypt-hashed-password.py Password1234 12)'" "${POSTGRES_URI}" < ./scripts/clean-db-dump.sql
+psql --single-transaction --variable bcrypt_password="'$(${VIRTUALENV_ROOT}/bin/python ./scripts/generate-bcrypt-hashed-password.py Password1234 12)'" "${POSTGRES_URI}" < ./scripts/clean-db-dump.sql


### PR DESCRIPTION
Last change for the `import-and-clean-db-dump` script had the order of arguments slightly wrong, so the script failed with

```
psql: invalid connection option "bcrypt_password"
```

This commit should fix it 🤞