### PR TITLE
750 search api missing logs alarm did not raise for 30 minutes when search api app was down

### DIFF
--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -15,9 +15,10 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
     LogGroupName = "${var.environment}-${var.app_names[count.index]}-${var.type}"
   }
 
-  // For 15 minutes
-  evaluation_periods = "1"
-  period             = "600"
+  // For 5 minutes
+  // This appears to cause our alarms to trigger at around the 12 mminute
+  evaluation_periods = "5"
+  period             = "60"
 
   // Totals 0
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -16,9 +16,10 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   }
 
   // For 5 minutes
-  // This appears to cause our alarms to trigger at around the 12 mminute
+  // This appears to cause our alarms to trigger at around the 10-12 minute mark
   evaluation_periods = "5"
-  period             = "60"
+
+  period = "60"
 
   // Totals 0
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/slow-requests/alarms.tf
+++ b/terraform/modules/logging/alarms/slow-requests/alarms.tf
@@ -15,6 +15,9 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_5_10_alarm" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = "5"
 
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
   // Email slack
   alarm_actions = ["${var.alarm_email_topic_arn}"]
   ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]


### PR DESCRIPTION
https://trello.com/c/0OgvW0sn/750-search-api-missing-logs-alarm-did-not-raise-for-30-minutes-when-search-api-app-was-down

* Move missing logs to 5 minutes to cause to trigger at 12ish mins
* Do not trigger slow request on missing logs, missing-logs alarms handle this