### PR TITLE
add splunk service to apps

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -9,7 +9,8 @@ router:
     - antivirus-api.{env}.marketplace.team
     - assets.{env}.marketplace.team
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 api:
   routes:
@@ -17,7 +18,8 @@ api:
     - dm-api-{env}.cloudapps.digital/_metrics
   services:
     - digitalmarketplace_api_db
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 search-api:
   routes:
@@ -25,7 +27,8 @@ search-api:
     - dm-search-api-{env}.cloudapps.digital/_metrics
   services:
     - search_api_elasticsearch
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 antivirus-api:
   memory: 2G
@@ -33,21 +36,24 @@ antivirus-api:
     - dm-antivirus-api-{env}.cloudapps.digital
     - dm-antivirus-api-{env}.cloudapps.digital/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 user-frontend:
   routes:
     - dm-{env}.cloudapps.digital/user
     - dm-{env}.cloudapps.digital/user/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 admin-frontend:
   routes:
     - dm-{env}.cloudapps.digital/admin
     - dm-{env}.cloudapps.digital/admin/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 buyer-frontend:
   memory: 700M
@@ -56,7 +62,8 @@ buyer-frontend:
     - dm-{env}.cloudapps.digital/_metrics
     - dm-{env}.cloudapps.digital/buyers/direct-award
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 supplier-frontend:
   memory: 700M
@@ -64,21 +71,24 @@ supplier-frontend:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 briefs-frontend:
   routes:
     - dm-{env}.cloudapps.digital/buyers
     - dm-{env}.cloudapps.digital/buyers/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 brief-responses-frontend:
   routes:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
     - dm-{env}.cloudapps.digital/suppliers/opportunities/_metrics
   services:
-    - digitalmarketplace_prometheus
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
 
 db-backup:
   instances: 1

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -9,8 +9,7 @@ router:
     - antivirus-api.{env}.marketplace.team
     - assets.{env}.marketplace.team
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 api:
   routes:
@@ -18,8 +17,7 @@ api:
     - dm-api-{env}.cloudapps.digital/_metrics
   services:
     - digitalmarketplace_api_db
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 search-api:
   routes:
@@ -27,8 +25,7 @@ search-api:
     - dm-search-api-{env}.cloudapps.digital/_metrics
   services:
     - search_api_elasticsearch
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 antivirus-api:
   memory: 2G
@@ -36,24 +33,21 @@ antivirus-api:
     - dm-antivirus-api-{env}.cloudapps.digital
     - dm-antivirus-api-{env}.cloudapps.digital/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 user-frontend:
   routes:
     - dm-{env}.cloudapps.digital/user
     - dm-{env}.cloudapps.digital/user/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 admin-frontend:
   routes:
     - dm-{env}.cloudapps.digital/admin
     - dm-{env}.cloudapps.digital/admin/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 buyer-frontend:
   memory: 700M
@@ -62,8 +56,7 @@ buyer-frontend:
     - dm-{env}.cloudapps.digital/_metrics
     - dm-{env}.cloudapps.digital/buyers/direct-award
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 supplier-frontend:
   memory: 700M
@@ -71,24 +64,21 @@ supplier-frontend:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 briefs-frontend:
   routes:
     - dm-{env}.cloudapps.digital/buyers
     - dm-{env}.cloudapps.digital/buyers/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 brief-responses-frontend:
   routes:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
     - dm-{env}.cloudapps.digital/suppliers/opportunities/_metrics
   services:
-    - digitalmarketplace_prometheus 
-    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 db-backup:
   instances: 1

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -2,15 +2,58 @@
 domain: preview.marketplace.team
 maintenance_mode: live
 
+admin-frontend:
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
+
+antivirus-api:
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
+
 api:
   memory: 2GB
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
+    - digitalmarketplace_api_db
+
+brief-responses-frontend:
+    services:
+      - digitalmarketplace_splunk
+      - digitalmarketplace_prometheus
+
+briefs-frontend:
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 buyer-frontend:
   instances: 2
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 router:
   instances: 2
   rate_limiting_enabled: enabled
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
 
 search-api:
   instances: 2
+  services:
+    - search_api_elasticsearch
+    - digitalmarketplace_prometheus
+
+supplier-frontend:
+  services:
+    - digitalmarketplace_splunk
+    - digitalmarketplace_prometheus
+
+user-frontend:
+  services:
+    - search_api_elasticsearch
+    - digitalmarketplace_prometheus

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -47,6 +47,7 @@ search-api:
   services:
     - search_api_elasticsearch
     - digitalmarketplace_prometheus
+    - digitalmarketplace_splunk
 
 supplier-frontend:
   services:


### PR DESCRIPTION
https://trello.com/c/yJeKtmkj/201-2-setup-splunk-on-our-apps-for-log-aggregation-timebox-2-days
add splunk service to apps. This is as-per https://github.com/alphagov/tech-ops/blob/master/cyber-security/components/csls-splunk-broker/docs/user-guide.md#bind-a-splunk-service-to-your-apps-using-an-app-manifest