### PR TITLE
terraform: add "*-dropped-antivirus-sns" log metrics, sourced from both failure and success sns feedback logs

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -52,10 +52,13 @@ module "log_streaming" {
 }
 
 module "log_metrics" {
-  source                = "../../modules/log-metrics"
-  environment           = "preview"
-  app_names             = ["${module.application_logs.app_names}"]
-  router_log_group_name = "${element(module.preview_router.json_log_groups, 0)}"
+  source                               = "../../modules/log-metrics"
+  environment                          = "preview"
+  app_names                            = ["${module.application_logs.app_names}"]
+  router_log_group_name                = "${element(module.preview_router.json_log_groups, 0)}"
+  antivirus_sns_failure_log_group_name = "${module.antivirus-sns.failure_log_group_name}"
+  antivirus_sns_success_log_group_name = "${module.antivirus-sns.success_log_group_name}"
+  antivirus_sns_topic_num_retries      = "${module.antivirus-sns.topic_num_retries}"
 }
 
 module "antivirus-sns" {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -52,10 +52,13 @@ module "log_streaming" {
 }
 
 module "log_metrics" {
-  source                = "../../modules/log-metrics"
-  environment           = "production"
-  app_names             = ["${module.application_logs.app_names}"]
-  router_log_group_name = "${element(module.production_router.json_log_groups, 0)}"
+  source                               = "../../modules/log-metrics"
+  environment                          = "production"
+  app_names                            = ["${module.application_logs.app_names}"]
+  router_log_group_name                = "${element(module.production_router.json_log_groups, 0)}"
+  antivirus_sns_failure_log_group_name = "${module.antivirus-sns.failure_log_group_name}"
+  antivirus_sns_success_log_group_name = "${module.antivirus-sns.success_log_group_name}"
+  antivirus_sns_topic_num_retries      = "${module.antivirus-sns.topic_num_retries}"
 }
 
 module "antivirus-sns" {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -46,10 +46,13 @@ module "log_streaming" {
 }
 
 module "log_metrics" {
-  source                = "../../modules/log-metrics"
-  environment           = "staging"
-  app_names             = ["${module.application_logs.app_names}"]
-  router_log_group_name = "${element(module.staging_router.json_log_groups, 0)}"
+  source                               = "../../modules/log-metrics"
+  environment                          = "staging"
+  app_names                            = ["${module.application_logs.app_names}"]
+  router_log_group_name                = "${element(module.staging_router.json_log_groups, 0)}"
+  antivirus_sns_failure_log_group_name = "${module.antivirus-sns.failure_log_group_name}"
+  antivirus_sns_success_log_group_name = "${module.antivirus-sns.success_log_group_name}"
+  antivirus_sns_topic_num_retries      = "${module.antivirus-sns.topic_num_retries}"
 }
 
 module "antivirus-sns" {

--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -10,7 +10,7 @@ resource "aws_sns_topic" "s3_file_upload_notification" {
     "defaultHealthyRetryPolicy": {
       "minDelayTarget": 1,
       "maxDelayTarget": 2399,
-      "numRetries": 5,
+      "numRetries": ${var.topic_num_retries},
       "numMaxDelayRetries": 0,
       "numNoDelayRetries": 1,
       "numMinDelayRetries": 0,

--- a/terraform/modules/antivirus-sns/outputs.tf
+++ b/terraform/modules/antivirus-sns/outputs.tf
@@ -1,0 +1,11 @@
+output "failure_log_group_name" {
+  value = "${aws_cloudwatch_log_group.antivirus_sns_logs_failure.name}"
+}
+
+output "success_log_group_name" {
+  value = "${aws_cloudwatch_log_group.antivirus_sns_logs_success.name}"
+}
+
+output "topic_num_retries" {
+  value = "${var.topic_num_retries}"
+}

--- a/terraform/modules/antivirus-sns/variables.tf
+++ b/terraform/modules/antivirus-sns/variables.tf
@@ -10,3 +10,7 @@ variable "antivirus_api_basic_auth" {}
 
 variable "retention_in_days" {}
 variable "log_stream_lambda_arn" {}
+
+variable "topic_num_retries" {
+  default = 5
+}

--- a/terraform/modules/log-metrics/variables.tf
+++ b/terraform/modules/log-metrics/variables.tf
@@ -5,3 +5,7 @@ variable "app_names" {
 }
 
 variable "router_log_group_name" {}
+
+variable "antivirus_sns_failure_log_group_name" {}
+variable "antivirus_sns_success_log_group_name" {}
+variable "antivirus_sns_topic_num_retries" {}


### PR DESCRIPTION
https://trello.com/c/cQEkAi5b/214-enable-hosted-graphite-alerts-for-final-failed-sns-deliveries

Triggered by both "final retry" "failure"s and 4xx responses from the "success" log group.

This includes quite a bit of variable wiring around the place so we can pull e.g. the max number of retries to filter for and the names of the log groups from the various places they're decided.