### PR TITLE
413-re-create-an-alarm-for-dropped-av-sns

### DIFF
--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -53,3 +53,10 @@ module "router_429_alarm" {
   alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
+
+module "dropped_av_sns_alarm" {
+  source                         = "../../modules/logging/alarms/dropped-av-sns"
+  environment                    = "preview"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
+}

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -53,3 +53,10 @@ module "router_429_alarm" {
   alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
+
+module "dropped_av_sns_alarm" {
+  source                         = "../../modules/logging/alarms/dropped-av-sns"
+  environment                    = "production"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
+}

--- a/terraform/modules/logging/alarms/README.md
+++ b/terraform/modules/logging/alarms/README.md
@@ -39,6 +39,7 @@ module "missing_logs_alarms" {
   environment           = "preview"
   app_names             = ["buyer-frontend", "api", "something else", "etc..."]
   alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 ```
 
@@ -54,6 +55,7 @@ module "slow_requests_alarms" {
   environment           = "preview"
   app_name              = "router"
   alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 ```
 
@@ -69,5 +71,6 @@ module "router_500_alarm" {
   environment           = "preview"
   status_code           = "500"
   alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 ```

--- a/terraform/modules/logging/alarms/README.md
+++ b/terraform/modules/logging/alarms/README.md
@@ -74,3 +74,18 @@ module "router_500_alarm" {
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 ```
+
+### dropped-av-sns
+
+This module creates a single alarm that is triggered on an entry in the ${var.environment}-dropped-antivirus-sns metric.
+
+It relies on the [`${var.environment}-dropped-antivirus-sns` metrics](https://github.com/alphagov/digitalmarketplace-aws/blob/2df2d21ea8c8bd0da78a37c7f6ce3d71889d00e2/terraform/modules/logging/log-metric-filters/main.tf#L325).
+
+```
+module "dropped_av_sns_alarm" {
+  source                = "../../modules/logging/alarms/dropped-av-sns"
+  environment           = "preview"
+  alarm_email_topic_arn = "${module.email_alarm_sns.alarm_email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
+}
+```

--- a/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
+++ b/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
@@ -1,0 +1,21 @@
+resource "aws_cloudwatch_metric_alarm" "dropped_antivirus_sns_alarm" {
+  alarm_name        = "${var.environment}-dropped-antivirus-sns"
+  alarm_description = "Alarms on failure to inform the ${var.environment} AV API that a file has uploaded and needs to be scanned."
+
+  // Metric
+  namespace   = "DM-SNS"
+  metric_name = "${var.environment}-dropped-antivirus-sns"
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 1 or higher
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+
+  // Email slack
+  alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
+}

--- a/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
+++ b/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
@@ -15,6 +15,9 @@ resource "aws_cloudwatch_metric_alarm" "dropped_antivirus_sns_alarm" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "1"
 
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
   ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]

--- a/terraform/modules/logging/alarms/dropped-av-sns/variables.tf
+++ b/terraform/modules/logging/alarms/dropped-av-sns/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {}
+variable "alarm_email_topic_arn" {}
+variable "alarm_recovery_email_topic_arn" {}

--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -28,7 +28,6 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   treat_missing_data = "breaching"
 
   // Email slack on error and recovery
-  insufficient_data_actions = []
-  alarm_actions             = ["${var.alarm_email_topic_arn}"]
-  ok_actions                = ["${var.alarm_recovery_email_topic_arn}"]
+  alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
 }

--- a/terraform/modules/logging/alarms/slow-requests/alarms.tf
+++ b/terraform/modules/logging/alarms/slow-requests/alarms.tf
@@ -37,6 +37,9 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_gt_10_alarm" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "5"
 
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
   ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]

--- a/terraform/modules/logging/alarms/status-code/alarms.tf
+++ b/terraform/modules/logging/alarms/status-code/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "status_code_alarm" {
   namespace   = "DM-${var.status_code}s"
   metric_name = "${var.environment}-router-nginx-${var.status_code}s"
 
-  // For for every 10 seconds
+  // For for every 60 seconds
   evaluation_periods = "1"
   period             = "60"
 

--- a/terraform/modules/logging/alarms/status-code/alarms.tf
+++ b/terraform/modules/logging/alarms/status-code/alarms.tf
@@ -15,6 +15,9 @@ resource "aws_cloudwatch_metric_alarm" "status_code_alarm" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "1"
 
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
   ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]

--- a/terraform/modules/logging/log-metric-filters/main.tf
+++ b/terraform/modules/logging/log-metric-filters/main.tf
@@ -322,8 +322,9 @@ resource "aws_cloudwatch_log_metric_filter" "router-429s" {
   }
 }
 
-# The following two log metric filters both output to the same log metric: SNS considers 4xx responses "successes" so
-# we have to extract logs from both the "success" and "failure" log groups to catch all cases we'd consider fails
+# The following two log metric filters output to the same metric (${var.environment}-dropped-antivirus-sns):
+# Because we have separate log streams 'Failure to connect to the AV API' and 'The AV API successfully returned a response'
+# we have to filter the "success" log group for responses >= 400 and the "failure" log group for anything
 
 resource "aws_cloudwatch_log_metric_filter" "dropped-antivirus-sns-final-retry" {
   name           = "${var.environment}-dropped-antivirus-sns-final-retry"


### PR DESCRIPTION
https://trello.com/c/gHYwVkSu/413-re-create-an-alarm-for-dropped-av-sns

* Update comment with more info
* Update comment with correct second value
* Update readme with alarm_recovery_email_topic_arn arg for log examples
* Add new dropped-av-sns alarm module for creating dropped av alarm
* Add readme entry for new dropped av sns alarm
* Apply new dropped av sns alarm to preview
* Apply new dropped av sns alarm to production
