### PR TITLE
Revert "[TAKE 2] app environment variables: use ugly "if" statement to switch these to  the .apps.internal addresses for preview only"

### DIFF
--- a/paas/admin-frontend.j2
+++ b/paas/admin-frontend.j2
@@ -5,11 +5,7 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
 

--- a/paas/api.j2
+++ b/paas/api.j2
@@ -9,9 +9,5 @@
       DM_API_CALLBACK_AUTH_TOKENS: {{ api.callback_auth_tokens|join(':') }}
 
       DM_SEARCH_API_AUTH_TOKEN: {{ search_api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_SEARCH_API_URL: http://dm-search-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 {% endblock %}

--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -5,11 +5,7 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}

--- a/paas/briefs-frontend.j2
+++ b/paas/briefs-frontend.j2
@@ -5,11 +5,7 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
 

--- a/paas/buyer-frontend.j2
+++ b/paas/buyer-frontend.j2
@@ -5,20 +5,12 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
 
       DM_SEARCH_API_AUTH_TOKEN: {{ search_api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_SEARCH_API_URL: http://dm-search-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 

--- a/paas/router.j2
+++ b/paas/router.j2
@@ -8,15 +8,9 @@
       DM_DEV_USER_IPS: '{{ dev_user_ips|join(",") }}'
       DM_USER_IPS: '{{ user_ips|join(",") }}'
 
-  {% if environment == "preview" %}
-      DM_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-      DM_SEARCH_API_URL: http://dm-search-api-{{ environment }}.apps.internal:8080
-      DM_ANTIVIRUS_API_URL: http://dm-antivirus-api-{{ environment }}.apps.internal:8080
-  {% else %}
-      DM_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-      DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
-      DM_ANTIVIRUS_API_URL: https://dm-antivirus-api-{{ environment }}.cloudapps.digital
-  {% endif %}
+      DM_API_URL: 'https://dm-api-{{ environment }}.cloudapps.digital'
+      DM_SEARCH_API_URL: 'https://dm-search-api-{{ environment }}.cloudapps.digital'
+      DM_ANTIVIRUS_API_URL: 'https://dm-antivirus-api-{{ environment }}.cloudapps.digital'
       DM_FRONTEND_URL: 'https://dm-{{ environment }}.cloudapps.digital'
 
       DM_G7_DRAFT_DOCUMENTS_S3_URL: {{ g7_draft_documents_s3_url }}

--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -5,11 +5,7 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
       DM_NOTIFY_API_KEY: {{ notify_api_key }}

--- a/paas/user-frontend.j2
+++ b/paas/user-frontend.j2
@@ -5,11 +5,7 @@
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}
 
       DM_DATA_API_AUTH_TOKEN: {{ api.auth_tokens[0] }}
-  {% if environment == "preview" %}
-      DM_DATA_API_URL: http://dm-api-{{ environment }}.apps.internal:8080
-  {% else %}
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
-  {% endif %}
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
 


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-aws#513

As long as this is merged, preview will always need its router restarted every time an API is released.