### PR TITLE
1145-remove-adminuserips-and-userips-from-creds-terraform-commonjson-and-rename-devuserips

### DIFF
--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -17,10 +17,10 @@ terraform {
 }
 
 module "iam_common" {
-  source              = "../../modules/iam-common"
-  dev_user_ips        = "${var.dev_user_ips}"
-  aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id  = "${var.aws_dev_account_id}"
+  source                            = "../../modules/iam-common"
+  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
+  aws_main_account_id               = "${var.aws_main_account_id}"
+  aws_dev_account_id                = "${var.aws_dev_account_id}"
 }
 
 module "switch_roles" {

--- a/terraform/accounts/development/variables.tf
+++ b/terraform/accounts/development/variables.tf
@@ -1,4 +1,4 @@
-variable "dev_user_ips" {
+variable "aws_account_and_jenkins_login_ips" {
   type = "list"
 }
 

--- a/terraform/accounts/main/jenkins.tf
+++ b/terraform/accounts/main/jenkins.tf
@@ -9,31 +9,31 @@ module "jenkins_elb_log_bucket" {
 }
 
 module "jenkins_2" {
-  source                        = "../../modules/jenkins/jenkins"
-  name                          = "jenkins2"
-  dev_user_ips                  = "${var.dev_user_ips}"
-  jenkins_public_key_name       = "${aws_key_pair.jenkins.key_name}"                            # Or ${var.ssh_key_name}
-  jenkins_instance_profile      = "${aws_iam_instance_profile.jenkins.name}"
-  jenkins_wildcard_elb_cert_arn = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
-  ami_id                        = "ami-01e6a0b85de033c99"
-  instance_type                 = "t3.large"
-  dns_zone_id                   = "${aws_route53_zone.marketplace_team.zone_id}"
-  dns_name                      = "ci.marketplace.team"
-  log_bucket_name               = "${module.jenkins_elb_log_bucket.bucket_id}"
+  source                            = "../../modules/jenkins/jenkins"
+  name                              = "jenkins2"
+  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
+  jenkins_public_key_name           = "${aws_key_pair.jenkins.key_name}"                            # Or ${var.ssh_key_name}
+  jenkins_instance_profile          = "${aws_iam_instance_profile.jenkins.name}"
+  jenkins_wildcard_elb_cert_arn     = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
+  ami_id                            = "ami-01e6a0b85de033c99"
+  instance_type                     = "t3.large"
+  dns_zone_id                       = "${aws_route53_zone.marketplace_team.zone_id}"
+  dns_name                          = "ci.marketplace.team"
+  log_bucket_name                   = "${module.jenkins_elb_log_bucket.bucket_id}"
 }
 
 module "jenkins3" {
-  source                        = "../../modules/jenkins/jenkins"
-  name                          = "jenkins3"
-  dev_user_ips                  = "${var.dev_user_ips}"
-  jenkins_public_key_name       = "${aws_key_pair.jenkins.key_name}"                            # Or ${var.ssh_key_name}
-  jenkins_instance_profile      = "${aws_iam_instance_profile.jenkins.name}"
-  jenkins_wildcard_elb_cert_arn = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
-  ami_id                        = "ami-01e6a0b85de033c99"
-  instance_type                 = "t3.large"
-  dns_zone_id                   = "${aws_route53_zone.marketplace_team.zone_id}"
-  dns_name                      = "ci3.marketplace.team"
-  log_bucket_name               = "${module.jenkins_elb_log_bucket.bucket_id}"
+  source                            = "../../modules/jenkins/jenkins"
+  name                              = "jenkins3"
+  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
+  jenkins_public_key_name           = "${aws_key_pair.jenkins.key_name}"                            # Or ${var.ssh_key_name}
+  jenkins_instance_profile          = "${aws_iam_instance_profile.jenkins.name}"
+  jenkins_wildcard_elb_cert_arn     = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
+  ami_id                            = "ami-01e6a0b85de033c99"
+  instance_type                     = "t3.large"
+  dns_zone_id                       = "${aws_route53_zone.marketplace_team.zone_id}"
+  dns_name                          = "ci3.marketplace.team"
+  log_bucket_name                   = "${module.jenkins_elb_log_bucket.bucket_id}"
 }
 
 module "jenkins_snapshots" {

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -17,10 +17,10 @@ terraform {
 }
 
 module "iam_common" {
-  source              = "../../modules/iam-common"
-  dev_user_ips        = "${var.dev_user_ips}"
-  aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id  = "${var.aws_dev_account_id}"
+  source                            = "../../modules/iam-common"
+  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
+  aws_main_account_id               = "${var.aws_main_account_id}"
+  aws_dev_account_id                = "${var.aws_dev_account_id}"
 }
 
 module "iam_users" {

--- a/terraform/accounts/main/variables.tf
+++ b/terraform/accounts/main/variables.tf
@@ -1,7 +1,7 @@
 variable "ssh_key_name" {}
 variable "jenkins_public_key" {}
 
-variable "dev_user_ips" {
+variable "aws_account_and_jenkins_login_ips" {
   type = "list"
 }
 

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -17,10 +17,10 @@ terraform {
 }
 
 module "iam_common" {
-  source              = "../../modules/iam-common"
-  dev_user_ips        = "${var.dev_user_ips}"
-  aws_main_account_id = "${var.aws_main_account_id}"
-  aws_dev_account_id  = "${var.aws_dev_account_id}"
+  source                            = "../../modules/iam-common"
+  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
+  aws_main_account_id               = "${var.aws_main_account_id}"
+  aws_dev_account_id                = "${var.aws_dev_account_id}"
 }
 
 module "switch_roles" {

--- a/terraform/accounts/production/variables.tf
+++ b/terraform/accounts/production/variables.tf
@@ -1,4 +1,4 @@
-variable "dev_user_ips" {
+variable "aws_account_and_jenkins_login_ips" {
   type = "list"
 }
 

--- a/terraform/modules/iam-common/common_policies.tf
+++ b/terraform/modules/iam-common/common_policies.tf
@@ -11,7 +11,7 @@ resource "aws_iam_policy" "ip_restricted_access" {
     "Resource": "*",
     "Condition": {
       "NotIpAddress": {
-        "aws:SourceIp": [${join(",", formatlist("\"%s\"", var.dev_user_ips))}]
+        "aws:SourceIp": [${join(",", formatlist("\"%s\"", var.aws_account_and_jenkins_login_ips))}]
       },
       "Null": {
         "kms:ViaService": "true"

--- a/terraform/modules/iam-common/variables.tf
+++ b/terraform/modules/iam-common/variables.tf
@@ -1,4 +1,4 @@
-variable "dev_user_ips" {
+variable "aws_account_and_jenkins_login_ips" {
   type = "list"
 }
 

--- a/terraform/modules/jenkins/jenkins/security_group.tf
+++ b/terraform/modules/jenkins/jenkins/security_group.tf
@@ -11,7 +11,7 @@ resource "aws_security_group_rule" "jenkins_elb_allow_ssh_from_whitelisted_ips" 
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = ["${var.dev_user_ips}"]
+  cidr_blocks       = ["${var.aws_account_and_jenkins_login_ips}"]
 }
 
 resource "aws_security_group_rule" "jenkins_elb_allow_https_from_whitelisted_ips" {
@@ -20,7 +20,7 @@ resource "aws_security_group_rule" "jenkins_elb_allow_https_from_whitelisted_ips
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["${var.dev_user_ips}", "${aws_eip.jenkins.public_ip}/32"]
+  cidr_blocks       = ["${var.aws_account_and_jenkins_login_ips}", "${aws_eip.jenkins.public_ip}/32"]
 }
 
 resource "aws_security_group_rule" "jenkins_elb_allow_http_to_jenkins_instance" {

--- a/terraform/modules/jenkins/jenkins/variables.tf
+++ b/terraform/modules/jenkins/jenkins/variables.tf
@@ -1,4 +1,4 @@
-variable "dev_user_ips" {
+variable "aws_account_and_jenkins_login_ips" {
   type = "list"
 }
 


### PR DESCRIPTION
Update to new variable name used in credentials

https://trello.com/c/9k6TWovP/1145-remove-adminuserips-and-userips-from-creds-terraform-commonjson-and-rename-devuserips

Changed dev_user_ips to aws_account_and_jenkins_login_ips to better reflect use case

Requires:
https://github.com/alphagov/digitalmarketplace-credentials/pull/274