### PR TITLE
Increase time window for all alerts to 5 minutes

### DIFF
--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -22,9 +22,9 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
     path = "/data"
   }
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 10gb or lower (in bytes)
   statistic           = "Sum"
@@ -48,9 +48,9 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
     path = "/"
   }
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1gb or lower (in bytes)
   statistic           = "Sum"

--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
     path = "/data"
   }
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
     path = "/"
   }
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
     Resource     = "preview-log-stream-lambda"
   }
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -74,9 +74,9 @@ resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
     Resource     = "preview-log-stream-lambda"
   }
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -88,9 +88,9 @@ resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
     Resource     = "production-log-stream-lambda"
   }
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -88,7 +88,7 @@ resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
     Resource     = "production-log-stream-lambda"
   }
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/admin-manager-password-reset/alarms.tf
+++ b/terraform/modules/logging/alarms/admin-manager-password-reset/alarms.tf
@@ -6,9 +6,9 @@ resource "aws_cloudwatch_metric_alarm" "admin_manager_password_reset" {
   namespace   = "DM-admin-manager-password-reset"
   metric_name = "${var.environment}-admin-manager-password-reset"
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/admin-manager-password-reset/alarms.tf
+++ b/terraform/modules/logging/alarms/admin-manager-password-reset/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_manager_password_reset" {
   namespace   = "DM-admin-manager-password-reset"
   metric_name = "${var.environment}-admin-manager-password-reset"
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
+++ b/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
@@ -6,9 +6,9 @@ resource "aws_cloudwatch_metric_alarm" "dropped_antivirus_sns_alarm" {
   namespace   = "DM-SNS"
   metric_name = "${var.environment}-dropped-antivirus-sns"
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
+++ b/terraform/modules/logging/alarms/dropped-av-sns/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "dropped_antivirus_sns_alarm" {
   namespace   = "DM-SNS"
   metric_name = "${var.environment}-dropped-antivirus-sns"
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -16,9 +16,8 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   }
 
   // For 5 minutes
-
   evaluation_periods = "1"
-  period = "300"
+  period             = "300"
 
   // Totals 0
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -16,10 +16,9 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   }
 
   // For 5 minutes
-  // This appears to cause our alarms to trigger at around the 10-12 minute mark
-  evaluation_periods = "5"
 
-  period = "60"
+  evaluation_periods = "1"
+  period = "300"
 
   // Totals 0
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
+++ b/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "reset_email_bad_role_alarm" {
   namespace   = "DM-reset-email-bad-role"
   metric_name = "${var.environment}-reset-email-bad-role"
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
+++ b/terraform/modules/logging/alarms/reset-email-bad-role/alarms.tf
@@ -6,9 +6,9 @@ resource "aws_cloudwatch_metric_alarm" "reset_email_bad_role_alarm" {
   namespace   = "DM-reset-email-bad-role"
   metric_name = "${var.environment}-reset-email-bad-role"
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"

--- a/terraform/modules/logging/alarms/slow-requests/alarms.tf
+++ b/terraform/modules/logging/alarms/slow-requests/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_5_10_alarm" {
   namespace   = "DM-RequestTimeBuckets"
   metric_name = "${var.environment}-router-request-times-8"
 
-  // For for every 5 minutes
+  // For every 5 minutes
   evaluation_periods = "1"
   period             = "300"
 
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "slow_requests_gt_10_alarm" {
   namespace   = "DM-RequestTimeBuckets"
   metric_name = "${var.environment}-router-request-times-9"
 
-  // For for every 10 seconds
+  // For every 5 minutes
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/status-code/alarms.tf
+++ b/terraform/modules/logging/alarms/status-code/alarms.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "status_code_alarm" {
   namespace   = "DM-${var.status_code}s"
   metric_name = "${var.environment}-router-nginx-${var.status_code}s"
 
-  // For for every 300 seconds
+  // For every 300 seconds
   evaluation_periods = "1"
   period             = "300"
 

--- a/terraform/modules/logging/alarms/status-code/alarms.tf
+++ b/terraform/modules/logging/alarms/status-code/alarms.tf
@@ -6,9 +6,9 @@ resource "aws_cloudwatch_metric_alarm" "status_code_alarm" {
   namespace   = "DM-${var.status_code}s"
   metric_name = "${var.environment}-router-nginx-${var.status_code}s"
 
-  // For for every 60 seconds
+  // For for every 300 seconds
   evaluation_periods = "1"
-  period             = "60"
+  period             = "300"
 
   // If totals 1 or higher
   statistic           = "Sum"


### PR DESCRIPTION
~~**DO NOT MERGE OR APPLY BEFORE #675**~~ READY TO MERGE

Trello: https://trello.com/c/fF0V5auU

Please check commit messages for more information.

Note there are two actions that should follow after this PR has been merged:

- [x]  Revisit the notifications when resetting passwords for admin manager and if it's fit for the intended purpose. This will be a tech debt card
- [ ] Test that the change to the missing logs alarm keeps the alert of downtime at ~15 minute mark. To be tested before release to production