### PR TITLE
Revert "Scale supplier and api for DOS3 applications"

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -13,14 +13,9 @@ router:
 
 api:
   memory: 2GB
-  instances: 15
 
 user-frontend:
   instances: 2
 
 admin-frontend:
   instances: 2
-
-supplier-frontend:
-  memory: 750MB
-  instances: 20


### PR DESCRIPTION
This reverts commit 35c1b56e3242ec6b563ea04c0e10e301b9753499.

DOS3 applications are now closed so we can return to the default
instance count and memory size of the api and supplier fe.