### PR TITLE
do not expand console output

### DIFF
--- a/db-backup/create-db-dump.sh
+++ b/db-backup/create-db-dump.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-set +x  # Don't log credentials
-DB_URI=$(echo $VCAP_SERVICES | jq -r '.postgres[0].credentials.uri')
-set -x  # Restore logging
 echo -n "${PUBKEY}" > /app/public.key
 gpg2 --import /app/public.key
-pg_dump "${DB_URI}" --no-acl --no-owner --clean --if-exists | gzip | \
+pg_dump "${DATABASE_URL}" --no-acl --no-owner --clean --if-exists | gzip | \
   gpg2 --trust-model always -r "${RECIPIENT}" --out /app/"${DUMP_FILE_NAME}" --encrypt
 
 /usr/local/bin/python /app/upload-dump-to-s3.py

--- a/db-backup/create-db-dump.sh
+++ b/db-backup/create-db-dump.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 echo -n "${PUBKEY}" > /app/public.key
 gpg2 --import /app/public.key


### PR DESCRIPTION
https://trello.com/c/TNoXg0lb/147-2-postgres-secrets-logged-to-console-when-db-backup-job-fails

The effect of the `set -x` argument was to print and expand all arguments which caused the printing of secrets into the logs.

Please documentation at: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html

This also switches to use the PaaS built-in [DATABASE_URL](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#DATABASE-URL) rather than parsing VCAP using jq.

You can see the output of this branch for a failure case here: https://ci.marketplace.team/job/database-backup/1166/execution/node/161/log/