### PR TITLE
paas manifests: hook up /_metrics route for router

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,11 +1,15 @@
 ---
 router:
   routes:
+    - dm-router-{env}.cloudapps.digital
+    - dm-router-{env}.cloudapps.digital/_metrics
     - www.{env}.marketplace.team
     - api.{env}.marketplace.team
     - search-api.{env}.marketplace.team
     - antivirus-api.{env}.marketplace.team
     - assets.{env}.marketplace.team
+  services:
+    - digitalmarketplace_prometheus
 
 api:
   routes:

--- a/vars/ip_whitelist_routes.json
+++ b/vars/ip_whitelist_routes.json
@@ -1,5 +1,6 @@
 {
   "preview": {
+    "router": [{"hostname": "dm-router-preview", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-preview", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-preview", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-preview", "path": "/_metrics"}],
@@ -11,6 +12,7 @@
     "user-frontend": [{"hostname": "dm-preview", "path": "/user/_metrics"}]
   },
   "staging": {
+    "router": [{"hostname": "dm-router-staging", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-staging", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-staging", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-staging", "path": "/_metrics"}],
@@ -22,6 +24,7 @@
     "user-frontend": [{"hostname": "dm-staging", "path": "/user/_metrics"}]
   },
   "production": {
+    "router": [{"hostname": "dm-router-production", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-production", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-production", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-production", "path": "/_metrics"}],

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -7,6 +7,8 @@ router:
   instances: 3
   rate_limiting_enabled: enabled
   routes:
+    - dm-router-{env}.cloudapps.digital
+    - dm-router-{env}.cloudapps.digital/_metrics
     - www.digitalmarketplace.service.gov.uk
     - api.digitalmarketplace.service.gov.uk
     - search-api.digitalmarketplace.service.gov.uk


### PR DESCRIPTION
~This would allow https://github.com/alphagov/digitalmarketplace-router/pull/64 to be implemented in a slightly neater way.~

To enable https://trello.com/c/wkDN6HHk