### PR TITLE
Add permissions for jenkins to delete old dev db dumps from arn:aws:s…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ import-and-clean-db-dump: virtualenv ## Connects to the postgres container, impo
 	VIRTUALENV_ROOT=${VIRTUALENV_ROOT} ./scripts/import-and-clean-db-dump.sh
 
 .PHONY: apply-cleaned-db-dump
-apply-cleaned-db-dump: ## Migrate the cleaned db dump to a target stage and sync with google drive.
+apply-cleaned-db-dump: ## Migrate the cleaned db dump to a target stage and sync with s3.
 	./scripts/apply-cleaned-db-to-target.sh
 
 .PHONY: cleanup-postgres-container

--- a/scripts/apply-cleaned-db-to-target.sh
+++ b/scripts/apply-cleaned-db-to-target.sh
@@ -8,7 +8,7 @@ LATEST_PROD_DUMP=$(aws s3 ls digitalmarketplace-database-backups | grep producti
 pg_dump --no-acl --no-owner --clean postgres://postgres:@localhost:63306/postgres | gzip > ./dumps/cleaned-"${LATEST_PROD_DUMP%.*}"
 
 if [ "${TARGET}" == 's3' ]; then
-  echo 'Uploading cleaned dump to Google Drive'
+  echo 'Uploading cleaned dump to S3'
 elif [ "${TARGET}" == 'preview' ] || [ "${TARGET}" == 'staging' ]; then
   echo "Migrating cleaned dump to ${TARGET} and uploading to Google Drive"
   cf target -s ${TARGET}

--- a/terraform/accounts/main/jenkins_instance_profile.tf
+++ b/terraform/accounts/main/jenkins_instance_profile.tf
@@ -140,6 +140,15 @@ resource "aws_iam_role_policy" "jenkins" {
           "arn:aws:s3:::digitalmarketplace-documents-staging-staging",
           "arn:aws:s3:::digitalmarketplace-documents-preview-preview"
         ]
+    },
+    {
+        "Effect": "Allow",
+        "Action": [
+          "s3:DeleteObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::digitalmarketplace-cleaned-db-dumps/*"
+        ]
     }
   ]
 }


### PR DESCRIPTION
Add permissions for jenkins to delete old dev db dumps from arn:aws:s3:::digitalmarketplace-cleaned-db-dumps

To do the `sync` operation in https://github.com/alphagov/digitalmarketplace-aws/blob/master/scripts/apply-cleaned-db-to-target.sh jenkins requires DeleteObject on the above bucket