### PR TITLE
Bump Search API app to 2 instances on preview

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -8,3 +8,6 @@ api:
 router:
   instances: 2
   rate_limiting_enabled: enabled
+
+search-api:
+  instances: 2


### PR DESCRIPTION
https://trello.com/c/7IanBWbi/1234-search-api-on-preview-bump-memory

Overnight indexing failures on Preview add quite a bit of noise to the release channel. Usually the Preview `search-api` app has run out of memory. 

The Staging `search-api` is also on 512Mb, but has 2 instances instead of 1 (Production is on 512Mb as well, with 5 instances). 

I was originally going to bump the memory up to 2GB as per the `api` and `antivirus-api`, but I decided to reflect 'reality' as closely as possible by bumping the number of Preview instances instead.