### PR TITLE
Add role for validating CloudWatch logs

### DIFF
--- a/terraform/accounts/backups/cloudwatch.tf
+++ b/terraform/accounts/backups/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudtrail" {
   source              = "../../modules/cloudtrail"
-  aws_main_account_id = "${var.aws_main_account_id}"
+  account_id          = "${var.aws_backups_account_id}"
   s3_bucket_name      = "digitalmarketplaces-backups-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-backups-account-cloudtrail"
 }

--- a/terraform/accounts/backups/cloudwatch.tf
+++ b/terraform/accounts/backups/cloudwatch.tf
@@ -3,4 +3,5 @@ module "cloudtrail" {
   account_id          = "${var.aws_backups_account_id}"
   s3_bucket_name      = "digitalmarketplaces-backups-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-backups-account-cloudtrail"
+  validate_account_id = "${var.aws_main_account_id}"
 }

--- a/terraform/accounts/development/cloudwatch.tf
+++ b/terraform/accounts/development/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudtrail" {
   source              = "../../modules/cloudtrail"
-  aws_main_account_id = "${var.aws_main_account_id}"
+  account_id          = "${var.aws_dev_account_id}"
   s3_bucket_name      = "digitalmarketplaces-dev-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-dev-account-cloudtrail"
 }

--- a/terraform/accounts/development/cloudwatch.tf
+++ b/terraform/accounts/development/cloudwatch.tf
@@ -3,4 +3,5 @@ module "cloudtrail" {
   account_id          = "${var.aws_dev_account_id}"
   s3_bucket_name      = "digitalmarketplaces-dev-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-dev-account-cloudtrail"
+  validate_account_id = "${var.aws_main_account_id}"
 }

--- a/terraform/accounts/main/cloudwatch.tf
+++ b/terraform/accounts/main/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudtrail" {
   source              = "../../modules/cloudtrail"
-  aws_main_account_id = "${var.aws_main_account_id}"
+  account_id          = "${var.aws_main_account_id}"
   s3_bucket_name      = "digitalmarketplaces-main-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-main-account-cloudtrail"
 }

--- a/terraform/accounts/main/cloudwatch.tf
+++ b/terraform/accounts/main/cloudwatch.tf
@@ -3,4 +3,5 @@ module "cloudtrail" {
   account_id          = "${var.aws_main_account_id}"
   s3_bucket_name      = "digitalmarketplaces-main-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-main-account-cloudtrail"
+  validate_account_id = "${var.aws_main_account_id}"
 }

--- a/terraform/accounts/production/cloudwatch.tf
+++ b/terraform/accounts/production/cloudwatch.tf
@@ -3,4 +3,5 @@ module "cloudtrail" {
   account_id          = "${var.aws_prod_account_id}"
   s3_bucket_name      = "digitalmarketplaces-prod-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-prod-account-cloudtrail"
+  validate_account_id = "${var.aws_main_account_id}"
 }

--- a/terraform/accounts/production/cloudwatch.tf
+++ b/terraform/accounts/production/cloudwatch.tf
@@ -1,6 +1,6 @@
 module "cloudtrail" {
   source              = "../../modules/cloudtrail"
-  aws_main_account_id = "${var.aws_main_account_id}"
+  account_id          = "${var.aws_prod_account_id}"
   s3_bucket_name      = "digitalmarketplaces-prod-account-cloudtrail-bucket"
   trail_name          = "digitalmarketplaces-prod-account-cloudtrail"
 }

--- a/terraform/modules/cloudtrail/README.md
+++ b/terraform/modules/cloudtrail/README.md
@@ -76,9 +76,8 @@ The `main.tf` file of this module will take care of all of this for you however:
 ```
 module "cloudtrail" {
   source               = "../../modules/cloudtrail"
-  trail_name           = "digitalmarketplaces-account-cloudtrail" // Can be any name
-  retention_in_days    = 731 // How long to make logs accessible in CloudWatch for
+  account_id           = "${var.account_id}" // for the S3 bucket key prefix
   s3_bucket_name       = "digitalmarketplaces-account-cloudtrail-bucket" // Can be any name
-  aws_main_account_id  = "${var.account_id}" // for the S3 bucket key prefix
+  trail_name           = "digitalmarketplaces-account-cloudtrail" // Can be any name
 }
 ```

