### PR TITLE
Scale down api and supplier frontend on production

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,14 +13,9 @@ router:
 
 api:
   memory: 2GB
-  instances: 15
 
 user-frontend:
   instances: 2
 
 admin-frontend:
   instances: 2
-
-supplier-frontend:
-  memory: 750MB
-  instances: 20


### PR DESCRIPTION
DOS3 has now closed and we can return the instance counts and memory for
the api and the supplier fe back to normal.