### PR TITLE
preview private routes: open a public .cloudapps.digital route for /_metrics only

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,6 +4,7 @@ maintenance_mode: live
 
 api:
   routes:
+    - dm-api-{env}.cloudapps.digital/_metrics
     - dm-api-{env}.apps.internal
   memory: 2GB
   egress_to_applications:
@@ -11,10 +12,12 @@ api:
 
 search-api:
   routes:
+    - dm-search-api-{env}.cloudapps.digital/_metrics
     - dm-search-api-{env}.apps.internal
 
 antivirus-api:
   routes:
+    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
     - dm-antivirus-api-{env}.apps.internal
 
 router:


### PR DESCRIPTION
https://trello.com/c/QOj2iMLO

Even though we're likely to yank this all from preview soon, it would be nice to have committed the proper solution for this so it's clear what needs to be restored to bring private apps back...