### PR TITLE
[WIP] Do not stream _metrics requests to Kibana.

### DIFF
--- a/terraform/modules/log-streaming/subscriptions.tf
+++ b/terraform/modules/log-streaming/subscriptions.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_log_subscription_filter" "elasticsearch_subscription_ap
   count           = "${length(var.application_log_groups)}"
   name            = "elasticsearch-subscription-${element(var.application_log_groups, count.index)}"
   log_group_name  = "${element(var.application_log_groups, count.index)}"
-  filter_pattern  = "{ $.url NOT EXISTS || $.url != \"*/_status?ignore-dependencies\" }"
+  filter_pattern  = "{ $.url NOT EXISTS || $.url != \"*/_status?ignore-dependencies\" || $.url != \"*/_metrics\" }"
   destination_arn = "${aws_lambda_function.log_stream_lambda.arn}"
   depends_on      = ["aws_lambda_permission.cloudwatch_application"]
 }


### PR DESCRIPTION
* Kibana should reflect real user usage.

https://trello.com/c/Ij14C1Eu/1055-add-requests-to-metrics-to-the-log-events-we-filter-out-before-sending-to-logit