### PR TITLE
terraform: further refinement of antivirus-api infrastructure

### DIFF
--- a/paas/antivirus-api.j2
+++ b/paas/antivirus-api.j2
@@ -1,0 +1,16 @@
+{% extends "_base.j2" %}
+
+{% block env %}
+
+      AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
+      AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
+
+      DM_ANTIVIRUS_API_AUTH_TOKENS: {{ antivirus_api.auth_tokens|join(':') }}
+      DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS: {{ antivirus_api_basic_auth }}
+
+      DM_NOTIFY_API_KEY: {{ notify_api_key }}
+
+      {% if antivirus_api.developer_virus_alert_email is defined -%}
+      DM_DEVELOPER_VIRUS_ALERT_EMAIL: {{ antivirus_api.developer_virus_alert_email }}
+      {%- endif %}
+{% endblock %}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,8 +22,9 @@ All projects are then able to import and use the functionality they require from
 
 ## Requirements
 
-You will need to install the following manually (they are not installed as part of any other process such as
-`make requirements` or `pip`).
+Unless you're using the Nix environment (https://alphagov.github.io/digitalmarketplace-manual/nix.html) (in which they
+are all included), you will need to install the following manually (they are not installed as part of other process
+such as `make requirements` or `pip`).
 
 ### Install Terraform
 

--- a/terraform/modules/antivirus-sns/iam.tf
+++ b/terraform/modules/antivirus-sns/iam.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role_policy_attachment" "sns_failure_feedback_sns_feedback" {
 }
 
 resource "aws_iam_policy" "sns_feedback" {
-  name = "sns_feedback"
+  name = "sns_feedback_${var.environment}"
 
   policy = <<EOF
 {

--- a/terraform/modules/application-logs/variables.tf
+++ b/terraform/modules/application-logs/variables.tf
@@ -13,5 +13,6 @@ variable "app_names" {
     "briefs-frontend",
     "brief-responses-frontend",
     "user-frontend",
+    "antivirus-api",
   ]
 }

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -18,6 +18,10 @@ search-api:
   services:
     - search_api_elasticsearch
 
+antivirus-api:
+  routes:
+    - dm-antivirus-api-{env}.cloudapps.digital
+
 user-frontend:
   routes:
     - dm-{env}.cloudapps.digital/user


### PR DESCRIPTION
https://trello.com/c/i30jDD69/14-automatically-virus-scan-uploaded-files

Here we do a couple of things:

 - namespace the `sns_feedback` IAM policy with the environment name to allow staging & production's policies to co-exist.
 - add `antivirus-api` to terraform's list of apps to create log groups for