### PR TITLE
Stop old versions of PaaS apps before deleting them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ deploy-app: ## Deploys the app to PaaS
 	@echo "Waiting for previous app version to process existing requests..."
 	sleep 60
 
+	cf stop ${APPLICATION_NAME}
 	cf delete -f ${APPLICATION_NAME}
 	cf rename ${APPLICATION_NAME}-release ${APPLICATION_NAME}
 


### PR DESCRIPTION
Trello: https://trello.com/c/6U8VSFdr/259-deploy-script-should-we-use-cf-stop-before-cf-delete

We've been seeing 500 errors during deploys of the Search API. Our theory is that the requests  cannot reach the Elasticsearch service bound to old instances of the app.

On the suggestion of the PaaS team, calling `cf stop` before `cf delete` may address the issue. This will mean an extra 10s delay in the deploy, however hopefully it should give any requests a chance to finish before the app drops its binding to the service (e.g. Search API and Elasticsearch).