### PR TITLE
168-spike-check-a-newly-deployed-app-can-connect-to-its-paas-backing-service-timebox-1d

### DIFF
--- a/paas/api.j2
+++ b/paas/api.j2
@@ -1,5 +1,10 @@
 {% extends "_base.j2" %}
 
+{% block health_check %}
+    health-check-type: http
+    health-check-http-endpoint: {{ routes[0].partition('/')[1:]|join("") }}/_status
+{% endblock %}
+
 {% block env %}
       AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}

--- a/paas/search-api.j2
+++ b/paas/search-api.j2
@@ -1,5 +1,10 @@
 {% extends "_base.j2" %}
 
+{% block health_check %}
+    health-check-type: http
+    health-check-http-endpoint: {{ routes[0].partition('/')[1:]|join("") }}/_status
+{% endblock %}
+
 {% block env %}
       AWS_ACCESS_KEY_ID: {{ aws_access_key_id }}
       AWS_SECRET_ACCESS_KEY: {{ aws_secret_access_key }}


### PR DESCRIPTION
Make APIs use backing service checking healthcheck to ensure apps can connect to services
    
https://docs.google.com/document/d/18JV_ZTUqM500WLBxOt0lKtV12IYcS6Ay1SwJmxDOYb0
https://trello.com/c/ZxGiuNQb/1092-spike-check-a-newly-deployed-app-can-connect-to-its-paas-backing-service-timebox-1d