### PR TITLE
preview: remove .cloudapps.digital routes from apis

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,7 +4,6 @@ maintenance_mode: live
 
 api:
   routes:
-    - dm-api-{env}.cloudapps.digital
     - dm-api-{env}.apps.internal
   memory: 2GB
   egress_to_applications:
@@ -12,12 +11,10 @@ api:
 
 search-api:
   routes:
-    - dm-search-api-{env}.cloudapps.digital
     - dm-search-api-{env}.apps.internal
 
 antivirus-api:
   routes:
-    - dm-antivirus-api-{env}.cloudapps.digital
     - dm-antivirus-api-{env}.apps.internal
 
 router:


### PR DESCRIPTION
https://trello.com/c/H53K45It

I guess this is the next logical step...