--- a/terraform/modules/cloudtrail/README.md
+++ b/terraform/modules/cloudtrail/README.md
@@ -13,13 +13,14 @@ This module is used to set up and direct [AWS CloudTrail](https://docs.aws.amazo
 CloudTrail creates log entries for user action events in AWS accounts and puts them in to log files in a specified AWS S3 bucket.
 It is also possible (but not required) to export these log files into CloudWatch so they are easier to search and view.
 
-This module has three sub-modules which it uses to do its work:
+This module has four sub-modules which it uses to do its work:
 
 * The `cloudtrail-bucket` module creates a bucket pre-configured with the permissions required for AWS CloudTrail service to put logs in it. If you already know which bucket you want to put the log files in you don't need this.
 * The `cloudtrail-cloudwatch` module
   * creates an AWS IAM role for the AWS CloudTrail service to assume
   * creates a AWS CloudWatch log group that the above IAM role can write to
 * The `cloudtrail-cloudtrail` module creates an AWS CloudTrail trail that writes to the given AWS S3 bucket and (optionally) exports logs to the given AWS CloudWatch log group
+* The `cloudtrail-validate-logs-role` module creates a role which can be used to validate logs using the AWS cli command `aws cloudtrail validate-logs`
 
 ## Examples
 
@@ -60,6 +61,12 @@ module "cloudtrail-cloudwatch" {
   retention_in_days = 731 // How long to make logs accessible in CloudWatch for
 }
 
+module "cloudtrail-validate-logs-role" {
+  source            = "../modules/cloudtrail/modules/cloudtrail-validate-logs-role"
+  assume_role_arn   = "arn:aws:iam::${var.account_id}:root" // Which account can assume this role
+  s3_bucket_arn     = "${module.cloudtrail-bucket.s3_bucket_arn}"
+}
+
 // Set up the CloudTrail trail
 module "cloudtrail-cloudtrail" {
   source                     = "../../modules/cloudtrail/modules/cloudtrail"
@@ -79,5 +86,6 @@ module "cloudtrail" {
   account_id           = "${var.account_id}" // for the S3 bucket key prefix
   s3_bucket_name       = "digitalmarketplaces-account-cloudtrail-bucket" // Can be any name
   trail_name           = "digitalmarketplaces-account-cloudtrail" // Can be any name
+  validate_account_id  = "${var.account_id}" // For assuming the cloudtrail-validate-logs role
 }
 ```

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -9,6 +9,12 @@ module "cloudtrail-cloudwatch" {
   retention_in_days = 731                               // As per RE convention on keeping logs for 2 years
 }
 
+module "cloudtrail-validate-logs-role" {
+  source          = "./modules/cloudtrail-validate-logs-role"
+  assume_role_arn = "arn:aws:iam::${var.validate_account_id}:root"
+  s3_bucket_arn   = "${module.cloudtrail-bucket.s3_bucket_arn}"
+}
+
 module "cloudtrail-cloudtrail" {
   source                     = "./modules/cloudtrail-cloudtrail"
   trail_name                 = "${var.trail_name}"

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -13,7 +13,7 @@ module "cloudtrail-cloudtrail" {
   source                     = "./modules/cloudtrail-cloudtrail"
   trail_name                 = "${var.trail_name}"
   s3_bucket_name             = "${var.s3_bucket_name}"
-  s3_bucket_key_prefix       = "${var.aws_main_account_id}"
+  s3_bucket_key_prefix       = "${var.account_id}"
   cloud_watch_logs_role_arn  = "${module.cloudtrail-cloudwatch.cloud_watch_logs_role_arn}"
   cloud_watch_logs_group_arn = "${module.cloudtrail-cloudwatch.cloud_watch_logs_group_arn}"
 }

--- a/terraform/modules/cloudtrail/modules/cloudtrail-bucket/outputs.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-bucket/outputs.tf
@@ -1,3 +1,7 @@
+output "s3_bucket_arn" {
+  value = "${aws_s3_bucket.cloudtrail_bucket.arn}"
+}
+
 output "s3_bucket_name" {
   value = "${aws_s3_bucket.cloudtrail_bucket.bucket}"
 }

--- a/terraform/modules/cloudtrail/modules/cloudtrail-validate-logs-role/main.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-validate-logs-role/main.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "cloudtrail_validate_logs_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.assume_role_arn}"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudtrail_validate_logs_policy" {
+  statement {
+    actions = [
+      "cloudtrail:ListPublicKeys",
+      "cloudtrail:DescribeTrails",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = ["${var.s3_bucket_arn}"]
+  }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${var.s3_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_role" "cloudtrail_validate_logs_role" {
+  name               = "cloudtrail-validate-logs"
+  assume_role_policy = "${data.aws_iam_policy_document.cloudtrail_validate_logs_role.json}"
+}
+
+resource "aws_iam_role_policy" "cloudtrail_validate_logs_policy" {
+  name   = "cloudtrail-validate-logs"
+  role   = "${aws_iam_role.cloudtrail_validate_logs_role.id}"
+  policy = "${data.aws_iam_policy_document.cloudtrail_validate_logs_policy.json}"
+}

--- a/terraform/modules/cloudtrail/modules/cloudtrail-validate-logs-role/variables.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-validate-logs-role/variables.tf
@@ -1,0 +1,7 @@
+variable "assume_role_arn" {
+  description = "The ARN of the account that can assume this role"
+}
+
+variable "s3_bucket_arn" {
+  description = "The ARN of the S3 bucket where CloudTrail logs are stored"
+}

--- a/terraform/modules/cloudtrail/variables.tf
+++ b/terraform/modules/cloudtrail/variables.tf
@@ -5,3 +5,7 @@ variable "account_id" {
 variable "s3_bucket_name" {}
 
 variable "trail_name" {}
+
+variable "validate_account_id" {
+  description = "The ID of the account that can assume the role for validating logs"
+}

--- a/terraform/modules/cloudtrail/variables.tf
+++ b/terraform/modules/cloudtrail/variables.tf
@@ -1,4 +1,6 @@
-variable "aws_main_account_id" {}
+variable "account_id" {
+  description = "The ID of the account, used as the S3 bucket key prefix"
+}
 
 variable "s3_bucket_name" {}
 


### PR DESCRIPTION
We want to be able to validate our CloudWatch logs; this PR adds a role with the correct access rights. Adding it to the existing cloudtrail module means that it will be automatically picked up by all the accounts.

It has been configured so that the role in each account can be assumed by the main account; this is so that we can validate the logs periodically with Jenkins.