### PR TITLE
Set maxDelayTarget slightly lower

### DIFF
--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -9,7 +9,7 @@ resource "aws_sns_topic" "s3_file_upload_notification" {
   "http": {
     "defaultHealthyRetryPolicy": {
       "minDelayTarget": 1,
-      "maxDelayTarget": 3599,
+      "maxDelayTarget": 2399,
       "numRetries": 5,
       "numMaxDelayRetries": 0,
       "numNoDelayRetries": 1,


### PR DESCRIPTION
This is the max value that can be used with 5 retries that will apply.
Any higher and AWS will claim that the total retry period is over an
hour. I do not fully understand how it calculates this. This came from
trial and error.