### PR TITLE
1071-why-did-api-release-to-preview-fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ deploy-app: ## Deploys the app to PaaS
 .PHONY: deploy-db-migration
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
-	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none -i 1 -m 128M -c 'sleep 2h'
+	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none --health-check-http-endpoint none -i 1 -m 128M -c 'sleep 2h'
 	cf stop ${APPLICATION_NAME}-db-migration
 	cf run-task ${APPLICATION_NAME}-db-migration "cd /app && venv/bin/python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 


### PR DESCRIPTION
## Add health-check-http-endpoint none when creating db migration app

Recieved error:

Health check type must be 'http' to set a health check HTTP endpoint.

Assumption is that we cannot set health-check-http-endpoint endpoint value when setting health-check-type to none. Command line arguments override manifest values so this should solve the problem.

<img width="907" alt="Screen Shot 2019-08-28 at 16 48 15" src="https://user-images.githubusercontent.com/3469840/63873250-2ba5e000-c9b7-11e9-8802-d0651ae51c31.png">

https://trello.com/c/IgxiQyEE/1071-why-did-api-release-to-preview-fail