### PR TITLE
Remove Jonathan, add Ares from IAM users

### DIFF
--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -3,8 +3,8 @@ resource "aws_iam_user" "ben_vandersteen" {
   force_destroy = true
 }
 
-resource "aws_iam_user" "jonathan_kerr" {
-  name          = "jonathankerr"
+resource "aws_iam_user" "argyris_galamatis" {
+  name          = "argyrisgalamatis"
   force_destroy = true
 }
 


### PR DESCRIPTION
Trello: https://trello.com/c/oC3a9na4/699-set-up-ares-on-everything

The IAM user has already been created for Ares so that should be a no-op; this will force-destroy Jonathan's IAM user (we've already removed his group membership and permissions).