### PR TITLE
568-remove-arnawsiamvarawsdevaccountidrole-s3-only-references-from-terraform-this-role-is-not-created-anywhere

### DIFF
--- a/terraform/modules/iam-common/admin.tf
+++ b/terraform/modules/iam-common/admin.tf
@@ -14,25 +14,6 @@ resource "aws_iam_policy" "admin" {
           "aws:MultiFactorAuthPresent": true
         }
       }
-    },
-    {
-      "Effect": "Allow",
-      "Action": "sts:AssumeRole",
-      "Resource": [
-        "arn:aws:iam::${var.aws_dev_account_id}:role/s3-only"
-      ]
-    },
-    {
-      "Effect": "Deny",
-      "Action": "sts:AssumeRole",
-      "NotResource": [
-        "arn:aws:iam::${var.aws_dev_account_id}:role/s3-only"
-      ],
-      "Condition": {
-        "BoolIfExists": {
-          "aws:MultiFactorAuthPresent": false
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
## Remove arn:aws:iam::${var.aws_dev_account_id}:role/s3-only references from terraform

This _role_ is not created anywhere. A group is. A role is not.

We have references to an s3-only role for the dev account. This isn't created anywhere and doesn't exist.

arn:aws:iam::${var.aws_dev_account_id}:role/s3-only

https://trello.com/c/PvVlMCTz/568-remove-arnawsiamvarawsdevaccountidrole-s3-only-references-from-terraform-this-role-is-not-created-anywhere

https://console.aws.amazon.com/iam/home?region=eu-west-1#/roles

![screen shot 2018-09-18 at 09 47 13](https://user-images.githubusercontent.com/3469840/45675784-057d8c00-bb28-11e8-9247-f9358e3f9eea.png)
