### PR TITLE
Enable Travis checks for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 env:
   - TERRAFORM_VERSION=0.11.7 TERRAFORM_FILE_NAME=terraform_${TERRAFORM_VERSION}_linux_amd64.zip TERRAFORM_DOWNLOAD_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_FILE_NAME}
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-flake8==3.5.0
+flake8==3.7.7
 mock==1.0.1
 pytest==3.2.3
 requests-mock==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 click==6.6
 Jinja2==2.10
-PyYAML==3.11
-awscli==1.15.67
+PyYAML==5.1.2
+awscli==1.16.272
 requests==2.20.0
-boto3==1.4.5
+boto3==1.10.25
 docopt==0.6.2
 bcrypt==3.1.3
 yq==2.7.2


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- No dependency bumps so far 🤞 