### PR TITLE
Increase default router instances to 2 on preview

### DIFF
--- a/example_manifests/router-manifest.yml.example
+++ b/example_manifests/router-manifest.yml.example
@@ -17,7 +17,7 @@ applications:
     health-check-type: http
     health-check-http-endpoint: /_status?ignore-dependencies
 
-    instances: 1
+    instances: 2
     memory: 512M
     disk_quota: 2G
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,3 +4,6 @@ maintenance_mode: live
 
 api:
   memory: 2GB
+
+router:
+  instances: 2


### PR DESCRIPTION
Our smoulder tests were triggering rate limiting on preview as there was only one nginx instance running there. This PR scales up the default instances to 2 (I've already done it manually on preview with `cf scale router -i 2`).

Tested locally with `make generate-manifest APPLICATION_NAME=router STAGE=preview`. 

Also updated the example manifest to match.

Manual entry coming soon!