### PR TITLE
antivirus-api: specify 2 instances on production

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -19,3 +19,6 @@ user-frontend:
 
 admin-frontend:
   instances: 2
+
+antivirus-api-frontend:
+  instances: 2


### PR DESCRIPTION
Seems like the most sensible thing, for a low-demand service.