### PR TITLE
Remove old, unused, dmutils/metrics.py environment variable

### DIFF
--- a/example_manifests/api-manifest.yml.example
+++ b/example_manifests/api-manifest.yml.example
@@ -19,7 +19,6 @@ applications:
     env:
       DM_APP_NAME: api
       DM_ENVIRONMENT: preview
-      DM_METRICS_NAMESPACE: preview-preview/api
 
       DM_LOG_PATH: ''
 

--- a/example_manifests/buyer-frontend-manifest.yml.example
+++ b/example_manifests/buyer-frontend-manifest.yml.example
@@ -21,7 +21,6 @@ applications:
     env:
       DM_APP_NAME: buyer-frontend
       DM_ENVIRONMENT: preview
-      DM_METRICS_NAMESPACE: preview-preview/buyer-frontend
 
       DM_LOG_PATH: ''
 

--- a/example_manifests/router-manifest.yml.example
+++ b/example_manifests/router-manifest.yml.example
@@ -24,7 +24,6 @@ applications:
     env:
       DM_APP_NAME: router
       DM_ENVIRONMENT: preview
-      DM_METRICS_NAMESPACE: preview-preview/router
 
       DM_LOG_PATH: ''
 

--- a/example_manifests/search-api-manifest.yml.example
+++ b/example_manifests/search-api-manifest.yml.example
@@ -20,7 +20,6 @@ applications:
     env:
       DM_APP_NAME: search-api
       DM_ENVIRONMENT: preview
-      DM_METRICS_NAMESPACE: preview-preview/search-api
       DM_ELASTICSEARCH_SERVICE_NAME: search_api_elasticsearch   # This env var is added manually during migrations
 
       DM_LOG_PATH: ''

--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -29,7 +29,6 @@ applications:
       DM_APP_NAME: {{ app }}
       DM_ENVIRONMENT: {{ environment }}
 
-      DM_METRICS_NAMESPACE: {{ environment }}-{{ environment }}/{{ app }}
       PROMETHEUS_METRICS_PATH: /_metrics
       METRICS_BASIC_AUTH: false
 


### PR DESCRIPTION
https://trello.com/c/EGGLjxJQ/456-remove-instances-of-dmmetricsnamespace

This environment variable is no longer required, we've gotten rid of `dmutils/metrics.py` which used it.

https://github.com/alphagov/digitalmarketplace-utils/pull/504
