### PR TITLE
Add _metrics routes and prom-service for buyer, briefs, user and admin

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -34,16 +34,25 @@ antivirus-api:
 user-frontend:
   routes:
     - dm-{env}.cloudapps.digital/user
+    - dm-{env}.cloudapps.digital/user/_metrics
+  services:
+    - digitalmarketplace_prometheus
 
 admin-frontend:
   routes:
     - dm-{env}.cloudapps.digital/admin
+    - dm-{env}.cloudapps.digital/admin/_metrics
+  services:
+    - digitalmarketplace_prometheus
 
 buyer-frontend:
   memory: 700M
   routes:
     - dm-{env}.cloudapps.digital
+    - dm-{env}.cloudapps.digital/_metrics
     - dm-{env}.cloudapps.digital/buyers/direct-award
+  services:
+    - digitalmarketplace_prometheus
 
 supplier-frontend:
   memory: 700M
@@ -56,6 +65,9 @@ supplier-frontend:
 briefs-frontend:
   routes:
     - dm-{env}.cloudapps.digital/buyers
+    - dm-{env}.cloudapps.digital/buyers/_metrics
+  services:
+    - digitalmarketplace_prometheus
 
 brief-responses-frontend:
   routes:


### PR DESCRIPTION
* Add _metrics routes and prom-service to:
  * buyer
  * briefs
  * user
  * admin

https://trello.com/c/Fqq8RCEb/495-add-metrics-to-briefs-user-and-admin-frontends