### PR TITLE
Give Jenkins access to reports S3 bucket on Staging

### DIFF
--- a/terraform/environments/staging/s3_buckets.tf
+++ b/terraform/environments/staging/s3_buckets.tf
@@ -27,7 +27,7 @@ resource "aws_s3_bucket" "agreements_bucket" {
   }
 }
 
-# Reports - jenkins/developers: read write list
+# Reports - jenkins: read write list
 
 data "aws_iam_policy_document" "reports_bucket_policy_document" {
   statement {
@@ -35,7 +35,6 @@ data "aws_iam_policy_document" "reports_bucket_policy_document" {
 
     principals {
       identifiers = [
-        "arn:aws:iam::${var.aws_dev_account_id}:role/developers",
         "arn:aws:iam::${var.aws_main_account_id}:role/jenkins-ci-IAMRole-1FIPDG9DE2CWJ",
       ]
 

--- a/terraform/environments/staging/s3_buckets.tf
+++ b/terraform/environments/staging/s3_buckets.tf
@@ -27,7 +27,35 @@ resource "aws_s3_bucket" "agreements_bucket" {
   }
 }
 
-# Reports
+# Reports - jenkins/developers: read write list
+
+data "aws_iam_policy_document" "reports_bucket_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = [
+        "arn:aws:iam::${var.aws_dev_account_id}:role/developers",
+        "arn:aws:iam::${var.aws_main_account_id}:role/jenkins-ci-IAMRole-1FIPDG9DE2CWJ",
+      ]
+
+      type = "AWS"
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::digitalmarketplace-reports-staging-staging/*",
+      "arn:aws:s3:::digitalmarketplace-reports-staging-staging",
+    ]
+  }
+}
 
 resource "aws_s3_bucket" "reports_bucket" {
   bucket = "digitalmarketplace-reports-staging-staging"
@@ -41,6 +69,8 @@ resource "aws_s3_bucket" "reports_bucket" {
     target_bucket = "${aws_s3_bucket.server_access_logs_bucket.id}"
     target_prefix = "digitalmarketplace-reports-staging-staging/"
   }
+
+  policy = "${data.aws_iam_policy_document.reports_bucket_policy_document.json}"
 }
 
 # Communications


### PR DESCRIPTION
Trello: https://trello.com/c/FtV7sVMU/138-admin-download-all-suppliers-for-framework-endpoint-locks-up-an-api-process

The new CSV report creation and download is working great on Preview. 

To test on staging, we need Jenkins to have write access on the S3 reports bucket in order for the script to run successfully. Then we can release the Router and Admin FE to staging, and test the download.

(Planned and applied on staging)