### PR TITLE
add log metric and alarm for login.reset-email.bad-role

### DIFF
--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -54,6 +54,13 @@ module "router_429_alarm" {
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
 
+module "reset_email_bad_role_alarm" {
+  source                         = "../../modules/logging/alarms/reset-email-bad-role"
+  environment                    = "production"
+  alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
+  alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
+}
+
 module "dropped_av_sns_alarm" {
   source                         = "../../modules/logging/alarms/dropped-av-sns"
   environment                    = "production"

--- a/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
+++ b/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
@@ -1,0 +1,24 @@
+resource "aws_cloudwatch_metric_alarm" "reset_email_bad_role_alarm" {
+  alarm_name        = "${var.environment}-reset-email-bad-roles"
+  alarm_description = "Attempts at resetting the password for a user role it has been disabled for on ${var.environment}."
+
+  // Metric
+  namespace   = "DM-reset-email-bad-role"
+  metric_name = "${var.environment}-reset-email-bad-role"
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 1 or higher
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
+  // Email slack
+  alarm_actions = ["${var.alarm_email_topic_arn}"]
+  ok_actions    = ["${var.alarm_recovery_email_topic_arn}"]
+}

--- a/terraform/modules/logging/alarms/reset-email-bad-role/variables.tf
+++ b/terraform/modules/logging/alarms/reset-email-bad-role/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {}
+variable "alarm_email_topic_arn" {}
+variable "alarm_recovery_email_topic_arn" {}

--- a/terraform/modules/logging/log-metric-filters/main.tf
+++ b/terraform/modules/logging/log-metric-filters/main.tf
@@ -322,6 +322,19 @@ resource "aws_cloudwatch_log_metric_filter" "router-429s" {
   }
 }
 
+resource "aws_cloudwatch_log_metric_filter" "reset-email-bad-role" {
+  name           = "${var.environment}-reset-email-bad-role"
+  pattern        = "{$$.code = \"login.reset-email.bad-role\"}"
+  log_group_name = "${var.environment}-user-frontend-application"
+
+  metric_transformation {
+    name          = "${var.environment}-reset-email-bad-role"
+    namespace     = "DM-reset-email-bad-role"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
 # The following two log metric filters output to the same metric (${var.environment}-dropped-antivirus-sns):
 # Because we have separate log streams 'Failure to connect to the AV API' and 'The AV API successfully returned a response'
 # we have to filter the "success" log group for responses >= 400 and the "failure" log group for anything


### PR DESCRIPTION
https://trello.com/c/Vxmq7W0m

Seems to work.

Alarm is only enabled for production, because I don't think it's a particular worry for other environments, where we can still view the metric from the aws console for testing & debugging purposes.
