### PR TITLE
Pin the CSW git reference in production

### DIFF
--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -35,7 +35,7 @@ module "paas" {
 }
 
 module "csw_inspector_role" {
-  source                = "git::https://github.com/alphagov/csw-client-role.git"
+  source                = "git::https://github.com/alphagov/csw-client-role.git?ref=v1.0"
   csw_agent_account_id  = "${var.csw_agent_account_id}"
   csw_target_account_id = "${var.aws_prod_account_id}"
 }


### PR DESCRIPTION
So it is consistent with all the environments

Main/Backups/Development all are using v1

There will be breaking changes on csw master soon

Co-authored-by: Alex <alex.kinnane@digital.cabinet-office.gov.uk>
Co-authored-by: Dan <dan.jones@digital.cabinet-office.gov.uk>
Co-authored-by: Toby <toby.lornewelch-richards@digital.cabinet-office.gov.uk>