### PR TITLE
NOTICKET-make-ip-whitelist-script-more-robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ deploy-app: ## Deploys the app to PaaS
 	./scripts/map-route.sh ${APPLICATION_NAME}-release <(make -s -C ${CURDIR} generate-manifest)
 
 	# Make sure relevant routes are whitelisted (can be found in vars/ip_whitelist_routes.json)
-	./scripts/add-ip-whitelist-route-service.sh ${STAGE}
+	./scripts/add-ip-whitelist-route-service.sh ${STAGE} ${APPLICATION_NAME}
 
 	# Delete the route for the old app
 	@if cf app ${APPLICATION_NAME} >/dev/null; then ./scripts/unmap-route.sh ${APPLICATION_NAME}; fi

--- a/scripts/add-ip-whitelist-route-service.sh
+++ b/scripts/add-ip-whitelist-route-service.sh
@@ -1,16 +1,17 @@
 #!/bin/bash -e
 
-if [ "$#" -ne 1 ]; then
+if [ "$#" -ne 2 ]; then
     echo "This script uses the variables in vars/ip_whitelist_routes.json to ip whitelist routes using the re-ip-whitelist-service."
     echo ""
-    echo "Usage: ./scripts/add-ip-whitelist-route-service.sh <stage>"
+    echo "Usage: ./scripts/add-ip-whitelist-route-service.sh <STAGE> <APPLICATION_NAME>"
     exit 1
 fi
 
 export STAGE=$( echo $1 | awk '{ print tolower($0) }' )
+export APPLICATION_NAME=$( echo $2 | awk '{ print tolower($0) }' )
 
 IFS=$'\n'
-for HOSTNAME_PATH in $(jq -r '.[env.STAGE][] | "\(.hostname) \(.path)"' vars/ip_whitelist_routes.json); do
+for HOSTNAME_PATH in $(jq -r '.[env.STAGE][env.APPLICATION_NAME][] | "\(.hostname) \(.path)"' vars/ip_whitelist_routes.json); do
   HOSTNAME=$(echo $HOSTNAME_PATH | cut -f1 -d" ")
   ROUTE_PATH=$(echo $HOSTNAME_PATH | cut -f2 -d" ")
   echo cf bind-route-service cloudapps.digital re-ip-whitelist-service --hostname $HOSTNAME --path $ROUTE_PATH

