### PR TITLE
427-put-metrics-on-api

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -28,7 +28,10 @@ applications:
     env:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}
+
       DM_METRICS_NAMESPACE: {{ environment }}-{{ environment }}/{{ app }}
+      PROMETHEUS_METRICS_PATH: /_metrics
+      METRICS_BASIC_AUTH: false
 
       DM_LOG_PATH: ''
 

--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -18,6 +18,4 @@
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 
-      PROMETHEUS_METRICS_PATH: /_metrics
-      METRICS_BASIC_AUTH: false
 {% endblock %}

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -10,12 +10,14 @@ router:
 api:
   routes:
     - dm-api-{env}.cloudapps.digital
+    - dm-api-{env}.cloudapps.digital/_metrics
   services:
     - digitalmarketplace_api_db
 
 search-api:
   routes:
     - dm-search-api-{env}.cloudapps.digital
+    - dm-search-api-{env}.cloudapps.digital/_metrics
   services:
     - search_api_elasticsearch
 
@@ -23,6 +25,7 @@ antivirus-api:
   memory: 2G
   routes:
     - dm-antivirus-api-{env}.cloudapps.digital
+    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
 
 user-frontend:
   routes:

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -5,7 +5,6 @@ maintenance_mode: live
 api:
   routes:
     - dm-api-{env}.apps.internal
-    - dm-api-{env}.cloudapps.digital/_metrics
   memory: 2GB
   egress_to_applications:
     - search-api
@@ -13,12 +12,10 @@ api:
 search-api:
   routes:
     - dm-search-api-{env}.apps.internal
-    - dm-search-api-{env}.cloudapps.digital/_metrics
 
 antivirus-api:
   routes:
     - dm-antivirus-api-{env}.apps.internal
-    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
 
 router:
   instances: 2


### PR DESCRIPTION

https://trello.com/c/wGJZQFxO/427-put-metrics-on-api

* Move _metrics PaaS env arguments from brief-responses only to global base so they are available for every deployment
* Move metrics routes definitions from preview vars to common vars so these routes are defined on next release of all stages
