### PR TITLE
658-aws-lambdas-are-using-old-version-of-node

### DIFF
--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -59,7 +59,7 @@ resource "aws_lambda_function" "log_stream_lambda" {
   source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
   role             = "${aws_iam_role.lambda.arn}"
   handler          = "main.handler"
-  runtime          = "nodejs6.10"
+  runtime          = "nodejs8.10"
   memory_size      = 128
   timeout          = 10
 


### PR DESCRIPTION
As per email from AWS: 6.10 node.js is EOL
8.10 is newest available Lambda runtime
8.10 is supported until 12/2019

See:

| Release  | Status              | Codename    |Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life               |
| :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                     |
| [6.x][]  | **Maintenance LTS** | [Boron][]   | 2016-04-26     | 2016-10-18       | 2018-04-30            | 2019-04-30                |
| [8.x][]  | **Maintenance LTS** | [Carbon][]  | 2017-05-30     | 2017-10-31       | 2019-01-01            | December 2019<sup>1</sup> |
| [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |

https://raw.githubusercontent.com/nodejs/Release/master/README.md

https://trello.com/c/JpNb9XWJ/658-aws-lambdas-are-using-old-version-of-node