### PR TITLE
502-rm-internal-routes-from-preview-for-now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,20 +97,6 @@ deploy-app: ## Deploys the app to PaaS
 	$(if ${STAGE},,$(error Must specify STAGE))
 	cf push --no-start --no-route -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}
 
-	# apps that communicate with each other over the "internal" private network (*.apps.internal) need
-	# to have their explicitly "allowed" communication paths added as "network policies". these must be
-	# added before the app is started otherwise it will not be able to access those other apps, or those
-	# other apps won't be able to access *it*. the policies end up being associated with the app's guid
-	# rather than app name, so these need to be re-created for new apps we create, but the policies
-	# should follow the app's renaming at the end of the release process.
-	#
-	# the order of operations performed here (including inside add-application-network-policies.sh)
-	# is carefully designed to make it hopefully-impossible for an app to get to the point of being started
-	# with any required network policies not being in place, even if the "other" app (the other "party"
-	# in the policy) is simultaneously going through the release process and having its names & routes
-	# similarly juggled around. consider this carefully if making any changes to this.
-	./scripts/add-application-network-policies.sh ./vars/${STAGE}.yml ./vars/common.yml ${APPLICATION_NAME} "-release"
-
 	@echo "Waiting to ensure new app's assigned service credentials have taken effect..."
 	sleep 60
 

--- a/scripts/add-application-network-policies.sh
+++ b/scripts/add-application-network-policies.sh
@@ -10,6 +10,21 @@ export BASE_YAML=$2
 export APPLICATION_NAME=$3
 export APPLICATION_SUFFIX=$4
 
+# TODO re add to Makefile deploy-app when we activate internal routes.
+# apps that communicate with each other over the "internal" private network (*.apps.internal) need
+# to have their explicitly "allowed" communication paths added as "network policies". these must be
+# added before the app is started otherwise it will not be able to access those other apps, or those
+# other apps won't be able to access *it*. the policies end up being associated with the app's guid
+# rather than app name, so these need to be re-created for new apps we create, but the policies
+# should follow the app's renaming at the end of the release process.
+#
+# the order of operations performed here (including inside add-application-network-policies.sh)
+# is carefully designed to make it hopefully-impossible for an app to get to the point of being started
+# with any required network policies not being in place, even if the "other" app (the other "party"
+# in the policy) is simultaneously going through the release process and having its names & routes
+# similarly juggled around. consider this carefully if making any changes to this.
+# ./scripts/add-application-network-policies.sh ./vars/${STAGE}.yml ./vars/common.yml ${APPLICATION_NAME} "-release"
+
 # In each of the cases for ingress and egress applications, we first apply the policy to any instances of the (in|e)gress
 # application that might (also?) be in the process of being released. The order that the two commands are run in *is* relevant
 # and designed to not to allow any policy combinations to be missed even in the face of concurrent release processes. As such,

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -3,53 +3,8 @@ domain: preview.marketplace.team
 maintenance_mode: live
 
 api:
-  routes:
-    - dm-api-{env}.apps.internal
-    - dm-api-{env}.cloudapps.digital/_metrics
   memory: 2GB
-  egress_to_applications:
-    - search-api
-
-search-api:
-  routes:
-    - dm-search-api-{env}.apps.internal
-    - dm-search-api-{env}.cloudapps.digital/_metrics
-
-antivirus-api:
-  routes:
-    - dm-antivirus-api-{env}.apps.internal
-    - dm-antivirus-api-{env}.cloudapps.digital/_metrics
 
 router:
   instances: 2
   rate_limiting_enabled: enabled
-  egress_to_applications:
-    - api
-    - antivirus-api
-    - search-api
-
-admin-frontend:
-  egress_to_applications:
-    - api
-
-brief-responses-frontend:
-  egress_to_applications:
-    - api
-
-briefs-frontend:
-  egress_to_applications:
-    - api
-
-buyer-frontend:
-  egress_to_applications:
-    - api
-    - search-api
-
-supplier-frontend:
-  egress_to_applications:
-    - api
-
-user-frontend:
-  egress_to_applications:
-    - api
-


### PR DESCRIPTION
Remove internal route setup from deployment
Keep script with readme for when we decide to use them

* Rm script call in `deploy-app`
* Add TODO explaining when to reimplement
* Rm internal route definitions from `preview.yml` and fall back to `common.yml`
* Rm `egress_to_applications` values from `preview.yml`

https://trello.com/c/IMVZsuoJ/502-rm-internal-routes-from-preview-for-now