### PR TITLE
Don't use metric routes for healthchecks

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,21 +4,21 @@ maintenance_mode: live
 
 api:
   routes:
-    - dm-api-{env}.cloudapps.digital/_metrics
     - dm-api-{env}.apps.internal
+    - dm-api-{env}.cloudapps.digital/_metrics
   memory: 2GB
   egress_to_applications:
     - search-api
 
 search-api:
   routes:
-    - dm-search-api-{env}.cloudapps.digital/_metrics
     - dm-search-api-{env}.apps.internal
+    - dm-search-api-{env}.cloudapps.digital/_metrics
 
 antivirus-api:
   routes:
-    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
     - dm-antivirus-api-{env}.apps.internal
+    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
 
 router:
   instances: 2


### PR DESCRIPTION
Trello: https://trello.com/c/LcuyPXvI/664-app-release-failing-healthchecks

The Search API was failing to start up on preview as the healthchecks were failing.

The healthcheck endpoint is generated from the first item in the `routes` var:
`health-check-http-endpoint: {{ routes[0].partition('/')[1:]|join("") }}/_status?ignore-dependencies`

Moving the metrics down below it should do the trick.