### PR TITLE
production instances: scale down even more following g-cloud-11's closing

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -15,7 +15,7 @@ router:
 
 api:
   memory: 2GB
-  instances: 10
+  instances: 7
 
 user-frontend:
   instances: 2
@@ -27,4 +27,4 @@ antivirus-api:
   instances: 2
 
 supplier-frontend:
-  instances: 10
+  instances: 7


### PR DESCRIPTION
api & supplier-frontend 10 -> 7?

Want to do this before the weekend.