### PR TITLE
Example PaaS manifests for API, Search API, Buyer FE and Router

### DIFF
--- a/example_manifests/api-manifest.yml.example
+++ b/example_manifests/api-manifest.yml.example
@@ -1,0 +1,37 @@
+# Example of a PaaS manifest for the API app on Preview, based on the paas/api.j2 template.
+# Generated with:
+#    make generate-manifest APPLICATION_NAME=api STAGE=preview DM_CREDENTIALS_REPO=/path/to/creds
+---
+
+applications:
+  - name: api-release
+
+    routes:
+      - route: dm-api-preview.cloudapps.digital
+
+    health-check-type: http
+    health-check-http-endpoint: /_status?ignore-dependencies
+
+    instances: 1
+    memory: 2GB
+    disk_quota: 2G
+
+    env:
+      DM_APP_NAME: api
+      DM_ENVIRONMENT: preview
+      DM_METRICS_NAMESPACE: preview-preview/api
+
+      DM_LOG_PATH: ''
+
+      AWS_ACCESS_KEY_ID: ExampleAWSAccessKeyID
+      AWS_SECRET_ACCESS_KEY: ExampleAWSSecretAccessKey
+
+      DM_API_AUTH_TOKENS: ExampleApiAuthToken:ExampleJenkinsAuthToken:ExampleDeveloperAuthToken
+
+      DM_API_CALLBACK_AUTH_TOKENS: ExampleNotifyApiCallbackToken
+
+      DM_SEARCH_API_AUTH_TOKEN: ExampleSearchApiAuthToken
+      DM_SEARCH_API_URL: https://dm-search-api-preview.cloudapps.digital
+
+    services:
+        - digitalmarketplace_api_db

--- a/example_manifests/buyer-frontend-manifest.yml.example
+++ b/example_manifests/buyer-frontend-manifest.yml.example
@@ -1,0 +1,42 @@
+# Example of a PaaS manifest for the Buyer FE app on Preview, based on the paas/buyer-frontend.j2 template.
+# The other frontend apps have similar manifests, but with their own env vars and routes.
+# Generated with:
+#    make generate-manifest APPLICATION_NAME=buyer-frontend STAGE=preview DM_CREDENTIALS_REPO=/path/to/creds
+---
+
+applications:
+  - name: buyer-frontend-release
+
+    routes:
+      - route: dm-preview.cloudapps.digital
+      - route: dm-preview.cloudapps.digital/buyers/direct-award
+
+    health-check-type: http
+    health-check-http-endpoint: /_status?ignore-dependencies
+
+    instances: 1
+    memory: 512M
+    disk_quota: 2G
+
+    env:
+      DM_APP_NAME: buyer-frontend
+      DM_ENVIRONMENT: preview
+      DM_METRICS_NAMESPACE: preview-preview/buyer-frontend
+
+      DM_LOG_PATH: ''
+
+      AWS_ACCESS_KEY_ID: ExampleAWSAccessKeyID
+      AWS_SECRET_ACCESS_KEY: ExampleAWSSecretAccessKey
+
+      DM_DATA_API_AUTH_TOKEN: ExampleAPIAuthToken
+      DM_DATA_API_URL: https://dm-api-preview.cloudapps.digital
+
+      DM_MANDRILL_API_KEY: ExampleMandrillAPIKey
+
+      DM_SEARCH_API_AUTH_TOKEN: ExampleSearchApiAuthToken
+      DM_SEARCH_API_URL: https://dm-search-api-preview.cloudapps.digital
+
+      PROXY_AUTH_CREDENTIALS: ExampleProxyAuthCredentials
+
+      SECRET_KEY: ExampleFlaskSecretKey
+      SHARED_EMAIL_KEY: ExampleEmailKey

