### PR TITLE
Ensure new Jenkins volumes are encrypted

### DIFF
--- a/terraform/modules/jenkins/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/jenkins/ec2.tf
@@ -33,6 +33,7 @@ resource "aws_ebs_volume" "jenkins_volume" {
   availability_zone = "${aws_instance.jenkins.availability_zone}"
   type              = "gp2"
   size              = 100
+  encrypted         = true
 
   tags {
     Name      = "jenkins data"


### PR DESCRIPTION
We encrypted our data volume in the AWS console but did not add that to
our terraform, this commit fixes that.