### PR TITLE
nix: strip PYTHONPATH from env when wrapping aws-auth

### DIFF
--- a/aws-auth.nix
+++ b/aws-auth.nix
@@ -17,7 +17,8 @@ stdenv.mkDerivation rec {
   installPhase = ''
     install -D $src/aws-auth.sh $out/bin/aws-auth
     wrapProgram $out/bin/aws-auth \
-      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq openssl ]}
+      --prefix PATH : ${stdenv.lib.makeBinPath [ awscli jq openssl ]} \
+      --unset PYTHONPATH
   '';
 
   meta = {


### PR DESCRIPTION
this should isolate aws-auth's python env from the enclosing session's python env, particularly a problem when one is py2 and the other py3.