### PR TITLE
paas: bump memory for buyer and supplier frontends to 700M

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -36,11 +36,13 @@ admin-frontend:
     - dm-{env}.cloudapps.digital/admin
 
 buyer-frontend:
+  memory: 700M
   routes:
     - dm-{env}.cloudapps.digital
     - dm-{env}.cloudapps.digital/buyers/direct-award
 
 supplier-frontend:
+  memory: 700M
   routes:
     - dm-{env}.cloudapps.digital/suppliers
 


### PR DESCRIPTION
https://trello.com/c/8tJsE7Gp/