### PR TITLE
Add digitalmarketplace-gov-uk to CodeCommit

### DIFF
--- a/terraform/accounts/main/codecommit.tf
+++ b/terraform/accounts/main/codecommit.tf
@@ -31,6 +31,7 @@ variable "alphagov_git_repositories" {
     "digitalmarketplace-user-frontend",
     "digitalmarketplace-utils",
     "digitalmarketplace-visual-regression",
+    "digitalmarketplace-govuk-frontend",
   ]
 }
 


### PR DESCRIPTION
We want to be able to backup the digitalmarketplace-govuk-frontend
repository to AWS CodeCommit, so we need to add it to the list of repos
here.

We add it to the end because otherwise Terraform will try to recreate
all the resources for repositories that follow in the list if we insert
in the correct alphabetical location.

https://trello.com/c/KBZFQOfK/326-create-a-new-digitalmarketplace-shared-frontend-code-repo