### PR TITLE
increase antivirus timeout at startup from 60 to 90 seconds

### DIFF
--- a/paas/antivirus-api.j2
+++ b/paas/antivirus-api.j2
@@ -1,5 +1,9 @@
 {% extends "_base.j2" %}
 
+{% block extra %}
+    timeout: 90
+{% endblock %}
+
 {% block env %}
 
       AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}


### PR DESCRIPTION
trello: https://trello.com/c/JDKeSdiu/1245-increase-antivirus-apis-manifest-startup-timeout-setting

The timeout is also limited by the could controller's maximum_health_check_timeout which is 180 by default.