### PR TITLE
paas: antivirus-api: give these instances 2G of memory on all stages

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -19,6 +19,7 @@ search-api:
     - search_api_elasticsearch
 
 antivirus-api:
+  memory: 2G
   routes:
     - dm-antivirus-api-{env}.cloudapps.digital
 


### PR DESCRIPTION
Seems to be what `clamd` needs.