### PR TITLE
production paas instances: scale supplier-frontend and api down to 8 instances each post-DOS4-closure

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -17,7 +17,7 @@ router:
 
 api:
   memory: 2GB
-  instances: 10
+  instances: 8
 
 user-frontend:
   instances: 2
@@ -29,4 +29,4 @@ antivirus-api:
   instances: 4
 
 supplier-frontend:
-  instances: 14
+  instances: 8


### PR DESCRIPTION
Seems a sensible number.