--- a/vars/ip_whitelist_routes.json
+++ b/vars/ip_whitelist_routes.json
@@ -1,35 +1,35 @@
 {
-  "preview": [
-    {"hostname": "dm-api-preview", "path": "/_metrics"},
-    {"hostname": "dm-search-api-preview", "path": "/_metrics"},
-    {"hostname": "dm-antivirus-api-preview", "path": "/_metrics"},
-    {"hostname": "dm-preview", "path": "/_metrics"},
-    {"hostname": "dm-preview", "path": "/admin/_metrics"},
-    {"hostname": "dm-preview", "path": "/buyers/_metrics"},
-    {"hostname": "dm-preview", "path": "/suppliers/_metrics"},
-    {"hostname": "dm-preview", "path": "/suppliers/opportunities/_metrics"},
-    {"hostname": "dm-preview", "path": "/user/_metrics"}
-  ],
-  "staging": [
-    {"hostname": "dm-api-staging", "path": "/_metrics"},
-    {"hostname": "dm-search-api-staging", "path": "/_metrics"},
-    {"hostname": "dm-antivirus-api-staging", "path": "/_metrics"},
-    {"hostname": "dm-staging", "path": "/_metrics"},
-    {"hostname": "dm-staging", "path": "/admin/_metrics"},
-    {"hostname": "dm-staging", "path": "/buyers/_metrics"},
-    {"hostname": "dm-staging", "path": "/suppliers/_metrics"},
-    {"hostname": "dm-staging", "path": "/suppliers/opportunities/_metrics"},
-    {"hostname": "dm-staging", "path": "/user/_metrics"}
-  ],
-  "production": [
-    {"hostname": "dm-api-production", "path": "/_metrics"},
-    {"hostname": "dm-search-api-production", "path": "/_metrics"},
-    {"hostname": "dm-antivirus-api-production", "path": "/_metrics"},
-    {"hostname": "dm-production", "path": "/_metrics"},
-    {"hostname": "dm-production", "path": "/admin/_metrics"},
-    {"hostname": "dm-production", "path": "/buyers/_metrics"},
-    {"hostname": "dm-production", "path": "/suppliers/_metrics"},
-    {"hostname": "dm-production", "path": "/suppliers/opportunities/_metrics"},
-    {"hostname": "dm-production", "path": "/user/_metrics"}
-  ]
+  "preview": {
+    "api": [{"hostname": "dm-api-preview", "path": "/_metrics"}],
+    "search-api": [{"hostname": "dm-search-api-preview", "path": "/_metrics"}],
+    "antivirus-api": [{"hostname": "dm-antivirus-api-preview", "path": "/_metrics"}],
+    "buyer-frontend": [{"hostname": "dm-preview", "path": "/_metrics"}],
+    "admin-frontend": [{"hostname": "dm-preview", "path": "/admin/_metrics"}],
+    "briefs-frontend": [{"hostname": "dm-preview", "path": "/buyers/_metrics"}],
+    "supplier-frontend": [{"hostname": "dm-preview", "path": "/suppliers/_metrics"}],
+    "brief-responses-frontend": [{"hostname": "dm-preview", "path": "/suppliers/opportunities/_metrics"}],
+    "user-frontend": [{"hostname": "dm-preview", "path": "/user/_metrics"}]
+  },
+  "staging": {
+    "api": [{"hostname": "dm-api-staging", "path": "/_metrics"}],
+    "search-api": [{"hostname": "dm-search-api-staging", "path": "/_metrics"}],
+    "antivirus-api": [{"hostname": "dm-antivirus-api-staging", "path": "/_metrics"}],
+    "buyer-frontend": [{"hostname": "dm-staging", "path": "/_metrics"}],
+    "admin-frontend": [{"hostname": "dm-staging", "path": "/admin/_metrics"}],
+    "briefs-frontend": [{"hostname": "dm-staging", "path": "/buyers/_metrics"}],
+    "supplier-frontend": [{"hostname": "dm-staging", "path": "/suppliers/_metrics"}],
+    "brief-responses-frontend": [{"hostname": "dm-staging", "path": "/suppliers/opportunities/_metrics"}],
+    "user-frontend": [{"hostname": "dm-staging", "path": "/user/_metrics"}]
+  },
+  "production": {
+    "api": [{"hostname": "dm-api-production", "path": "/_metrics"}],
+    "search-api": [{"hostname": "dm-search-api-production", "path": "/_metrics"}],
+    "antivirus-api": [{"hostname": "dm-antivirus-api-production", "path": "/_metrics"}],
+    "buyer-frontend": [{"hostname": "dm-production", "path": "/_metrics"}],
+    "admin-frontend": [{"hostname": "dm-production", "path": "/admin/_metrics"}],
+    "briefs-frontend": [{"hostname": "dm-production", "path": "/buyers/_metrics"}],
+    "supplier-frontend": [{"hostname": "dm-production", "path": "/suppliers/_metrics"}],
+    "brief-responses-frontend": [{"hostname": "dm-production", "path": "/suppliers/opportunities/_metrics"}],
+    "user-frontend": [{"hostname": "dm-production", "path": "/user/_metrics"}]
+  }
 }


### PR DESCRIPTION
Add APPLICATION_NAME arg to ip-whitelist script so script only adds route relevant to current deployment

This script may cause failures when routes do not yet exist. So if a new route is added to the vars here for whitelisting, and this script runs without the route existing already, we will see deployment failures.

* Add new variable to script
* Supply new var in Makefile
* Nest values in json by app name

