### PR TITLE
deploy-app: add network policy handling, enable for preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,15 @@ deploy-app: ## Deploys the app to PaaS
 	$(if ${STAGE},,$(error Must specify STAGE))
 	cf push --no-start -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}
 
+	# apps that communicate with each other over the "internal" private network (*.apps.internal) need
+	# to have their explicitly "allowed" communication paths added as "network policies". these must be
+	# added before the app is started otherwise it will not be able to access those other apps, or those
+	# other apps won't be able to access *it*. the policies end up being associated with the app's guid
+	# rather than app name, so these need to be re-created for new apps we create, but the policies
+	# should follow the app's renaming at the end of the release process.
+	#
 	# the order of operations performed here (including inside add-application-network-policies.sh)
-	# is carefully designed to make it impossible for an app to get to the point of being started
+	# is carefully designed to make it hopefully-impossible for an app to get to the point of being started
 	# with any required network policies not being in place, even if the "other" app (the other "party"
 	# in the policy) is simultaneously going through the release process and having its names & routes
 	# similarly juggled around. consider this carefully if making any changes to this.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests==2.20.0
 boto3==1.4.5
 docopt==0.6.2
 bcrypt==3.1.3
+yq==2.7.2

--- a/scripts/add-application-network-policies.sh
+++ b/scripts/add-application-network-policies.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+if [ "$#" -lt 3 -o "$#" -gt 4 ]; then
+    echo "Usage: ./scripts/add-application-network-policies.sh <vars_yaml> <base_yaml> <application_name> [<application_suffix>]"
+    exit 1
+fi
+
+export VARS_YAML=$1
+export BASE_YAML=$2
+export APPLICATION_NAME=$3
+export APPLICATION_SUFFIX=$4
+
+# In each of the cases for ingress and egress applications, we first apply the policy to any instances of the (in|e)gress
+# application that might (also?) be in the process of being released. The order that the two commands are run in *is* relevant
+# and designed to not to allow any policy combinations to be missed even in the face of concurrent release processes. As such,
+# we must be tolerant to any of these commands failing because any of these application names may or may not exist at the exact
+# point in time the command is executed. This is ok, because the *other* release process is also expected to be attempting
+# to create these policies at the same time and this routine is designed so that at least one of them should be able to succeed
+# before an application is started.
+#
+# And of course, because of this the commands also need to be robust against the network policy already existing
+
+for EGRESS_APPLICATION_NAME in $(yq -rs '.[0] * .[1] | .[env.APPLICATION_NAME]?.egress_to_applications?[]?' "$BASE_YAML" "$VARS_YAML") ; do
+    echo "Adding policy for access from ${APPLICATION_NAME}${APPLICATION_SUFFIX} to $EGRESS_APPLICATION_NAME-release..."
+    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME-release --protocol tcp --port 8080 || echo "...but that's probably fine."
+    echo "Adding policy for access from ${APPLICATION_NAME}${APPLICATION_SUFFIX} to $EGRESS_APPLICATION_NAME..."
+    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME --protocol tcp --port 8080 || echo "...but that's probably fine."
+done
+
+for INGRESS_APPLICATION_NAME in $(yq -rs '.[0] * .[1] | to_entries | .[] | select(.value.egress_to_applications? | any(. == env.APPLICATION_NAME))? | .key' "$BASE_YAML" "$VARS_YAML") ; do
+    echo "Adding policy for access from $INGRESS_APPLICATION_NAME-release to ${APPLICATION_NAME}${APPLICATION_SUFFIX}..."
+    cf add-network-policy $INGRESS_APPLICATION_NAME-release --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 || echo "...but that's probably fine."
+    echo "Adding policy for access from $INGRESS_APPLICATION_NAME to ${APPLICATION_NAME}${APPLICATION_SUFFIX}..."
+    cf add-network-policy $INGRESS_APPLICATION_NAME --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 || echo "...but that's probably fine."
+done

--- a/scripts/add-application-network-policies.sh
+++ b/scripts/add-application-network-policies.sh
@@ -22,14 +22,18 @@ export APPLICATION_SUFFIX=$4
 
 for EGRESS_APPLICATION_NAME in $(yq -rs '.[0] * .[1] | .[env.APPLICATION_NAME]?.egress_to_applications?[]?' "$BASE_YAML" "$VARS_YAML") ; do
     echo "Adding policy for access from ${APPLICATION_NAME}${APPLICATION_SUFFIX} to $EGRESS_APPLICATION_NAME-release..."
