### PR TITLE
Add recovery emails for alarms in terraform

### DIFF
--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -1,44 +1,55 @@
-module "email_alarm_sns" {
-  source      = "../../modules/logging/alarms/email-notification"
-  environment = "preview"
-  account_id  = "${var.aws_dev_account_id}"
+module "alarm_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "preview"
+  account_id = "${var.aws_dev_account_id}"
+}
+
+module "alarm_recovery_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "preview-recovery"
+  account_id = "${var.aws_dev_account_id}"
 }
 
 // Missing logs for the preview-<app-name>-application log group metrics
 module "missing_application_logs_alarms" {
-  source                = "../../modules/logging/alarms/missing-logs"
-  environment           = "preview"
-  type                  = "application"
-  app_names             = ["${module.application_logs.app_names}"]
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/missing-logs"
+  environment                    = "preview"
+  type                           = "application"
+  app_names                      = ["${module.application_logs.app_names}"]
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 // Missing logs for the preview-router-nginx log group metrics
 module "missing_nginx_logs_alarms" {
-  source                = "../../modules/logging/alarms/missing-logs"
-  environment           = "preview"
-  type                  = "nginx"
-  app_names             = ["router"]
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/missing-logs"
+  environment                    = "preview"
+  type                           = "nginx"
+  app_names                      = ["router"]
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "slow_requests_alarms" {
-  source                = "../../modules/logging/alarms/slow-requests"
-  environment           = "preview"
-  app_name              = "router"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/slow-requests"
+  environment                    = "preview"
+  app_name                       = "router"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "router_500_alarm" {
-  source                = "../../modules/logging/alarms/status-code"
-  environment           = "preview"
-  status_code           = "500"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/status-code"
+  environment                    = "preview"
+  status_code                    = "500"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "router_429_alarm" {
-  source                = "../../modules/logging/alarms/status-code"
-  environment           = "preview"
-  status_code           = "429"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/status-code"
+  environment                    = "preview"
+  status_code                    = "429"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -1,44 +1,55 @@
-module "email_alarm_sns" {
-  source      = "../../modules/logging/alarms/email-notification"
-  environment = "production"
-  account_id  = "${var.aws_prod_account_id}"
+module "alarm_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "production"
+  account_id = "${var.aws_prod_account_id}"
+}
+
+module "alarm_recovery_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "production-recovery"
+  account_id = "${var.aws_prod_account_id}"
 }
 
 // Missing logs for the production-<app-name>-application log group metrics
 module "missing_application_logs_alarms" {
-  source                = "../../modules/logging/alarms/missing-logs"
-  environment           = "production"
-  type                  = "application"
-  app_names             = ["${module.application_logs.app_names}"]
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/missing-logs"
+  environment                    = "production"
+  type                           = "application"
+  app_names                      = ["${module.application_logs.app_names}"]
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 // Missing logs for the production-router-nginx log group metrics
 module "missing_nginx_logs_alarms" {
-  source                = "../../modules/logging/alarms/missing-logs"
-  environment           = "production"
-  type                  = "nginx"
-  app_names             = ["router"]
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/missing-logs"
+  environment                    = "production"
+  type                           = "nginx"
+  app_names                      = ["router"]
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "slow_requests_alarms" {
-  source                = "../../modules/logging/alarms/slow-requests"
-  environment           = "production"
-  app_name              = "router"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/slow-requests"
+  environment                    = "production"
+  app_name                       = "router"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "router_500_alarm" {
-  source                = "../../modules/logging/alarms/status-code"
-  environment           = "production"
-  status_code           = "500"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/status-code"
+  environment                    = "production"
+  status_code                    = "500"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
 module "router_429_alarm" {
-  source                = "../../modules/logging/alarms/status-code"
-  environment           = "production"
-  status_code           = "429"
-  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  source                         = "../../modules/logging/alarms/status-code"
+  environment                    = "production"
+  status_code                    = "429"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }

--- a/terraform/modules/logging/alarms/email-notification/outputs.tf
+++ b/terraform/modules/logging/alarms/email-notification/outputs.tf
@@ -1,3 +1,3 @@
-output "alarm_email_topic_arn" {
+output "email_topic_arn" {
   value = "${aws_sns_topic.alarm_email_topic.arn}"
 }

--- a/terraform/modules/logging/alarms/email-notification/sns.tf
+++ b/terraform/modules/logging/alarms/email-notification/sns.tf
@@ -1,6 +1,6 @@
 // Create topic
 resource "aws_sns_topic" "alarm_email_topic" {
-  name = "${var.environment}-alarm-email"
+  name = "${var.name}-alarm-email"
 }
 
 // Policy enforcing

--- a/terraform/modules/logging/alarms/email-notification/variables.tf
+++ b/terraform/modules/logging/alarms/email-notification/variables.tf
@@ -1,2 +1,2 @@
 variable "account_id" {}
-variable "environment" {}
+variable "name" {}

--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -30,5 +30,5 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   // Email slack on error and recovery
   insufficient_data_actions = []
   alarm_actions             = ["${var.alarm_email_topic_arn}"]
-  ok_actions                = ["${var.alarm_email_topic_arn}"]
+  ok_actions                = ["${var.alarm_recovery_email_topic_arn}"]
 }

--- a/terraform/modules/logging/alarms/missing-logs/variables.tf
+++ b/terraform/modules/logging/alarms/missing-logs/variables.tf
@@ -1,6 +1,7 @@
 variable "environment" {}
 variable "type" {}
 variable "alarm_email_topic_arn" {}
+variable "alarm_recovery_email_topic_arn" {}
 
 variable "app_names" {
   type = "list"

--- a/terraform/modules/logging/alarms/slow-requests/alarms.tf
+++ b/terraform/modules/logging/alarms/slow-requests/alarms.tf
@@ -17,6 +17,7 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_5_10_alarm" {
 
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "slow_requests_gt_10_alarm" {
@@ -38,4 +39,5 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_gt_10_alarm" {
 
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
 }

--- a/terraform/modules/logging/alarms/slow-requests/variables.tf
+++ b/terraform/modules/logging/alarms/slow-requests/variables.tf
@@ -1,3 +1,4 @@
 variable "environment" {}
 variable "app_name" {}
 variable "alarm_email_topic_arn" {}
+variable "alarm_recovery_email_topic_arn" {}

--- a/terraform/modules/logging/alarms/status-code/alarms.tf
+++ b/terraform/modules/logging/alarms/status-code/alarms.tf
@@ -17,4 +17,5 @@ resource "aws_cloudwatch_metric_alarm" "status_code_alarm" {
 
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
 }

--- a/terraform/modules/logging/alarms/status-code/variables.tf
+++ b/terraform/modules/logging/alarms/status-code/variables.tf
@@ -1,3 +1,4 @@
 variable "environment" {}
 variable "alarm_email_topic_arn" {}
+variable "alarm_recovery_email_topic_arn" {}
 variable "status_code" {}


### PR DESCRIPTION
When an AWS alarm triggers a notification it's actually triggering a 'topic'.
A topic is just a list of emails that will all get the same notification.

In our case we want one email address to receive bad :( notifications and one email address to receive good :) email notifications.

To do this we have to create 2 'topics', a 'good' topic and a 'bad' topic, each with one email registered to it. 

When a good notification is triggered it is sent to the 1 slack integration email subscribed to that 'topic'.
And the 1 slack integration email subscribed to our bad 'topic' gets the bad notifications.

This allows us to show them as green and red in Slack because you can only show icons for different users or emails, not based on the content of the message.

In this PR we create the new 'good' topic, give it the same policy as the bad one (only gds emails can subscribe, only actions in our AWS accounts can trigger emails etc), and then tell AWS to notify the new 'good' topic when an alarm changes to the OK state.