### PR TITLE
Increase Supplier FE memory to 1G

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -55,7 +55,7 @@ buyer-frontend:
     - digitalmarketplace_prometheus
 
 supplier-frontend:
-  memory: 700M
+  memory: 1G
   routes:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics


### PR DESCRIPTION
Scaling up Supplier FE to 1G memory on all environments (so we can check the deployment).