### PR TITLE
default.nix: bump terraform to 0.11.13 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,6 +13,7 @@ in (with args; {
     shortName = "dm-aws";
     buildInputs = [
       pythonPackages.python
+      pkgs.glibcLocales
       pkgs.nodejs
       pkgs.jq
       pkgs.sops

--- a/default.nix
+++ b/default.nix
@@ -17,12 +17,12 @@ in (with args; {
       pkgs.jq
       pkgs.sops
       (pkgs.terraform.overrideAttrs (oldAttrs: rec {
-        name = "terraform-0.11.7";
+        name = "terraform-0.11.13";
         src = pkgs.fetchFromGitHub {
           owner  = "hashicorp";
           repo   = "terraform";
-          rev    = "v0.11.7";
-          sha256 = "0q5gl8yn1f8fas1v68lz081k88gbmlk7f2xqlwqmh01qpqjxd42q";
+          rev    = "v0.11.13";
+          sha256 = "014d2ibmbp5yc1802ckdcpwqbm5v70xmjdyh5nadn02dfynaylna";
         };
       }))
       pkgs.libyaml


### PR DESCRIPTION
This actually ends up being an identical package to the default from nixpkgs `19.03`, which is fun. But keeping the override in because I predict having to bump it soon.