### PR TITLE
98-set-up-cross-region-replication-for-our-backups-s3-buckets

### DIFF
--- a/scripts/generate-s3-post-url-data.py
+++ b/scripts/generate-s3-post-url-data.py
@@ -19,9 +19,9 @@ from docopt import docopt
 def generate_s3_post_data(bucket, filename):
     s3 = boto3.client('s3')
 
-    fields = {"acl": "private"}
+    fields = {"acl": "bucket-owner-read"}
     conditions = [
-        {"acl": "private"}
+        {"acl": "bucket-owner-read"}
     ]
 
     post = s3.generate_presigned_post(

--- a/terraform/accounts/backups/access.tf
+++ b/terraform/accounts/backups/access.tf
@@ -1,3 +1,4 @@
+# Backups role, policy and role-policy attachment
 resource "aws_iam_role" "backups_role" {
   name = "backups"
 
@@ -27,8 +28,19 @@ resource "aws_iam_policy" "backups_policy" {
     {
       "Effect": "Allow",
       "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "arn:aws:s3:::*",
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": true
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "s3:ListBucket",
-        "s3:ListAllMyBuckets",
         "s3:GetBucketLocation"
       ],
       "Resource": "arn:aws:s3:::digitalmarketplace-database-backups",

--- a/terraform/accounts/backups/access.tf
+++ b/terraform/accounts/backups/access.tf
@@ -43,7 +43,10 @@ resource "aws_iam_policy" "backups_policy" {
         "s3:ListBucket",
         "s3:GetBucketLocation"
       ],
-      "Resource": "arn:aws:s3:::digitalmarketplace-database-backups",
+      "Resource": [
+        "arn:aws:s3:::digitalmarketplace-database-backups",
+        "arn:aws:s3:::digitalmarketplace-cross-region-database-backups"
+      ],
       "Condition": {
         "Bool": {
           "aws:MultiFactorAuthPresent": true
@@ -55,7 +58,10 @@ resource "aws_iam_policy" "backups_policy" {
       "Action": [
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::digitalmarketplace-database-backups/*",
+      "Resource": [
+        "arn:aws:s3:::digitalmarketplace-database-backups/*",
+        "arn:aws:s3:::digitalmarketplace-cross-region-database-backups/*"
+      ],
       "Condition": {
         "Bool": {
           "aws:MultiFactorAuthPresent": true

--- a/terraform/accounts/backups/access.tf
+++ b/terraform/accounts/backups/access.tf
@@ -71,3 +71,67 @@ resource "aws_iam_role_policy_attachment" "backups_role_policy_attachment" {
   role       = "${aws_iam_role.backups_role.id}"
   policy_arn = "${aws_iam_policy.backups_policy.arn}"
 }
+
+# Replication role, policy and role-policy attachment
+# Only S3 service can assume this role and perform these actions.
+# (See https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-replication-configuration)
+resource "aws_iam_role" "replication_role" {
+  name = "replication"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "replication_policy" {
+  name = "replication-policy"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::digitalmarketplace-database-backups"
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::digitalmarketplace-database-backups/*"
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::digitalmarketplace-cross-region-database-backups/*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "replication" {
+  role       = "${aws_iam_role.replication_role.id}"
+  policy_arn = "${aws_iam_policy.replication_policy.arn}"
+}

--- a/terraform/accounts/backups/main.tf
+++ b/terraform/accounts/backups/main.tf
@@ -3,6 +3,12 @@ provider "aws" {
   version = "1.9.0"
 }
 
+provider "aws" {
+  alias   = "london"
+  region  = "eu-west-2"
+  version = "1.9.0"
+}
+
 resource "aws_iam_account_alias" "alias" {
   account_alias = "digitalmarketplace-backups"
 }

--- a/terraform/accounts/backups/s3_buckets.tf
+++ b/terraform/accounts/backups/s3_buckets.tf
@@ -1,3 +1,47 @@
+resource "aws_s3_bucket" "cross_region_database_backups_s3_bucket" {
+  provider = "aws.london"
+  bucket   = "digitalmarketplace-cross-region-database-backups"
+  acl      = "private"
+  region   = "eu-west-2"
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Principal": {"AWS": "arn:aws:iam::${var.aws_backups_account_id}:role/backups"},
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": "arn:aws:s3:::digitalmarketplace-cross-region-database-backups"
+    },
+    {
+      "Principal": {"AWS": "arn:aws:iam::${var.aws_backups_account_id}:role/backups"},
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::digitalmarketplace-cross-region-database-backups/*"
+    }
+  ]
+}
+POLICY
+}
+
 resource "aws_s3_bucket" "database_backups_s3_bucket" {
   bucket = "digitalmarketplace-database-backups"
   acl    = "private"

--- a/terraform/accounts/backups/s3_buckets.tf
+++ b/terraform/accounts/backups/s3_buckets.tf
@@ -100,4 +100,17 @@ resource "aws_s3_bucket" "database_backups_s3_bucket" {
   ]
 }
 POLICY
+
+  replication_configuration {
+    role = "${aws_iam_role.replication_role.arn}"
+
+    rules {
+      prefix = "*"
+      status = "Enabled"
+
+      destination {
+        bucket = "${aws_s3_bucket.cross_region_database_backups_s3_bucket.arn}"
+      }
+    }
+  }
 }


### PR DESCRIPTION
#### Setting up cross region replication of incoming backups.

Predominantly followed this example, changing names to be in line with existing convention:
https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-replication-configuration

Only new incoming backups will be replicated (as per https://docs.aws.amazon.com/AmazonS3/latest/dev/crr-what-is-isnot-replicated.html) and the backups will be kept for 7 days (see https://github.com/alphagov/digitalmarketplace-aws/pull/429/files#diff-fe12ef74960acd2feb5dc4ef2c4d6a66R75); this has been cleared with the dev team and @louzoid-gds .

In order to give the new region bucket similar permissions to the regular backups bucket I removed the hard coded json bucket policy and created 2 policy documents. One inheriting from the other. 
`aws_iam_policy_document.cross_region_database_backups_s3_bucket_policy_document`
https://github.com/alphagov/digitalmarketplace-aws/pull/429/files#diff-fe12ef74960acd2feb5dc4ef2c4d6a66R2
and `aws_iam_policy_document.database_backups_s3_bucket_policy_document`
https://github.com/alphagov/digitalmarketplace-aws/pull/429/files#diff-fe12ef74960acd2feb5dc4ef2c4d6a66R48

We also need to apply `bucket-owner-read` acl to uploaded db dumps
    
As per https://docs.aws.amazon.com/AmazonS3/latest/dev/crr-troubleshoot.html

> By default, the bucket owner does not have any permissions on the objects created by <another> account. And the replication configuration replicates only the objects for which the bucket owner has access permissions.

Therefore the bucket owner must be granted read permissions on the uploaded object for replication to work.
We do this by applying the `bucket-owner-read` canned acl detailed here:

> Object owner gets FULL_CONTROL. Bucket owner gets READ access.

https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
