### PR TITLE
Jenkins IAM user can read/write preview/staging report buckets

### DIFF
--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -121,6 +121,8 @@ resource "aws_iam_role_policy" "jenkins" {
           "arn:aws:s3:::digitalmarketplace-documents-production-production/*",
           "arn:aws:s3:::digitalmarketplace-documents-staging-staging/*",
           "arn:aws:s3:::digitalmarketplace-documents-preview-preview/*",
+          "arn:aws:s3:::digitalmarketplace-reports-preview-preview/*",
+          "arn:aws:s3:::digitalmarketplace-reports-staging-staging/*",
           "arn:aws:s3:::digitalmarketplace-reports-production-production/*"
         ]
     }

--- a/terraform/environments/preview/s3_buckets.tf
+++ b/terraform/environments/preview/s3_buckets.tf
@@ -60,7 +60,10 @@ data "aws_iam_policy_document" "reports_bucket_policy_document" {
     effect = "Allow"
 
     principals {
-      identifiers = ["arn:aws:iam::${var.aws_dev_account_id}:role/developers"]
+      identifiers = [
+        "arn:aws:iam::${var.aws_dev_account_id}:role/developers",
+        "arn:aws:iam::${var.aws_main_account_id}:role/jenkins-ci-IAMRole-1FIPDG9DE2CWJ",
+      ]
       type        = "AWS"
     }
 

--- a/terraform/environments/preview/s3_buckets.tf
+++ b/terraform/environments/preview/s3_buckets.tf
@@ -64,7 +64,8 @@ data "aws_iam_policy_document" "reports_bucket_policy_document" {
         "arn:aws:iam::${var.aws_dev_account_id}:role/developers",
         "arn:aws:iam::${var.aws_main_account_id}:role/jenkins-ci-IAMRole-1FIPDG9DE2CWJ",
       ]
-      type        = "AWS"
+
+      type = "AWS"
     }
 
     actions = [


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

Enables the Jenkins role to access the preview and staging buckets, so we can test the script (and maybe even run functional tests in future).

I've already run terraform plan/apply for this so the changes reflect reality.