### PR TITLE
Always set DM_RATE_LIMIT_ENABLED var to a value

### DIFF
--- a/paas/router.j2
+++ b/paas/router.j2
@@ -22,7 +22,6 @@
 
       DM_APP_AUTH: '{{ app_auth }}'
       DM_MODE: '{{ maintenance_mode }}'
-      {% if rate_limiting_enabled %}
-      DM_RATE_LIMITING_ENABLED: true
-      {% endif %}
+      DM_RATE_LIMITING_ENABLED: '{{ rate_limiting_enabled }}'
+
 {% endblock %}

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -7,4 +7,4 @@ api:
 
 router:
   instances: 3
-  rate_limiting_enabled: false
+  rate_limiting_enabled: disabled

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -5,7 +5,7 @@ instances: 5
 
 router:
   instances: 3
-  rate_limiting_enabled: true
+  rate_limiting_enabled: enabled
   routes:
     - www.digitalmarketplace.service.gov.uk
     - api.digitalmarketplace.service.gov.uk

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -7,4 +7,4 @@ api:
   memory: 2GB
 
 router:
-  rate_limiting_enabled: true
+  rate_limiting_enabled: enabled


### PR DESCRIPTION
The Nginx Jinja isn't happy with falsy/missing environment values.

Staging and Prod are enabled, Preview is disabled for the moment.