### PR TITLE
Temporarily turn off preview rate limit and bump router instances to 3

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -6,5 +6,5 @@ api:
   memory: 2GB
 
 router:
-  instances: 2
-  rate_limiting_enabled: true
+  instances: 3
+  rate_limiting_enabled: false


### PR DESCRIPTION
Trello: https://trello.com/c/tFiYL9vk/379-load-test-the-supplier-account-creation-journey

Doing this manually isn't working so let's go through the 'official channels'.

The changes are only for preview, so shouldn't affect other envs if we 'temporarily' forget about this.