### PR TITLE
Update metrics path with _ now RE have a workaround

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -48,7 +48,7 @@ briefs-frontend:
 brief-responses-frontend:
   routes:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
-    - dm-{env}.cloudapps.digital/suppliers/opportunities/metrics
+    - dm-{env}.cloudapps.digital/suppliers/opportunities/_metrics
   services:
     - digitalmarketplace_prometheus
 


### PR DESCRIPTION
Allows us to bind this path to the ip whitelisting service
