### PR TITLE
Fix typo in preview services

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -56,5 +56,5 @@ supplier-frontend:
 
 user-frontend:
   services:
-    - search_api_elasticsearch
+    - digitalmarketplace_splunk
     - digitalmarketplace_prometheus


### PR DESCRIPTION
User frontend needs to be bound to Splunk, not Elasticsearch.