### PR TITLE
default.nix: add libffi dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,7 @@ in (with args; {
         };
       }))
       pkgs.libyaml
+      pkgs.libffi
       pkgs.cloudfoundry-cli
       ((import ./aws-auth.nix) (with pkgs; { inherit stdenv fetchFromGitHub makeWrapper jq awscli openssl; }))
     ] ++ pkgs.stdenv.lib.optionals forDev ([


### PR DESCRIPTION
This requirement had been hidden by pip caching my wheels.