### PR TITLE
Create S3 buckets for admin reports

### DIFF
--- a/paas/admin-frontend.j2
+++ b/paas/admin-frontend.j2
@@ -18,6 +18,7 @@
       DM_COMMUNICATIONS_BUCKET: digitalmarketplace-communications-{{ environment }}-{{ environment }}
       DM_DOCUMENTS_BUCKET: digitalmarketplace-documents-{{ environment }}-{{ environment }}
       DM_SUBMISSIONS_BUCKET: digitalmarketplace-submissions-{{ environment }}-{{ environment }}
+      DM_REPORTS_BUCKET: digitalmarketplace-reports-{{ environment }}-{{ environment }}
 
       # TODO remove once admin app is updated to use DM_DOCUMENTS_BUCKET instead
       DM_S3_DOCUMENT_BUCKET: digitalmarketplace-documents-{{ environment }}-{{ environment }}

--- a/paas/router.j2
+++ b/paas/router.j2
@@ -17,6 +17,7 @@
       DM_DOCUMENTS_S3_URL: {{ documents_s3_url }}
       DM_AGREEMENTS_S3_URL: {{ agreements_s3_url }}
       DM_COMMUNICATIONS_S3_URL: {{ communications_s3_url }}
+      DM_REPORTS_S3_URL: {{ reports_s3_url }}
       DM_SUBMISSIONS_S3_URL: {{ submissions_s3_url }}
 
       DM_APP_AUTH: '{{ app_auth }}'

--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -120,7 +120,8 @@ resource "aws_iam_role_policy" "jenkins" {
           "arn:aws:s3:::digitalmarketplace-communications-preview-preview/*",
           "arn:aws:s3:::digitalmarketplace-documents-production-production/*",
           "arn:aws:s3:::digitalmarketplace-documents-staging-staging/*",
-          "arn:aws:s3:::digitalmarketplace-documents-preview-preview/*"
+          "arn:aws:s3:::digitalmarketplace-documents-preview-preview/*",
+          "arn:aws:s3:::digitalmarketplace-reports-production-production/*"
         ]
     }
   ]

--- a/terraform/environments/preview/s3_buckets.tf
+++ b/terraform/environments/preview/s3_buckets.tf
@@ -53,6 +53,48 @@ resource "aws_s3_bucket" "agreements_bucket" {
   policy = "${data.aws_iam_policy_document.agreements_bucket_policy_document.json}"
 }
 
+# Reports - devs: read write list
+
+data "aws_iam_policy_document" "reports_bucket_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = ["arn:aws:iam::${var.aws_dev_account_id}:role/developers"]
+      type        = "AWS"
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::digitalmarketplace-reports-preview-preview/*",
+      "arn:aws:s3:::digitalmarketplace-reports-preview-preview",
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "reports_bucket" {
+  bucket = "digitalmarketplace-reports-preview-preview"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.server_access_logs_bucket.id}"
+    target_prefix = "digitalmarketplace-reports-preview-preview/"
+  }
+
+  policy = "${data.aws_iam_policy_document.reports_bucket_policy_document.json}"
+}
+
 # Communications jenkins: read write
 
 data "aws_iam_policy_document" "communications_bucket_policy_document" {

--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -19,6 +19,7 @@ variable "g7_draft_documents_s3_url" {}
 variable "documents_s3_url" {}
 variable "agreements_s3_url" {}
 variable "communications_s3_url" {}
+variable "reports_s3_url" {}
 variable "submissions_s3_url" {}
 
 variable "api_url" {}

--- a/terraform/environments/production/s3_buckets.tf
+++ b/terraform/environments/production/s3_buckets.tf
@@ -58,6 +58,53 @@ resource "aws_s3_bucket" "agreements_bucket" {
   policy = "${data.aws_iam_policy_document.agreements_bucket_policy_document.json}"
 }
 
+# Reports - devs: read write list jenkins: read write list
+
+data "aws_iam_policy_document" "reports_bucket_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = [
+        "arn:aws:iam::${var.aws_prod_account_id}:role/developers",
+        "arn:aws:iam::${var.aws_main_account_id}:role/jenkins-ci-IAMRole-1FIPDG9DE2CWJ",
+      ]
+
+      type = "AWS"
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::digitalmarketplace-reports-production-production/*",
+      "arn:aws:s3:::digitalmarketplace-reports-production-production",
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "reports_bucket" {
+  bucket = "digitalmarketplace-reports-production-production"
+  acl    = "private"
+
+  versioning {
+    enabled    = true
+    mfa_delete = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.server_access_logs_bucket.id}"
+    target_prefix = "digitalmarketplace-reports-production-production/"
+  }
+
+  policy = "${data.aws_iam_policy_document.reports_bucket_policy_document.json}"
+}
+
 # Communications jenkins: read write
 
 data "aws_iam_policy_document" "communications_bucket_policy_document" {

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -19,6 +19,7 @@ variable "g7_draft_documents_s3_url" {}
 variable "documents_s3_url" {}
 variable "agreements_s3_url" {}
 variable "communications_s3_url" {}
+variable "reports_s3_url" {}
 variable "submissions_s3_url" {}
 
 variable "api_url" {}

--- a/terraform/environments/staging/s3_buckets.tf
+++ b/terraform/environments/staging/s3_buckets.tf
@@ -27,6 +27,22 @@ resource "aws_s3_bucket" "agreements_bucket" {
   }
 }
 
+# Reports
+
+resource "aws_s3_bucket" "reports_bucket" {
+  bucket = "digitalmarketplace-reports-staging-staging"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.server_access_logs_bucket.id}"
+    target_prefix = "digitalmarketplace-reports-staging-staging/"
+  }
+}
+
 # Communications
 
 resource "aws_s3_bucket" "communications_bucket" {

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -19,6 +19,7 @@ variable "g7_draft_documents_s3_url" {}
 variable "documents_s3_url" {}
 variable "agreements_s3_url" {}
 variable "communications_s3_url" {}
+variable "reports_s3_url" {}
 variable "submissions_s3_url" {}
 
 variable "api_url" {}


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

Three shiny new buckets:
`digitalmarketplace-reports-preview-preview`
`digitalmarketplace-reports-staging-staging`
`digitalmarketplace-reports-production-production`

Copies permissions/policy from the Agreements buckets (which has no explicit policy for the staging bucket).