### PR TITLE
Increase instances for supplier frontend and antivirus api

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -26,7 +26,7 @@ admin-frontend:
   instances: 2
 
 antivirus-api:
-  instances: 2
+  instances: 4
 
 supplier-frontend:
-  instances: 7
+  instances: 10


### PR DESCRIPTION
G-Cloud 11 has gone into standstill, we should increase our capacity
precautionarily.