### PR TITLE
Mute output from cf set-env to hide credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	$(eval export S3_POST_URL_DATA=$(shell ${VIRTUALENV_ROOT}/bin/python ./scripts/generate-s3-post-url-data.py digitalmarketplace-database-backups ${DUMP_FILE_NAME}))
 	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/db-backup --no-route --health-check-type none -i 1 -m 128M -c 'sleep 2h'
 	cf set-env db-backup DUMP_FILE_NAME '${DUMP_FILE_NAME}'
-	cf set-env db-backup S3_POST_URL_DATA '${S3_POST_URL_DATA}'
+	@cf set-env db-backup S3_POST_URL_DATA '${S3_POST_URL_DATA}'
 	cf set-env db-backup RECIPIENT 'Digital Marketplace DB backups'
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"
 	cf restage db-backup


### PR DESCRIPTION
Trello https://trello.com/c/eBl3yUUT/27-jenkins-credentials-shown-in-plain-text-in-job-scripts-and-logs#

NB: not tested yet (to avoid strain on prod API)

See Jenkins database-backup output.