### PR TITLE
1071-why-did-api-release-to-preview-fail-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	$(eval export S3_POST_URL_DATA=$(shell ${VIRTUALENV_ROOT}/bin/python ./scripts/generate-s3-post-url-data.py digitalmarketplace-database-backups ${DUMP_FILE_NAME}))
 
 	# Deploy the backup app
-	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup
+	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup --no-route
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"
 	cf restage db-backup
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ deploy-app: ## Deploys the app to PaaS
 .PHONY: deploy-db-migration
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
-	cf push ${APPLICATION_NAME}-db-migration -f <(APPLICATION_NAME=db-migration make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route
+	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest APPLICATION_NAME=db-migration) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route
 	cf stop ${APPLICATION_NAME}-db-migration
 	cf run-task ${APPLICATION_NAME}-db-migration "cd /app && venv/bin/python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ deploy-app: ## Deploys the app to PaaS
 .PHONY: deploy-db-migration
 deploy-db-migration: ## Deploys the db migration app
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
-	cf push ${APPLICATION_NAME}-db-migration -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route --health-check-type none --health-check-http-endpoint none -i 1 -m 128M -c 'sleep 2h'
+	cf push ${APPLICATION_NAME}-db-migration -f <(APPLICATION_NAME=db-migration make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --no-route
 	cf stop ${APPLICATION_NAME}-db-migration
 	cf run-task ${APPLICATION_NAME}-db-migration "cd /app && venv/bin/python application.py db upgrade" --name ${APPLICATION_NAME}-db-migration
 

--- a/paas/db-backup.j2
+++ b/paas/db-backup.j2
@@ -6,7 +6,6 @@
 
 {% block health_check %}
     health-check-type: none
-    no-route: true
 {% endblock %}
 
 {% block extra %}

--- a/paas/db-migration.j2
+++ b/paas/db-migration.j2
@@ -6,7 +6,6 @@
 
 {% block health_check %}
     health-check-type: none
-    no-route: true
 {% endblock %}
 
 {% block extra %}

--- a/paas/db-migration.j2
+++ b/paas/db-migration.j2
@@ -1,0 +1,14 @@
+{% extends "_base.j2" %}
+
+{% block routes %}
+    no-route: true
+{% endblock %}
+
+{% block health_check %}
+    health-check-type: none
+    no-route: true
+{% endblock %}
+
+{% block extra %}
+    command: sleep 2h
+{% endblock %}

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -85,3 +85,9 @@ db-backup:
   memory: 128M
   services:
     - digitalmarketplace_api_db
+
+db-migration:
+  instances: 1
+  memory: 128M
+  services:
+    - digitalmarketplace_api_db


### PR DESCRIPTION
Create new manifest for a no-route app with db access to perform db-migration

Instead of using the api app manifest to perform migrations we can use a separate manifest that only gives the migrations app what it needs.

This removes the need to override loads of manifest values in the call to cf push which caused the below error

<img width="907" alt="63873250-2ba5e000-c9b7-11e9-8802-d0651ae51c31" src="https://user-images.githubusercontent.com/3469840/63940052-98c18000-ca60-11e9-9d5f-3d97235fd0a5.png">


https://trello.com/c/IgxiQyEE/1071-why-did-api-release-to-preview-fail