### PR TITLE
Don't echo credentials (send to /dev/null)

### DIFF
--- a/db-backup/create-db-dump.sh
+++ b/db-backup/create-db-dump.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-set +x  # Don't log credentials
-DB_URI=$(echo $VCAP_SERVICES | jq -r '.postgres[0].credentials.uri')
-set -x  # Restore logging
+DB_URI=$(echo $VCAP_SERVICES | jq -r '.postgres[0].credentials.uri') >/dev/null # Don't print credentials to stdout
 echo -n "${PUBKEY}" > /app/public.key
 gpg2 --import /app/public.key
 pg_dump "${DB_URI}" --no-acl --no-owner --clean --if-exists | gzip | \


### PR DESCRIPTION
https://trello.com/c/TNoXg0lb/147-2-postgres-secrets-logged-to-console-when-db-backup-job-fails

Previously in the error case the credentials were shown as they were printed to stdout in the PaaS logs. This still executes the command but forwards to `/dev/null` so nothing is printed.

We can confirm this is working on Jenkins as expected once merged.