### PR TITLE
Increase DB backup app memory

### DIFF
--- a/db-backup/create-db-dump.sh
+++ b/db-backup/create-db-dump.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+set +x  # Don't log credentials
 DB_URI=$(echo $VCAP_SERVICES | jq -r '.postgres[0].credentials.uri')
+set -x  # Restore logging
 echo -n "${PUBKEY}" > /app/public.key
 gpg2 --import /app/public.key
 pg_dump "${DB_URI}" --no-acl --no-owner --clean --if-exists | gzip | \

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -66,6 +66,6 @@ brief-responses-frontend:
 
 db-backup:
   instances: 1
-  memory: 128M
+  memory: 2G
   services:
     - digitalmarketplace_api_db


### PR DESCRIPTION
Trello: https://trello.com/c/f1PbVXEW/785-db-backup-app-runs-out-of-memory

Our `db-backup` app is created with 128MB of memory, even though our maximum memory usage for the task is later set to 2G:

`cf run-task db-backup "/app/create-db-dump.sh" --name db-backup -m 2G -k 2G`

Also adds a commit to hide the DB service credentials from Jenkins console output (please check I've got my bash the right way round here...)