### PR TITLE
router paas env vars: set `DM_ANTIVIRUS_API_URL`

### DIFF
--- a/paas/router.j2
+++ b/paas/router.j2
@@ -10,6 +10,7 @@
 
       DM_API_URL: 'https://dm-api-{{ environment }}.cloudapps.digital'
       DM_SEARCH_API_URL: 'https://dm-search-api-{{ environment }}.cloudapps.digital'
+      DM_ANTIVIRUS_API_URL: 'https://dm-antivirus-api-{{ environment }}.cloudapps.digital'
       DM_FRONTEND_URL: 'https://dm-{{ environment }}.cloudapps.digital'
 
       DM_G7_DRAFT_DOCUMENTS_S3_URL: {{ g7_draft_documents_s3_url }}


### PR DESCRIPTION
A prerequisite for https://github.com/alphagov/digitalmarketplace-router/pull/28