### PR TITLE
Scale Preview Buyer FE to 2 instances

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -5,6 +5,9 @@ maintenance_mode: live
 api:
   memory: 2GB
 
+buyer-frontend:
+  instances: 2
+
 router:
   instances: 2
   rate_limiting_enabled: enabled


### PR DESCRIPTION
https://trello.com/c/NdmLe2dd/1551-monitor-preview-buyer-fe-flakiness

Following recent app flakiness during smoulder tests. 

For example, at 2020-03-23T20:50:07Z  the Preview Buyer FE instance recycled itself (without crashing), during a smoulder test run. Although it recovered, this triggered some failures and noise in our release channel.

The Search API and router already have 2 instances, other Preview apps all have 1.