### PR TITLE
antivirus-api paas manifest template: solve lack of indentation for DM_DEVELOPER_VIRUS_ALERT_EMAIL

### DIFF
--- a/paas/antivirus-api.j2
+++ b/paas/antivirus-api.j2
@@ -10,7 +10,7 @@
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
-      {% if antivirus_api.developer_virus_alert_email is defined -%}
+      {% if antivirus_api.developer_virus_alert_email is defined %}
       DM_DEVELOPER_VIRUS_ALERT_EMAIL: {{ antivirus_api.developer_virus_alert_email }}
-      {%- endif %}
+      {% endif %}
 {% endblock %}


### PR DESCRIPTION
Didn't check its output again after I neatened it up with the whitespace-stripping.