-    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME-release --protocol tcp --port 8080 || echo "...but that's probably fine."
+    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME-release --protocol tcp --port 8080 \
+        || echo "...but that's probably fine because $EGRESS_APPLICATION_NAME may not be in a release process."
     echo "Adding policy for access from ${APPLICATION_NAME}${APPLICATION_SUFFIX} to $EGRESS_APPLICATION_NAME..."
-    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME --protocol tcp --port 8080 || echo "...but that's probably fine."
+    cf add-network-policy ${APPLICATION_NAME}${APPLICATION_SUFFIX} --destination-app $EGRESS_APPLICATION_NAME --protocol tcp --port 8080 \
+        || echo "...but that's possibly fine because $EGRESS_APPLICATION_NAME could be in the midst of renaming apps as part of its release process."
 done
 
 for INGRESS_APPLICATION_NAME in $(yq -rs '.[0] * .[1] | to_entries | .[] | select(.value.egress_to_applications? | any(. == env.APPLICATION_NAME))? | .key' "$BASE_YAML" "$VARS_YAML") ; do
     echo "Adding policy for access from $INGRESS_APPLICATION_NAME-release to ${APPLICATION_NAME}${APPLICATION_SUFFIX}..."
-    cf add-network-policy $INGRESS_APPLICATION_NAME-release --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 || echo "...but that's probably fine."
+    cf add-network-policy $INGRESS_APPLICATION_NAME-release --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 \
+        || echo "...but that's probably fine because $INGRESS_APPLICATION_NAME may not be in a release process."
     echo "Adding policy for access from $INGRESS_APPLICATION_NAME to ${APPLICATION_NAME}${APPLICATION_SUFFIX}..."
-    cf add-network-policy $INGRESS_APPLICATION_NAME --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 || echo "...but that's probably fine."
+    cf add-network-policy $INGRESS_APPLICATION_NAME --destination-app ${APPLICATION_NAME}${APPLICATION_SUFFIX} --protocol tcp --port 8080 \
+        || echo "...but that's possibly fine because $INGRESS_APPLICATION_NAME could be in the midst of renaming apps as part of its release process."
 done

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -3,8 +3,53 @@ domain: preview.marketplace.team
 maintenance_mode: live
 
 api:
+  routes:
+    - dm-api-{env}.cloudapps.digital
+    - dm-api-{env}.apps.internal
   memory: 2GB
+  egress_to_applications:
+    - search-api
+
+search-api:
+  routes:
+    - dm-search-api-{env}.cloudapps.digital
+    - dm-search-api-{env}.apps.internal
+
+antivirus-api:
+  routes:
+    - dm-antivirus-api-{env}.cloudapps.digital
+    - dm-antivirus-api-{env}.apps.internal
 
 router:
   instances: 2
   rate_limiting_enabled: enabled
+  egress_to_applications:
+    - api
+    - antivirus-api
+    - search-api
+
+admin-frontend:
+  egress_to_applications:
+    - api
+
+brief-responses-frontend:
+  egress_to_applications:
+    - api
+
+briefs-frontend:
+  egress_to_applications:
+    - api
+
+buyer-frontend:
+  egress_to_applications:
+    - api
+    - search-api
+
+supplier-frontend:
+  egress_to_applications:
+    - api
+
+user-frontend:
+  egress_to_applications:
+    - api
+


### PR DESCRIPTION
https://trello.com/c/H53K45It

This does a few things, but luckily should only have an effect on preview for now:

 - adds secondary `.apps.internal` routes to each of the preview api apps
 - adds a new step in the `make deploy-app` process which will attempt to create the network policies the newly created app is going to need. Do read the extensive comments on this, because it's quite carefully considered (!) and should hopefully work even in the face of simultaneous release procedures of both parties of an ingress/egress relationship.
 - these ingress/egress relationships are defined in the vars yaml on the "egress" side of the relationship by defining a `egress_to_applications` key. These should automatically get picked up as ingresses for the _referred_ app using a little bit of `yq` magick. Again, here i've only defined these egress relationships for the preview stage and designed the relevant steps so that they're no-ops for stages that have nothing relevant defined.

Note this PR doesn't actually make any apps actually _use_ the private urls yet - that comes later once we're sure bringing up the routes and policies works reliably enough. The idea is I merge this and then that allows me to hit "re-release all apps" for preview, which once I've done will allow us to rely on this new setup being persistent (when releasing from my machine without the code upstreamed, any random releases resulting from app merges will knock my alterations out).

I've also added a `add-all-app-network-policies` for panic-mode repairing the network policies if it turns out I haven't got the release procedure right.