### PR TITLE
Extend sns topic delivery retries to an hour

### DIFF
--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -9,11 +9,11 @@ resource "aws_sns_topic" "s3_file_upload_notification" {
   "http": {
     "defaultHealthyRetryPolicy": {
       "minDelayTarget": 1,
-      "maxDelayTarget": 3,
+      "maxDelayTarget": 3599,
       "numRetries": 5,
       "numMaxDelayRetries": 0,
       "numNoDelayRetries": 1,
-      "numMinDelayRetries": 1,
+      "numMinDelayRetries": 0,
       "backoffFunction": "linear"
     },
     "disableSubscriptionOverrides": true


### PR DESCRIPTION
This setup will retry once immediately, then 5 more times with a linear
backoff with the first retry after 1 second and the last after just
under an hour.