### PR TITLE
Deployment requirements for metrics

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -48,6 +48,9 @@ briefs-frontend:
 brief-responses-frontend:
   routes:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
+    - dm-{env}.cloudapps.digital/suppliers/opportunities/metrics
+  services:
+    - digitalmarketplace_prometheus
 
 db-backup:
   instances: 1


### PR DESCRIPTION
* Add explicitly defined route (/metrics) for metrics
  * This route allows us to bind the whitelisting route service
* Bind digitalmarketplace_prometheus service using the app manifest