### PR TITLE
Change acl to bucket-owner-full-control on uploaded dev db dumps

### DIFF
--- a/scripts/apply-cleaned-db-to-target.sh
+++ b/scripts/apply-cleaned-db-to-target.sh
@@ -31,6 +31,6 @@ else
   exit 1
 fi
 
-aws s3 sync --delete ./dumps s3://digitalmarketplace-cleaned-db-dumps
+aws s3 sync --delete --acl bucket-owner-full-control ./dumps s3://digitalmarketplace-cleaned-db-dumps
 
 rm -fr ./dumps


### PR DESCRIPTION
As part of 
https://trello.com/c/0jAgMP0d/405-gdrive-client-alternatives-data-dumps-only

We need to update the acl on the uploaded dumps, they're going in but we can't get them out without handing over management of the acl to the bucket owner (and therefore terraform)