### PR TITLE
clean-db-dump.sql: perform construction of mock json in a safer way than pure string formatting

### DIFF
--- a/scripts/clean-db-dump.sql
+++ b/scripts/clean-db-dump.sql
@@ -147,6 +147,7 @@ WHERE declaration IS NOT NULL
 -- Create some fake draft and submitted brief responses on closed briefs using eligible suppliers
 -- Ensuring essential requirements evidence length matches that of the brief essential requirements
 -- and nice to have requirements are representative of possible data given brief nice to have requirements
+\echo 'Generate fake brief_responses'
 INSERT INTO brief_responses (
       data,
       brief_id,


### PR DESCRIPTION
https://trello.com/c/JgsizEmz

While I don't _think_ the exact fields being used here _should_ cause us to be at risk, all it takes is for someone less experienced to need to include an extra field's data, and decide to simply copy & paste an existing line and include a text-based field - at this point we would open ourselves to the string being able to escape from the confines of its intended json key using the `"` character.

I've run this against an _already cleaned_ version of the database on my local machine, because that's all I think I'm able to do. It appears to do the right thing. Anyone got any bright ideas as to how to safely test this against the real target short of merging it & trying it for reals?