### PR TITLE
Update metrics path with _ now RE have a workaround

### DIFF
--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -14,6 +14,6 @@
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 
-      PROMETHEUS_METRICS_PATH: /metrics
+      PROMETHEUS_METRICS_PATH: /_metrics
       METRICS_BASIC_AUTH: false
 {% endblock %}


### PR DESCRIPTION
@philandstuff has found a work around for us to have _metrics! 🙌 

This env var controls where the `gds_python_metrics` puts our metrics endpoint and can be merged once his PR is deployed 

https://trello.com/c/6DZK1NzZ/349-update-metrics-path-with-now-re-have-a-workaround