### PR TITLE
Increase number of instances for supplier-frontend

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -24,3 +24,6 @@ admin-frontend:
 
 antivirus-api:
   instances: 2
+
+supplier-frontend:
+  instances: 7


### PR DESCRIPTION
Our supplier-frontend has been experiencing a lot of traffic recently;
we've bumped the memory, let's bump the number of instances as well.

Hopefully this will ease up the issues we've been seeing https://trello.com/c/nFfzjblY/697-memory-on-supplier-buyer-router-api