### PR TITLE
Enable access logging on Jenkins load balancers

### DIFF
--- a/terraform/modules/iam-users/infrastructure.tf
+++ b/terraform/modules/iam-users/infrastructure.tf
@@ -16,7 +16,7 @@ resource "aws_iam_group_policy" "dev_infrastructure" {
         "sts:AssumeRole"
       ],
       "Resource": [
-        "arn:aws:iam::${var.aws_dev_account_id}:role/infrastructure",
+        "arn:aws:iam::${var.aws_dev_account_id}:role/infrastructure"
       ]
     }
   ]
@@ -49,7 +49,7 @@ resource "aws_iam_group_policy" "prod_infrastructure" {
         "sts:AssumeRole"
       ],
       "Resource": [
-        "arn:aws:iam::${var.aws_prod_account_id}:role/infrastructure",
+        "arn:aws:iam::${var.aws_prod_account_id}:role/infrastructure"
       ]
     }
   ]

--- a/terraform/modules/jenkins/elb.tf
+++ b/terraform/modules/jenkins/elb.tf
@@ -4,6 +4,12 @@ resource "aws_elb" "jenkins_elb" {
   instances       = ["${aws_instance.jenkins.id}"]
   security_groups = ["${aws_security_group.jenkins_elb_security_group.id}"]
 
+  access_logs {
+    bucket   = "${aws_s3_bucket.jenkins_logs_bucket.bucket}"
+    interval = 60
+    enabled  = true
+  }
+
   listener {
     instance_port      = 80
     instance_protocol  = "http"

--- a/terraform/modules/jenkins/s3_bucket.tf
+++ b/terraform/modules/jenkins/s3_bucket.tf
@@ -1,0 +1,28 @@
+resource "aws_s3_bucket" "jenkins_logs_bucket" {
+  bucket        = "${var.name}-${var.dns_name}-logs-bucket"
+  force_destroy = true
+
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSElasticLoadBalancerWrite",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "arn:aws:iam::156460612806:root"
+                ]
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${var.name}-${var.dns_name}-logs-bucket/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}

--- a/terraform/modules/jenkins/s3_bucket.tf
+++ b/terraform/modules/jenkins/s3_bucket.tf
@@ -2,6 +2,9 @@ resource "aws_s3_bucket" "jenkins_logs_bucket" {
   bucket        = "${var.name}-${var.dns_name}-logs-bucket"
   force_destroy = true
 
+  # The id 156460612806 is the ELB account (eu-west-1)
+  # see https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
+
   policy = <<POLICY
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
We want to be able to audit who is accessing our Jenkins build server, and when.

This PR enables access logging on the Elastic Load Balancer that sits in front of our Jenkins box; this means that all SSH and HTTPS access will be logged.

The logs are stored hourly in an S3 bucket, in a compressed format.

For more details on how this works, see the [Trello ticket][ticket].

The Terraform for these changes have already been tested and applied, and the logging is now taking place.

[ticket]: https://trello.com/c/S7iFoAU8/253-configure-jenkins-box-ssh-access-logging