### PR TITLE
Increase memory and disk quotas for backup task 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"
 	cf restage db-backup
-	cf run-task db-backup "/app/create-db-dump.sh" --name db-backup -m 2G -k 2G
+	cf run-task db-backup "/app/create-db-dump.sh" --name db-backup -m 3G -k 3G
 
 .PHONY: check-db-backup-task
 check-db-backup-task: ## Get the status for the last db backup task

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -66,6 +66,6 @@ brief-responses-frontend:
 
 db-backup:
   instances: 1
-  memory: 2G
+  memory: 128M
   services:
     - digitalmarketplace_api_db


### PR DESCRIPTION
Trello: https://trello.com/c/f1PbVXEW/785-db-backup-app-runs-out-of-memory

Ben spotted that the task has different quotas (as it's run in a separate container): https://github.com/alphagov/digitalmarketplace-aws/pull/404/files

Bumping the quotas there to 3G each seems to work (i.e. the task failed with a different error, not 'out of memory' 😸).

Therefore we don't need to have the app memory at 2G - I've put it back down to 128M.