### PR TITLE
Add versioning to cleaned_db_dumps bucket

### DIFF
--- a/terraform/accounts/development/s3_buckets.tf
+++ b/terraform/accounts/development/s3_buckets.tf
@@ -91,5 +91,9 @@ resource "aws_s3_bucket" "cleaned_db_dumps_s3_bucket" {
   bucket = "digitalmarketplace-cleaned-db-dumps"
   acl    = "private"
 
+  versioning {
+    enabled = true
+  }
+
   policy = "${data.aws_iam_policy_document.cleaned_db_dumps_s3_bucket_policy_document.json}"
 }


### PR DESCRIPTION
[Ticket](https://trello.com/c/FDv4IfBt/417-clean-prod-db-dump-and-apply-deletes-the-old-dev-dump-and-creates-the-new-dump-we-could-just-use-versions-for-this)

Using the version capabilities of S3 buckets we can have old versions of the database dump, just in case we need them. At the moment we just delete them.