### PR TITLE
Change deploy-app to push new app without route

### DIFF
--- a/scripts/map-route.sh
+++ b/scripts/map-route.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: ./scripts/map-route.sh <application_name> <manifest_file>"
+    exit 1
+fi
+
+APPLICATION_NAME="$1"
+MANIFEST_FILE="$2"
+
+APP_ROUTES="$(yq '.applications[] | {(.name): .routes}' ${MANIFEST_FILE})"
+
+for ROUTE in $(echo $APP_ROUTES | jq -c '.["'${APPLICATION_NAME}'"] | .[]'); do
+  # use jq regex power to split url into component parts
+  MATCH=$(jq '.route | capture("^((?<host>[a-z_-]*).)?(?<domain>[a-z_.-]*)(?<path>[a-z_/-]*)?$")' <<< $ROUTE)
+
+  URL_DOMAIN=$(jq -r '.domain' <<< $MATCH)
+  URL_HOST=$(jq -r '.host' <<< $MATCH)
+  URL_PATH=$(jq -r '.path' <<< $MATCH)
+
+  ARGS="$APPLICATION_NAME $URL_DOMAIN"
+  [ -n "$URL_HOST" ] && ARGS="$ARGS --hostname $URL_HOST"
+  [ -n "$URL_PATH" ] && ARGS="$ARGS --path $URL_PATH"
+
+  echo cf map-route $ARGS
+  cf map-route $ARGS
+done


### PR DESCRIPTION
Our deploy-app recipe will create a `-release` app with a route and only removes the route after it has been started. If the app start fails this means there can be a route pointing to a dead app. See https://trello.com/c/x76uyB81/692-a-failed-api-release-will-leave-a-dangling-route for info on how this came up.

This commit changes the deploy-app recipe so that the release app will be created without a route, and then if the app fails to start nothing else will be broken 🤞. The route mapping is done by a new script, `scripts/map-route.sh`, that gets the desired route(s) from the app manifest.

This should also have the bonus effect of meaning our release process causes less downtime in our metrics.

This has been tested on preview.