### PR TITLE
paas instances: scale down production instances following G11's close

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -55,7 +55,7 @@ buyer-frontend:
     - digitalmarketplace_prometheus
 
 supplier-frontend:
-  memory: 1G
+  memory: 700M
   routes:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -4,7 +4,7 @@ maintenance_mode: live
 instances: 5
 
 router:
-  instances: 5
+  instances: 3
   rate_limiting_enabled: enabled
   routes:
     - www.digitalmarketplace.service.gov.uk
@@ -15,9 +15,6 @@ router:
 
 api:
   memory: 2GB
-  instances: 20
-
-buyer-frontend:
   instances: 10
 
 user-frontend:
@@ -27,7 +24,7 @@ admin-frontend:
   instances: 2
 
 antivirus-api:
-  instances: 3
+  instances: 2
 
 supplier-frontend:
-  instances: 20
+  instances: 10


### PR DESCRIPTION
Both number of instances and memory