### PR TITLE
148-remove-extraneous-variables-in-environments-variablestf-files

### DIFF
--- a/terraform/environments/preview/variables.tf
+++ b/terraform/environments/preview/variables.tf
@@ -1,34 +1,8 @@
 variable "aws_main_account_id" {}
 variable "aws_dev_account_id" {}
 
-variable "admin_user_ips" {
-  type = "list"
-}
-
-variable "dev_user_ips" {
-  type = "list"
-}
-
-variable "user_ips" {
-  type = "list"
-}
-
-variable "ssh_key_name" {}
-
-variable "g7_draft_documents_s3_url" {}
-variable "documents_s3_url" {}
-variable "agreements_s3_url" {}
-variable "communications_s3_url" {}
-variable "reports_s3_url" {}
-variable "submissions_s3_url" {}
-
-variable "api_url" {}
-variable "search_api_url" {}
-variable "frontend_url" {}
 variable "antivirus_api_host" {}
 variable "antivirus_api_basic_auth" {}
-
-variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -1,34 +1,8 @@
 variable "aws_main_account_id" {}
 variable "aws_prod_account_id" {}
 
-variable "admin_user_ips" {
-  type = "list"
-}
-
-variable "dev_user_ips" {
-  type = "list"
-}
-
-variable "user_ips" {
-  type = "list"
-}
-
-variable "ssh_key_name" {}
-
-variable "g7_draft_documents_s3_url" {}
-variable "documents_s3_url" {}
-variable "agreements_s3_url" {}
-variable "communications_s3_url" {}
-variable "reports_s3_url" {}
-variable "submissions_s3_url" {}
-
-variable "api_url" {}
-variable "search_api_url" {}
-variable "frontend_url" {}
 variable "antivirus_api_host" {}
 variable "antivirus_api_basic_auth" {}
-
-variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,34 +1,8 @@
 variable "aws_main_account_id" {}
 variable "aws_prod_account_id" {}
 
-variable "admin_user_ips" {
-  type = "list"
-}
-
-variable "dev_user_ips" {
-  type = "list"
-}
-
-variable "user_ips" {
-  type = "list"
-}
-
-variable "ssh_key_name" {}
-
-variable "g7_draft_documents_s3_url" {}
-variable "documents_s3_url" {}
-variable "agreements_s3_url" {}
-variable "communications_s3_url" {}
-variable "reports_s3_url" {}
-variable "submissions_s3_url" {}
-
-variable "api_url" {}
-variable "search_api_url" {}
-variable "frontend_url" {}
 variable "antivirus_api_host" {}
 variable "antivirus_api_basic_auth" {}
-
-variable "app_auth" {}
 
 variable "logs_elasticsearch_url" {}
 variable "logs_elasticsearch_api_key" {}


### PR DESCRIPTION
## Remove unused variables

It would appear that these have been at least partially copied from account/main/vairiables.tf?

We don't need that many variables injected in to these terraform modules so this commit strips un-needed variables
to reduce confusion and prevent extraneous code.

https://trello.com/c/vSknqk9R/148-remove-extraneous-variables-in-environments-variablestf-files