### PR TITLE
1098-kibana-alarm-on-failure-of-log-shipping-lambda

### DIFF
--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -60,3 +60,33 @@ module "dropped_av_sns_alarm" {
   alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
+
+resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
+  alarm_name        = "preview-log-stream-lambda"
+  alarm_description = "Alarms on failure of preview-log-stream-lambda lambda function."
+
+  // Metric
+  namespace   = "Lambda"
+  metric_name = "Errors"
+
+  dimensions {
+    LogGroupName = "preview-log-stream-lambda"
+    Resource     = "preview-log-stream-lambda"
+  }
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 1 or higher
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
+  // Email slack
+  alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]
+  ok_actions    = ["${module.alarm_recovery_email_sns.email_topic_arn}"]
+}

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -74,3 +74,33 @@ module "dropped_av_sns_alarm" {
   alarm_email_topic_arn          = "${module.alarm_email_sns.email_topic_arn}"
   alarm_recovery_email_topic_arn = "${module.alarm_recovery_email_sns.email_topic_arn}"
 }
+
+resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
+  alarm_name        = "production-log-stream-lambda"
+  alarm_description = "Alarms on failure of production-log-stream-lambda lambda function."
+
+  // Metric
+  namespace   = "Lambda"
+  metric_name = "Errors"
+
+  dimensions {
+    LogGroupName = "production-log-stream-lambda"
+    Resource     = "production-log-stream-lambda"
+  }
+
+  // For for every 60 seconds
+  evaluation_periods = "1"
+  period             = "60"
+
+  // If totals 1 or higher
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+
+  // If there is no data then do not alarm
+  treat_missing_data = "notBreaching"
+
+  // Email slack
+  alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]
+  ok_actions    = ["${module.alarm_recovery_email_sns.email_topic_arn}"]
+}


### PR DESCRIPTION
Add alarm to trigger when lambda fails with an error.

On the 4th of October logit is going to roll over an intermediate certificate. We want an alert to capture this and similar issues

https://trello.com/c/tsArQ9k3/1098-kibana-alarm-on-failure-of-log-shipping-lambda