### PR TITLE
Scale API and supplier FE for G11 applications

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -15,6 +15,7 @@ router:
 
 api:
   memory: 2GB
+  instances: 10
 
 user-frontend:
   instances: 2
@@ -26,4 +27,4 @@ antivirus-api:
   instances: 2
 
 supplier-frontend:
-  instances: 7
+  instances: 10


### PR DESCRIPTION
Trello: https://trello.com/c/gUe0oyAQ/3-scale-up-production-apps-ready-for-g11-application-deadline

We're anticipating high traffic in the last week of applications.

Bumps API and Supplier FE to 10 instances each.

Next week we will go a bit higher if necessary (last year we maxed at 20x API and 15x Supplier https://github.com/alphagov/digitalmarketplace-aws/commit/c9de45c81af7879dfae88a8956c81c3d37ecbdf1#diff-5318b18620ce14c1fca80d3b8f684840)