### PR TITLE
make deploy-app: add "wait" after pushing app before starting it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,13 @@ deploy-app: ## Deploys the app to PaaS
 	$(call check_space)
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${RELEASE_NAME},,$(error Must specify RELEASE_NAME))
-	cf push -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}
+	cf push --no-start -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}
+
+	@echo "Waiting to ensure new app's assigned service credentials have taken effect..."
+	sleep 60
+
+	@echo "Starting app..."
+	cf start ${APPLICATION_NAME}-release
 
 	# TODO restore scaling before route switch once we have autoscaling set up
 	# TODO for now, we're using the instance counts set in the manifest


### PR DESCRIPTION
https://trello.com/c/6vpsFZVM/552-search-api-releases-can-still-cause-a-flood-of-500s-as-instances-lose-contact-with-es

This is to ensure the new app's assigned service credentials have taken effect. Again, particularly a problem with new aiven-backed services, though this is apparently something that's being worked on and we should be able to remove this stopgap at some point.

Seems to work when performed from a local machine.