### PR TITLE
Update requests library

### DIFF
--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -1,5 +1,4 @@
 import os
-import re
 import collections
 
 import yaml
@@ -9,17 +8,6 @@ from jinja2.runtime import StrictUndefined
 
 
 DEFAULT_TEMPLATES_PATH = 'cloudformation_templates/'
-
-
-def safe_path_join(basedir, path):
-    path = os.path.join(basedir, path)
-    abs_path = os.path.abspath(path)
-    abs_basedir = os.path.abspath(basedir)
-
-    if not abs_path.startswith(abs_basedir):
-        raise ValueError('Path outside base directory %s' % abs_basedir)
-
-    return path
 
 
 def read_yaml_file(path):
@@ -112,12 +100,6 @@ def template_string(string, variables, templates_path=None):
 
     # can raise UndefinedError
     return template.render(variables)
-
-
-def param_to_env(name):
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1)
-    return s2.upper().replace('ENV_VAR_', '')
 
 
 def mkdir_p(path):

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -2,7 +2,6 @@ import os
 import re
 import collections
 
-import six
 import yaml
 import jinja2
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError  # noqa
@@ -31,19 +30,6 @@ def read_yaml_file(path):
 def load_file(path):
     with open(path) as f:
         return f.read()
-
-
-def dict_from_path(path, value):
-    result = {}
-    if isinstance(path, six.string_types):
-        path = path.split('.')
-
-    if not path:
-        return value
-
-    result[path[0]] = dict_from_path(path[1:], value)
-
-    return result
 
 
 def merge_dicts(a, b):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==6.6
 Jinja2==2.10
 PyYAML==3.11
-six==1.10.0
 awscli==1.15.67
 requests==2.20.0
 boto3==1.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Jinja2==2.10
 PyYAML==3.11
 six==1.10.0
 awscli==1.15.67
-requests==2.14.2
+requests==2.20.0
 boto3==1.4.5
 docopt==0.6.2
 bcrypt==3.1.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 
 from dmaws.utils import (
     DEFAULT_TEMPLATES_PATH,
-    dict_from_path, merge_dicts,
+    merge_dicts,
     safe_path_join,
     template, template_string, LazyTemplateMapping, UndefinedError,
     mkdir_p,
@@ -31,22 +31,6 @@ class TestSafePathJoin(object):
     def test_relative_basedir_root_subdir_subpath(self):
         with pytest.raises(ValueError):
             safe_path_join('./', '/../../app/static')
-
-
-class TestDictFromPath(object):
-    def test_simple_string(self):
-        assert dict_from_path("key", 1) == {"key": 1}
-
-    def test_dotted_pair_string(self):
-        assert dict_from_path("nested.key", 1) == {"nested": {"key": 1}}
-
-    def test_digits_are_treated_as_strings(self):
-        assert dict_from_path("0.key", 1) == {"0": {"key": 1}}
-
-    def test_nested_string(self):
-        assert dict_from_path("very.nested.key", 1) == {
-            "very": {"nested": {"key": 1}}
-        }
 
 
 class TestMergeDicts(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,33 +4,9 @@ import pytest
 from dmaws.utils import (
     DEFAULT_TEMPLATES_PATH,
     merge_dicts,
-    safe_path_join,
     template, template_string, LazyTemplateMapping, UndefinedError,
     mkdir_p,
 )
-
-
-class TestSafePathJoin(object):
-    def test_simple_subpath(self):
-        assert safe_path_join('', 'app/static') == 'app/static'
-
-    def test_relative_basedir_subpath(self):
-        assert safe_path_join('./', 'app/static') == './app/static'
-
-    def test_relative_basedir_relative_subpath(self):
-        assert safe_path_join('./', './app/static') == '././app/static'
-
-    def test_relative_basedir_parent_subpath(self):
-        with pytest.raises(ValueError):
-            safe_path_join('./', '../../app/static')
-
-    def test_relative_basedir_root_subpath(self):
-        with pytest.raises(ValueError):
-            safe_path_join('./', '/app/static')
-
-    def test_relative_basedir_root_subdir_subpath(self):
-        with pytest.raises(ValueError):
-            safe_path_join('./', '/../../app/static')
 
 
 class TestMergeDicts(object):


### PR DESCRIPTION
Trello: https://trello.com/c/XuJNrSHX/483-vulnerability-fix-weekly-tracking

- Upgrades `requests` to 2.20.0 following Snyk vulnerability warning
- Removes `six` (Py2 support no longer required in this repo)
- Removes unused utils functions `dict_from_path`, `safe_path_join` and `param_to_env ` (I did a full grep and some digging in the history but can't find any usage).
