### PR TITLE
default.nix: set forDev to true by default

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@ let
   args = rec {
     pkgs = import <nixpkgs> {};
     pythonPackages = pkgs.python36Packages;
-    forDev = false;
+    forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
 in (with args; {


### PR DESCRIPTION
So we're not left scratching our heads when the tests won't run.