### PR TITLE
Fix deploy scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
 VIRTUALENV_ROOT := $(shell [ -z ${VIRTUAL_ENV} ] && echo $$(pwd)/venv || echo ${VIRTUAL_ENV})
+export PATH := ${VIRTUALENV_ROOT}/bin:${PATH}
 
 PAAS_API ?= api.cloud.service.gov.uk
 PAAS_ORG ?= digitalmarketplace


### PR DESCRIPTION
We install tools such as yq that are expected by our deploy scripts.
This commit adds a line to the Makefile that adds the virtualenv to the
PATH of Makefile recipes so that scripts will be able to use these
commands.