### PR TITLE
448 run jenkins on u1804 2

### DIFF
--- a/scripts/import-and-clean-db-dump.sh
+++ b/scripts/import-and-clean-db-dump.sh
@@ -13,7 +13,7 @@ echo -n $($DM_CREDENTIALS_REPO/sops-wrapper -d $DM_CREDENTIALS_REPO/gpg/database
   gunzip | \
   psql "${POSTGRES_URI}"
 
-gpg2 --list-secret-keys --with-colons --fingerprint | grep fpr | cut -c 13-52 | xargs -n1 gpg2 --batch --delete-secret-key
+gpg2 --list-secret-keys --with-colons --fingerprint | grep sec -A 1 | grep fpr | cut -c 13-52 | xargs -n1 gpg2 --batch --yes --pinentry-mode loopback --delete-secret-key
 rm "${LATEST_PROD_DUMP}"
 
 psql --single-transaction --variable bcrypt_password="'$(${VIRTUALENV_ROOT}/bin/python ./scripts/generate-bcrypt-hashed-password.py Password1234 12)'" "${POSTGRES_URI}" < ./scripts/clean-db-dump.sql

--- a/terraform/accounts/main/jenkins.tf
+++ b/terraform/accounts/main/jenkins.tf
@@ -12,7 +12,7 @@ module "jenkins" {
   source                        = "../../modules/jenkins/jenkins"
   name                          = "jenkins"
   dev_user_ips                  = "${var.dev_user_ips}"
-  jenkins_public_key_name       = "${aws_key_pair.jenkins.key_name}"
+  jenkins_public_key_name       = "${aws_key_pair.jenkins.key_name}"                            # Or ${var.ssh_key_name}
   jenkins_instance_profile      = "${aws_iam_instance_profile.jenkins.name}"
   jenkins_wildcard_elb_cert_arn = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
   ami_id                        = "ami-2a7d75c0"

--- a/terraform/modules/jenkins/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/jenkins/ec2.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
 resource "aws_instance" "jenkins" {
   ami                     = "${var.ami_id}"
   disable_api_termination = true                                                         # prevent this instance from being destroyed from the console


### PR DESCRIPTION
* Clarify that `aws_key_pair.jenkins.key_name` and `var.ssh_key_name` are the same thing
* Remove provider block from within jenkins module  …
  * Provider blocks should be inherited from parent module (accounts/main)
  * https://www.terraform.io/docs/configuration/modules.html#providers-within-modules

> While in principle provider blocks can appear in any module, it is recommended that they be placed only in the root module of a configuration, since this approach allows users to configure providers just once and re-use them across all descendent modules.

