### PR TITLE
377-aws-alarm-for-disk-space-on-jenkins

### DIFF
--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -1,0 +1,63 @@
+module "alarm_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "main"
+  account_id = "${var.aws_main_account_id}"
+}
+
+module "alarm_recovery_email_sns" {
+  source     = "../../modules/logging/alarms/email-notification"
+  name       = "main-recovery"
+  account_id = "${var.aws_main_account_id}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
+  alarm_name        = "jenkins-data-volume-disk-space"
+  alarm_description = "Alerts on disk space on 100gb /data volume"
+
+  // Metric
+  namespace   = "CWAgent"
+  metric_name = "disk_free"
+
+  dimensions = {
+    path = "/data"
+  }
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 10gb or lower (in bytes)
+  statistic           = "Sum"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  threshold           = "10000000000"
+
+  // Email slack
+  alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]
+  ok_actions    = ["${module.alarm_recovery_email_sns.email_topic_arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
+  alarm_name        = "jenkins-main-volume-disk-space"
+  alarm_description = "Alerts on disk space on 8gb / volume"
+
+  // Metric
+  namespace   = "CWAgent"
+  metric_name = "disk_free"
+
+  dimensions = {
+    path = "/"
+  }
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 1gb or lower (in bytes)
+  statistic           = "Sum"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  threshold           = "1000000000"
+
+  // Email slack
+  alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]
+  ok_actions    = ["${module.alarm_recovery_email_sns.email_topic_arn}"]
+}

--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -144,7 +144,7 @@ resource "aws_iam_role_policy" "jenkins" {
 EOF
 }
 
-data "aws_iam_policy_document" "cloudwatch-policy" {
+data "aws_iam_policy_document" "cloudwatch-logs-policy" {
   statement {
     actions = [
       "logs:CreateLogGroup",
@@ -159,9 +159,28 @@ data "aws_iam_policy_document" "cloudwatch-policy" {
   }
 }
 
-resource "aws_iam_role_policy" "jenkins-cloudwatch" {
+resource "aws_iam_role_policy" "jenkins-cloudwatch-logs" {
   name = "JenkinsCloudWatchLogs"
   role = "${aws_iam_role.jenkins.id}"
 
-  policy = "${data.aws_iam_policy_document.cloudwatch-policy.json}"
+  policy = "${data.aws_iam_policy_document.cloudwatch-logs-policy.json}"
+}
+
+data "aws_iam_policy_document" "cloudwatch-metrics-policy" {
+  statement {
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "jenkins-cloudwatch-metrics" {
+  name = "JenkinsCloudWatchMetrics"
+  role = "${aws_iam_role.jenkins.id}"
+
+  policy = "${data.aws_iam_policy_document.cloudwatch-metrics-policy.json}"
 }


### PR DESCRIPTION
* Add permissions for jenkins instance to PutMetricData in to Cloudwatch (used with cloudwatch-logs-agent)
* Add new alarms for disk space on jenkins

https://trello.com/c/PdXsLT6d/377-aws-alarm-for-disk-space-on-jenkins