### PR TITLE
grafana: add antivirus-api to apps

### DIFF
--- a/grafana/dm-apps.json
+++ b/grafana/dm-apps.json
@@ -80,13 +80,18 @@
           "value": "api",
           "tags": []
         },
-        "query": "api,search-api,user-frontend,buyer-frontend,supplier-frontend,admin-frontend,briefs-frontend,brief-responses-frontend,router",
+        "query": "api,antivirus-api,search-api,user-frontend,buyer-frontend,supplier-frontend,admin-frontend,briefs-frontend,brief-responses-frontend,router",
         "type": "custom",
         "options": [
           {
             "text": "api",
             "selected": true,
             "value": "api"
+          },
+          {
+            "text": "antivirus-api",
+            "selected": true,
+            "value": "antivirus-api"
           },
           {
             "text": "search-api",


### PR DESCRIPTION
Trello https://trello.com/c/i30jDD69/14-automatically-virus-scan-uploaded-files

This makes our dashboards aware of the av-api. Has been pushed and appears to work.