### PR TITLE
Re-enable rate limiting on Preview

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -6,5 +6,5 @@ api:
   memory: 2GB
 
 router:
-  instances: 3
-  rate_limiting_enabled: disabled
+  instances: 2
+  rate_limiting_enabled: enabled


### PR DESCRIPTION
Load testing (https://trello.com/c/tFiYL9vk/379-load-test-the-supplier-account-creation-journey) is now done.

Re-enable rate limiting on preview, and scale back down to 2 router apps.