### PR TITLE
Add rate_limiting_enabled flag to router PaaS manifest

### DIFF
--- a/paas/router.j2
+++ b/paas/router.j2
@@ -22,4 +22,7 @@
 
       DM_APP_AUTH: '{{ app_auth }}'
       DM_MODE: '{{ maintenance_mode }}'
+      {% if rate_limiting_enabled %}
+      DM_RATE_LIMITING_ENABLED: true
+      {% endif %}
 {% endblock %}

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -7,3 +7,4 @@ api:
 
 router:
   instances: 2
+  rate_limiting_enabled: true

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -5,6 +5,7 @@ instances: 5
 
 router:
   instances: 3
+  rate_limiting_enabled: true
   routes:
     - www.digitalmarketplace.service.gov.uk
     - api.digitalmarketplace.service.gov.uk

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -5,3 +5,6 @@ instances: 2
 
 api:
   memory: 2GB
+
+router:
+  rate_limiting_enabled: true


### PR DESCRIPTION
To help ease our load testing (see Trello: https://trello.com/c/tFiYL9vk/379-load-test-the-supplier-account-creation-journey), it'd be nice to switch rate limiting on and off per environment.

This PR sets a `DM_RATE_LIMITING_ENABLED` variable in the router's PaaS environment vars, that the router can then use to include the rate limit config (or not). 

This is part 1 of 2 - set the vars to `true` for each environment by default.

Part 2 (router) incoming.

Tested this locally with `make generate-manifest APPLICATION_NAME=router STAGE=preview`. Setting to `false` means the var is not generated.