### PR TITLE
Provide DUMP_FILE_NAME as parameter to deploy-db-backup-app task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ check-db-snapshot-service: ## Get the status for the db snapshot service
 .PHONY: deploy-db-backup-app
 deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	$(eval export APPLICATION_NAME=db-backup)
-	$(eval export DUMP_FILE_NAME=${STAGE}-$(shell date +"%Y%m%d%H%M").sql.gz.gpg)
+	$(if ${DUMP_FILE_NAME},,$(error Must specify DUMP_FILE_NAME as '<stage>-yyyyMMddHHmm.sql.gz.gpg'))
 	$(eval export S3_POST_URL_DATA=$(shell ${VIRTUALENV_ROOT}/bin/python ./scripts/generate-s3-post-url-data.py digitalmarketplace-database-backups ${DUMP_FILE_NAME}))
 	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"


### PR DESCRIPTION
Trello: https://trello.com/c/f1PbVXEW/785-db-backup-app-runs-out-of-memory

Discovered during the DB backup failures.

Previously the task was setting its own value for DUMP_FILE_NAME - 1 second later, according to the timestamp - which was conflicting with the Jenkins DUMP_FILE_NAME, and causing the decryption check step to fail.

See Jenkins job update: https://github.com/alphagov/digitalmarketplace-jenkins/pull/219