### PR TITLE
Convert json to policy docs in cloudtrail/cloudtrail-cloudwatch module

### DIFF
--- a/terraform/modules/cloudtrail/cloudtrail-cloudwatch/main.tf
+++ b/terraform/modules/cloudtrail/cloudtrail-cloudwatch/main.tf
@@ -3,53 +3,50 @@ resource "aws_cloudwatch_log_group" "cloudtrail_log_group" {
   retention_in_days = "${var.retention_in_days}"
 }
 
-resource "aws_iam_role" "cloud_watch_logs_role" {
+# When this policy is attached to a role as an assume_role_policy the aws cloudtrail service can assume the role
+data "aws_iam_policy_document" "cloudtrail_assume_role_policy_document" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = ["cloudtrail.amazonaws.com"]
+      type        = "Service"
+    }
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "create_cloudtrail_logs_in_cloudwatch_cloudtrail_log_group_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "create_cloudtrail_logs_in_cloudwatch_cloudtrail_log_group_policy" {
+  name        = "create-logs-in-${var.trail_name}-cloudtrail-log-group"
+  description = "Create logs in the ${var.trail_name}-cloudtrail-log-group Log Group in CloudWatch"
+  policy      = "${data.aws_iam_policy_document.create_cloudtrail_logs_in_cloudwatch_cloudtrail_log_group_policy_document.json}"
+}
+
+resource "aws_iam_role" "cloudtrail_to_cloudwatch_role" {
   name = "CloudTrail_CloudWatchLogs_Role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "cloudtrail.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = "${data.aws_iam_policy_document.cloudtrail_assume_role_policy_document.json}"
 }
 
-resource "aws_iam_role_policy" "cloud_watch_policy" {
-  name = "CloudWatch-policy"
-  role = "${aws_iam_role.cloud_watch_logs_role.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream"
-      ],
-      "Resource": [
-        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:PutLogEvents"
-      ],
-      "Resource": [
-        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}"
-      ]
-    }
-  ]
-}
-EOF
+resource "aws_iam_role_policy_attachment" "attach_create_logs_in_log_group_to_cloudtrail_to_cloudwatch_role" {
+  role       = "${aws_iam_role.cloudtrail_to_cloudwatch_role.name}"
+  policy_arn = "${aws_iam_policy.create_cloudtrail_logs_in_cloudwatch_cloudtrail_log_group_policy.arn}"
 }

--- a/terraform/modules/cloudtrail/cloudtrail-cloudwatch/outputs.tf
+++ b/terraform/modules/cloudtrail/cloudtrail-cloudwatch/outputs.tf
@@ -3,5 +3,5 @@ output "cloud_watch_logs_group_arn" {
 }
 
 output "cloud_watch_logs_role_arn" {
-  value = "${aws_iam_role.cloud_watch_logs_role.arn}"
+  value = "${aws_iam_role.cloudtrail_to_cloudwatch_role.arn}"
 }


### PR DESCRIPTION
Wanted to test whether you can use an IAM policy as an assume_role_policy
You cannot:
https://www.terraform.io/docs/providers/aws/r/iam_role.html#assume_role_policy

But thought we might as well commit this.

It changes the name of the `module.cloudtrail-cloudwatch.aws_iam_role.cloud_watch_logs_role` to `module.cloudtrail-cloudwatch.aws_iam_role.cloudtrail_to_cloudwatch_role` so we'd have to do a `tf state mv` for that, but otherwise just `plan` and `apply`