### PR TITLE
Disable autoescape for jinja templates

### DIFF
--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -82,8 +82,8 @@ def template_string(string, variables, templates_path=None):
         variables: a dict of variables that the template can use
 
     Raises:
-        TemplateSyntaxError: there is an issue with the template syntax.
-        UndefinedError: the template could not find the value for a variable.
+        jinja2.TemplateSyntaxError: there is an issue with the template syntax.
+        jinja2.UndefinedError: the template could not find the value for a variable.
     """
     jinja_env = jinja2.Environment(
         autoescape=False,

--- a/dmaws/utils.py
+++ b/dmaws/utils.py
@@ -3,7 +3,6 @@ import collections
 
 import yaml
 import jinja2
-from jinja2.exceptions import TemplateSyntaxError, UndefinedError  # noqa
 from jinja2.runtime import StrictUndefined
 
 
@@ -87,6 +86,7 @@ def template_string(string, variables, templates_path=None):
         UndefinedError: the template could not find the value for a variable.
     """
     jinja_env = jinja2.Environment(
+        autoescape=False,
         trim_blocks=True,
         lstrip_blocks=True,
         undefined=StrictUndefined,

--- a/scripts/generate-paas-manifest.py
+++ b/scripts/generate-paas-manifest.py
@@ -8,8 +8,9 @@ import click
 
 sys.path.insert(0, '.')  # noqa
 
-from dmaws.utils import load_file, template_string, merge_dicts, UndefinedError
+from dmaws.utils import load_file, template_string, merge_dicts
 from dmaws.variables import load_variables
+from jinja2 import UndefinedError
 
 
 def get_variables_from_command_line_or_environment(vars):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,10 @@ import pytest
 from dmaws.utils import (
     DEFAULT_TEMPLATES_PATH,
     merge_dicts,
-    template, template_string, LazyTemplateMapping, UndefinedError,
+    template, template_string, LazyTemplateMapping,
     mkdir_p,
 )
+from jinja2 import UndefinedError
 
 
 class TestMergeDicts(object):


### PR DESCRIPTION
The jinja templates are solely used for paas manifest configuration. We're not sure what the impact of autoescaping will be, either now or in the future, and so we've taken a positive decision to turn it off.

I've also moved an unused import away from `utils.py`, where it's not used, to the two places it *is* used - `test_utils` and `generate-paas-manifest.py`

[Ticket](https://trello.com/c/H2ubPYqz/306-enable-autoescape-on-jinja-templates)