### PR TITLE
Revert "Change alarm on missing logs from 5 x 60s to 1 x 300s to keep…

### DIFF
--- a/terraform/modules/logging/alarms/missing-logs/alarms.tf
+++ b/terraform/modules/logging/alarms/missing-logs/alarms.tf
@@ -16,8 +16,10 @@ resource "aws_cloudwatch_metric_alarm" "missing_logs_alarm" {
   }
 
   // For 5 minutes
-  evaluation_periods = "1"
-  period             = "300"
+  // This appears to cause our alarms to trigger at around the 10-12 minute mark
+  evaluation_periods = "5"
+
+  period = "60"
 
   // Totals 0
   statistic           = "Sum"


### PR DESCRIPTION
… with rest of alert periods"

This reverts commit 4eabd764

Alerts are triggered at the 15 minute mark but since this alert can be sometimes used to flag an app being down, we're reverting to the previous solution (with alerts being triggered at 10-12 minute mark)

This means we are checking every 1 minute but with a 5 minute moving window, as opposed to simply checking every 5 minutes.

**Notes:**

- I expect the reason it takes 10-12 minutes is probably because we are shipping logs from PaaS to Cloudwatch every 5-10 minutes
- We should not depend on this alert to flag if an app is up, and depend instead on health checks or the smoulder/smoke tests. This discussion will be carried out on the side with @daniele-occhipinti 