### PR TITLE
Add new add-ip-whitelist-route-service.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ deploy-app: ## Deploys the app to PaaS
 
 	# Create the route for the release app
 	./scripts/map-route.sh ${APPLICATION_NAME}-release <(make -s -C ${CURDIR} generate-manifest)
+
+	# Make sure relevant routes are whitelisted (can be found in vars/ip_whitelist_routes.json)
+	.scripts/add-ip-whitelist-route-service.sh ${APPLICATION_NAME}
+
 	# Delete the route for the old app
 	@if cf app ${APPLICATION_NAME} >/dev/null; then ./scripts/unmap-route.sh ${APPLICATION_NAME}; fi
 

--- a/scripts/add-ip-whitelist-route-service.sh
+++ b/scripts/add-ip-whitelist-route-service.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if [ "$#" -ne 1 ]; then
+    echo "This script uses the variables in vars/ip_whitelist_routes.json to ip whitelist routes using the re-ip-whitelist-service."
+    echo ""
+    echo "Usage: ./scripts/add-ip-whitelist-route-service.sh <stage>"
+    exit 1
+fi
+
+STAGE=$( echo $1 | awk '{ print tolower($0) }' )
+
+IFS=$'\n'
+for HOSTNAME_PATH in $(jq -r ".${STAGE}[] | \"\(.hostname) \(.path)\"" vars/ip_whitelist_routes.json); do
+    HOSTNAME=$(echo $HOSTNAME_PATH | cut -f1 -d" ")
+    PATH=$(echo $HOSTNAME_PATH | cut -f2 -d" ")
+    echo cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname $HOSTNAME --path $PATH
+    cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname $HOSTNAME --path $PATH
+done

--- a/vars/ip_whitelist_routes.json
+++ b/vars/ip_whitelist_routes.json
@@ -1,0 +1,35 @@
+{
+  "preview": [
+    {"hostname": "dm-api-preview", "path": "/_metrics"},
+    {"hostname": "dm-search-api-preview", "path": "/_metrics"},
+    {"hostname": "dm-antivirus-api-preview", "path": "/_metrics"},
+    {"hostname": "dm-preview", "path": "/_metrics"},
+    {"hostname": "dm-preview", "path": "/admin/_metrics"},
+    {"hostname": "dm-preview", "path": "/buyers/_metrics"},
+    {"hostname": "dm-preview", "path": "/suppliers/_metrics"},
+    {"hostname": "dm-preview", "path": "/suppliers/opportunities/_metrics"},
+    {"hostname": "dm-preview", "path": "/user/_metrics"}
+  ],
+  "staging": [
+    {"hostname": "dm-api-staging", "path": "/_metrics"},
+    {"hostname": "dm-search-api-staging", "path": "/_metrics"},
+    {"hostname": "dm-antivirus-api-staging", "path": "/_metrics"},
+    {"hostname": "dm-staging", "path": "/_metrics"},
+    {"hostname": "dm-staging", "path": "/admin/_metrics"},
+    {"hostname": "dm-staging", "path": "/buyers/_metrics"},
+    {"hostname": "dm-staging", "path": "/suppliers/_metrics"},
+    {"hostname": "dm-staging", "path": "/suppliers/opportunities/_metrics"},
+    {"hostname": "dm-staging", "path": "/user/_metrics"}
+  ],
+  "production": [
+    {"hostname": "dm-api-production", "path": "/_metrics"},
+    {"hostname": "dm-search-api-production", "path": "/_metrics"},
+    {"hostname": "dm-antivirus-api-production", "path": "/_metrics"},
+    {"hostname": "dm-production", "path": "/_metrics"},
+    {"hostname": "dm-production", "path": "/admin/_metrics"},
+    {"hostname": "dm-production", "path": "/buyers/_metrics"},
+    {"hostname": "dm-production", "path": "/suppliers/_metrics"},
+    {"hostname": "dm-production", "path": "/suppliers/opportunities/_metrics"},
+    {"hostname": "dm-production", "path": "/user/_metrics"}
+  ]
+}


### PR DESCRIPTION
* Add new variable file for script to use.
  * These cannot be part of the manifest bacuse the manifest template variables are filled in inside generate-manifest which will also strip any custom variables out
* Add script which takes uses variables file to add routes to ip-whitelisting-service
* Run script in deployment after routes are created

https://trello.com/c/Ktinf9rQ/457-script-to-add-ip-whitelisted-routes-on-deploy