### PR TITLE
antivirus-api: *actually* set instances to 2 by spelling the app correctly

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -21,5 +21,5 @@ user-frontend:
 admin-frontend:
   instances: 2
 
-antivirus-api-frontend:
+antivirus-api:
   instances: 2


### PR DESCRIPTION
Doh.

https://trello.com/c/GELoPi7h/565-reduce-number-of-av-api-instances-on-production