### PR TITLE
Remove requirement on virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ requirements-dev: virtualenv requirements-dev.txt
 virtualenv: ${VIRTUALENV_ROOT}/activate ## Create virtualenv if it does not exist
 
 ${VIRTUALENV_ROOT}/activate:
-	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && virtualenv -p python3 venv || true
+	@[ -z "${VIRTUAL_ENV}" ] && [ ! -d venv ] && python3 -m venv venv || true
 
 .PHONY: preview
 preview: ## Set stage to preview

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are a few independent tools we're using that are configured and run from t
 ## Setup
 
 ### Set up python dependencies
-Install dependencies with [virtualenv](https://virtualenv.pypa.io/en/latest/)
+Install dependencies with [venv](https://docs.python.org/3.6/library/venv.html)
 and [pip](https://pip.pypa.io/en/latest/installing.html).
 
 ```

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@ in (with args; {
     name = "digitalmarketplace-aws-env";
     shortName = "dm-aws";
     buildInputs = [
-      pythonPackages.virtualenv
+      pythonPackages.python
       pkgs.nodejs
       pkgs.jq
       pkgs.sops
@@ -46,7 +46,7 @@ in (with args; {
       export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
 
       if [ ! -e $VIRTUALENV_ROOT ]; then
-        ${pythonPackages.virtualenv}/bin/virtualenv $VIRTUALENV_ROOT
+        ${pythonPackages.python}/bin/python -m venv $VIRTUALENV_ROOT
       fi
       source $VIRTUALENV_ROOT/bin/activate
       make requirements${pkgs.stdenv.lib.optionalString forDev "-dev"}


### PR DESCRIPTION
Python36 includes the venv module which means we no longer need virtualenv to be installed on the development system