--- a/example_manifests/router-manifest.yml.example
+++ b/example_manifests/router-manifest.yml.example
@@ -1,0 +1,51 @@
+# Example of a PaaS manifest for the Router app on Preview, based on the paas/router.j2 template.
+# DM_MODE mode can be either 'live' or 'maintenance'.
+# Generated with:
+#    make generate-manifest APPLICATION_NAME=router STAGE=preview DM_CREDENTIALS_REPO=/path/to/creds
+---
+
+applications:
+  - name: router-release
+
+    routes:
+      - route: www.preview.marketplace.team
+      - route: api.preview.marketplace.team
+      - route: search-api.preview.marketplace.team
+      - route: antivirus-api.preview.marketplace.team
+      - route: assets.preview.marketplace.team
+
+    health-check-type: http
+    health-check-http-endpoint: /_status?ignore-dependencies
+
+    instances: 1
+    memory: 512M
+    disk_quota: 2G
+
+    env:
+      DM_APP_NAME: router
+      DM_ENVIRONMENT: preview
+      DM_METRICS_NAMESPACE: preview-preview/router
+
+      DM_LOG_PATH: ''
+
+      AWS_ACCESS_KEY_ID: ExampleAWSAccessKeyID
+      AWS_SECRET_ACCESS_KEY: ExampleAWSSecretAccessKey
+
+      DM_ADMIN_USER_IPS: 'List/of/IPs'
+      DM_DEV_USER_IPS: 'List/of/IPs'
+      DM_USER_IPS: 'List/of/IPs'
+
+      DM_API_URL: 'https://dm-api-preview.cloudapps.digital'
+      DM_SEARCH_API_URL: 'https://dm-search-api-preview.cloudapps.digital'
+      DM_ANTIVIRUS_API_URL: 'https://dm-antivirus-api-preview.cloudapps.digital'
+      DM_FRONTEND_URL: 'https://dm-preview.cloudapps.digital'
+
+      DM_G7_DRAFT_DOCUMENTS_S3_URL: https://example-bucket1.s3.amazonaws.com
+      DM_DOCUMENTS_S3_URL: https://example-bucket2.s3.amazonaws.com
+      DM_AGREEMENTS_S3_URL: https://example-bucket3.s3.amazonaws.com
+      DM_COMMUNICATIONS_S3_URL: https://example-bucket4.s3.amazonaws.com
+      DM_REPORTS_S3_URL: https://example-bucket5.s3.amazonaws.com
+      DM_SUBMISSIONS_S3_URL: https://example-bucket6.s3.amazonaws.com
+
+      DM_APP_AUTH: 'ExampleBasicAuthToken'
+      DM_MODE: 'live'

--- a/example_manifests/search-api-manifest.yml.example
+++ b/example_manifests/search-api-manifest.yml.example
@@ -1,0 +1,34 @@
+# Example of a PaaS manifest for the Search API app on Preview, based on the paas/search-api.j2 template.
+# When migrating to a new Elasticsearch service, add in the DM_ELASTICSEARCH_SERVICE_NAME as an extra env var.
+# Generated with:
+#    make generate-manifest APPLICATION_NAME=search-api STAGE=preview DM_CREDENTIALS_REPO=/path/to/creds
+---
+
+applications:
+  - name: search-api-release
+
+    routes:
+      - route: dm-search-api-preview.cloudapps.digital
+
+    health-check-type: http
+    health-check-http-endpoint: /_status?ignore-dependencies
+
+    instances: 1
+    memory: 512M
+    disk_quota: 2G
+
+    env:
+      DM_APP_NAME: search-api
+      DM_ENVIRONMENT: preview
+      DM_METRICS_NAMESPACE: preview-preview/search-api
+      DM_ELASTICSEARCH_SERVICE_NAME: search_api_elasticsearch   # This env var is added manually during migrations
+
+      DM_LOG_PATH: ''
+
+      AWS_ACCESS_KEY_ID: ExampleAWSAccessKeyID
+      AWS_SECRET_ACCESS_KEY: ExampleAWSSecretAccessKey
+
+      DM_SEARCH_API_AUTH_TOKENS: ExampleApiAuthToken:ExampleJenkinsAuthToken:ExampleDeveloperAuthToken
+
+    services:
+      - search_api_elasticsearch


### PR DESCRIPTION
Trello: https://trello.com/c/GNMyCgSJ/232-example-paas-manifest-yaml-files

Generated some example PaaS manifests for Preview (with all credentials etc stripped) for:
- API
- Search API
- Router
- Buyer FE (the other frontend apps are similar enough that I only did this one - happy to add more if people think there's value in it)

These manifests are unlikely to change drastically in the future, but if they do, I've included a line at the top of the examples on how to generate new ones.

I've left in values for routes and URLs as these are public (described in the `vars` folder of this repo). Please double check that I've taken everything else out!
