### PR TITLE
Use metrics as blueprint

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -14,5 +14,5 @@
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 
-      PROMETHEUS_METRICS_PATH: /suppliers/opportunities/_metrics
+      PROMETHEUS_METRICS_PATH: /_metrics
 {% endblock %}


### PR DESCRIPTION
* This endpoint is now defined with the blueprint prefix in the brief-responses-frontend