### PR TITLE
Scale app servers for G12

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -30,9 +30,11 @@ antivirus-api:
   instances: 4
 
 buyer-frontend:
+  instances: 8
   memory: 1G
 
 search-api:
+  instances: 8
   memory: 1G
 
 supplier-frontend:


### PR DESCRIPTION
- We had more crashes of buyerFE and searchAPI, despite the traffic hasn’t really been ramping up. So it seems the strategy of scaling up servers is not very effective (at least for those apps). Let’s try scaling out.
- See https://trello.com/c/cfMyItQs and https://docs.google.com/document/d/1BLoJY0cpyNLVEKRFNjw98chTtMcbEEOAQmWhC7bmHWk/edit#heading=h.awi1p9ezj2mx

Signed-off-by: Paula Valenca <paula.valenca@digital.cabinet-office.gov.uk>