### PR TITLE
Create new bucket to store dev cleaned db dumps and give access

### DIFF
--- a/terraform/accounts/development/s3_buckets.tf
+++ b/terraform/accounts/development/s3_buckets.tf
@@ -3,7 +3,7 @@ data "aws_iam_policy_document" "dev_uploads_s3_bucket_policy_document" {
     effect = "Allow"
 
     principals {
-      identifiers = "arn:aws:iam::${var.aws_main_account_id}:root"
+      identifiers = ["arn:aws:iam::${var.aws_main_account_id}:root"]
       type        = "AWS"
     }
 
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "dev_uploads_s3_bucket_policy_document" {
     effect = "Allow"
 
     principals {
-      identifiers = "arn:aws:iam::${var.aws_main_account_id}:root"
+      identifiers = ["arn:aws:iam::${var.aws_main_account_id}:root"]
       type        = "AWS"
     }
 
@@ -44,4 +44,52 @@ resource "aws_s3_bucket" "dev_uploads_s3_bucket" {
   acl    = "private"
 
   policy = "${data.aws_iam_policy_document.dev_uploads_s3_bucket_policy_document.json}"
+}
+
+data "aws_iam_policy_document" "cleaned_db_dumps_s3_bucket_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = ["arn:aws:iam::${var.aws_main_account_id}:root"]
+      type        = "AWS"
+    }
+
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = ["arn:aws:iam::${var.aws_main_account_id}:root"]
+      type        = "AWS"
+    }
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:GetObjectAcl",
+      "s3:PutObjectAcl",
+    ]
+
+    resources = [
+      "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "cleaned_db_dumps_s3_bucket" {
+  bucket = "digitalmarketplace-cleaned-db-dumps"
+  acl    = "private"
+
+  policy = "${data.aws_iam_policy_document.cleaned_db_dumps_s3_bucket_policy_document.json}"
 }

--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -87,6 +87,7 @@ resource "aws_iam_role_policy" "jenkins" {
         "s3:GetBucketLocation"
       ],
       "Resource": [
+        "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps",
         "arn:aws:s3:::digitalmarketplace-submissions-production-production",
         "arn:aws:s3:::digitalmarketplace-documents-production-production",
         "arn:aws:s3:::digitalmarketplace-documents-staging-staging",
@@ -108,6 +109,7 @@ resource "aws_iam_role_policy" "jenkins" {
             "s3:PutObjectAcl"
         ],
         "Resource": [
+          "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps/*",
           "arn:aws:s3:::digitalmarketplace-agreements-production-production/*",
           "arn:aws:s3:::digitalmarketplace-communications-production-production/*",
           "arn:aws:s3:::digitalmarketplace-communications-preview-preview/*",

--- a/terraform/modules/iam-users/admins.tf
+++ b/terraform/modules/iam-users/admins.tf
@@ -14,7 +14,7 @@ resource "aws_iam_group_policy_attachment" "admins_ip_restriced" {
 
 resource "aws_iam_group_policy_attachment" "admins_dev_uploads_s3" {
   group      = "${aws_iam_group.admins.name}"
-  policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
+  policy_arn = "${aws_iam_policy.dev_s3_access.arn}"
 }
 
 resource "aws_iam_group_membership" "admins" {

--- a/terraform/modules/iam-users/developers.tf
+++ b/terraform/modules/iam-users/developers.tf
@@ -93,7 +93,7 @@ resource "aws_iam_group_policy_attachment" "dev_s3_only_iam_manage_account" {
   policy_arn = "${var.iam_manage_account_policy_arn}"
 }
 
-resource "aws_iam_policy" "dev_uploads_s3_access" {
+resource "aws_iam_policy" "dev_s3_access" {
   name = "devUploadsS3Access"
 
   policy = <<POLICY
@@ -105,14 +105,19 @@ resource "aws_iam_policy" "dev_uploads_s3_access" {
         "s3:*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::digitalmarketplace-dev-uploads"
-    },
-    {
+      "Resource": [
+        "arn:aws:s3:::digitalmarketplace-dev-uploads",
+        "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps"
+      ]
+    }, {
       "Action": [
         "s3:*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::digitalmarketplace-dev-uploads/*"
+      "Resource": [
+        "arn:aws:s3:::digitalmarketplace-dev-uploads/*",
+        "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps/*"
+      ]
     }
   ]
 }
@@ -121,10 +126,10 @@ POLICY
 
 resource "aws_iam_group_policy_attachment" "developers_dev_uploads_s3" {
   group      = "${aws_iam_group.developers.name}"
-  policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
+  policy_arn = "${aws_iam_policy.dev_s3_access.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "dev_s3_only_dev_uploads_s3" {
   group      = "${aws_iam_group.dev_s3_only.name}"
-  policy_arn = "${aws_iam_policy.dev_uploads_s3_access.arn}"
+  policy_arn = "${aws_iam_policy.dev_s3_access.arn}"
 }


### PR DESCRIPTION
As part of:
https://trello.com/c/uUxYtjSt/345-gdrive-client-alternatives-consolidate-data-dumps-store-in-s3

We need a new bucket that devs can access to for jenkins to put the db dumps in.

https://trello.com/c/0jAgMP0d/405-gdrive-client-alternatives-db-dumps-to-s3-not-drive