### PR TITLE
Add role to user name and email address in cleaned db dumps

### DIFF
--- a/scripts/clean-db-dump.sql
+++ b/scripts/clean-db-dump.sql
@@ -2,8 +2,8 @@
 
 \echo 'Update users'
 UPDATE users
-SET name = 'Test user',
-    email_address = id || '@user.marketplace.team',
+SET name = 'Test ' || role,
+    email_address = id || '@' || role || '.marketplace.team',
     password = :bcrypt_password,
     failed_login_count = 0,
     phone_number = '01234567890';


### PR DESCRIPTION
This is a straw-person PR to go with [this tech debt ticket](https://trello.com/c/Ry6E8Xzk/1152-change-the-database-cleaning-script-to-make-user-email-addresses-more-descriptive).