### PR TITLE
Add CloudWatch Logs policy to Jenkins instance profile

### DIFF
--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -143,3 +143,25 @@ resource "aws_iam_role_policy" "jenkins" {
 }
 EOF
 }
+
+data "aws_iam_policy_document" "cloudwatch-policy" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "arn:aws:logs:eu-west-1:*:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "jenkins-cloudwatch" {
+  name = "JenkinsCloudWatchLogs"
+  role = "${aws_iam_role.jenkins.id}"
+
+  policy = "${data.aws_iam_policy_document.cloudwatch-policy.json}"
+}

--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -154,7 +154,7 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
     ]
 
     resources = [
-      "arn:aws:logs:eu-west-1:*:*",
+      "arn:aws:logs:eu-west-1:398263320410:*",
     ]
   }
 }


### PR DESCRIPTION
We want our Jenkins server to be able to upload logs to CloudWatch.

Part of https://trello.com/c/Uf14tLzG/247-jenkins-get-the-job-logs-out.