### PR TITLE
Stop terraform replanning replication config

### DIFF
--- a/scripts/generate-s3-post-url-data.py
+++ b/scripts/generate-s3-post-url-data.py
@@ -19,9 +19,9 @@ from docopt import docopt
 def generate_s3_post_data(bucket, filename):
     s3 = boto3.client('s3')
 
-    fields = {"acl": "bucket-owner-read"}
+    fields = {"acl": "private"}
     conditions = [
-        {"acl": "bucket-owner-read"}
+        {"acl": "private"}
     ]
 
     post = s3.generate_presigned_post(

--- a/terraform/accounts/backups/s3_buckets.tf
+++ b/terraform/accounts/backups/s3_buckets.tf
@@ -105,6 +105,7 @@ POLICY
     role = "${aws_iam_role.replication_role.arn}"
 
     rules {
+      id     = "cross-region-backups-replication"
       prefix = "*"
       status = "Enabled"
 


### PR DESCRIPTION
According to
https://github.com/terraform-providers/terraform-provider-aws/issues/665

Unless you give your replication rule an id it will replan the 'changes' on every plan run.

https://trello.com/c/KqUhQHFv/126-stop-terraform-replannig-replication-config