### PR TITLE
terraform ACM certificate validation records

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -26,19 +26,18 @@ module "preview_router" {
 
   log_retention_days = "180"
 
-  cname_domain              = "d25mxit1hgdj3z.cloudfront.net"
-  www_acm_value             = "_d3502b7f8e8375277e10b2a7a5c5184f.tfmgdnztqk.acm-validations.aws."
-  www_acm_name              = "_d3fce2c248a4041784f06c22a0090865.assets."
-  api_acm_value             = "_bd3d82c6197b75e9ab21e7a60512f7ef.tfmgdnztqk.acm-validations.aws."
-  api_acm_name              = "_588eb18af3dc5d8581c483bd3df00607.api."
-  search_api_acm_value      = "_64f5fb82d733c1d2222e4aa64a03b037.tfmgdnztqk.acm-validations.aws."
-  search_api_acm_name       = "_652fee20b56f7182234ee35cf8cbbc3e.search-api."
-  assets_acm_value          = "_67847da8bf05e8175ebfdf514f34cd3f.tfmgdnztqk.acm-validations.aws."
-  assets_acm_name           = "_d3fce2c248a4041784f06c22a0090865.assets."
-  antivirus_api_acm_value   = "_304c9698a6caf6522fd7c0f8c1f3f206.tfmgdnztqk.acm-validations.aws."
-  antivirus_api_acm_name    = "_e9bbdc88aebdbb1753eb4c81fd7cf1b9.antivirus-api."
+  cname_domain            = "d25mxit1hgdj3z.cloudfront.net"
+  www_acm_value           = "_d3502b7f8e8375277e10b2a7a5c5184f.tfmgdnztqk.acm-validations.aws."
+  www_acm_name            = "_d3fce2c248a4041784f06c22a0090865.assets."
+  api_acm_value           = "_bd3d82c6197b75e9ab21e7a60512f7ef.tfmgdnztqk.acm-validations.aws."
+  api_acm_name            = "_588eb18af3dc5d8581c483bd3df00607.api."
+  search_api_acm_value    = "_64f5fb82d733c1d2222e4aa64a03b037.tfmgdnztqk.acm-validations.aws."
+  search_api_acm_name     = "_652fee20b56f7182234ee35cf8cbbc3e.search-api."
+  assets_acm_value        = "_67847da8bf05e8175ebfdf514f34cd3f.tfmgdnztqk.acm-validations.aws."
+  assets_acm_name         = "_d3fce2c248a4041784f06c22a0090865.assets."
+  antivirus_api_acm_value = "_304c9698a6caf6522fd7c0f8c1f3f206.tfmgdnztqk.acm-validations.aws."
+  antivirus_api_acm_name  = "_e9bbdc88aebdbb1753eb4c81fd7cf1b9.antivirus-api."
 }
-
 
 module "application_logs" {
   source = "../../modules/log-groups"

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -26,12 +26,19 @@ module "preview_router" {
 
   log_retention_days = "180"
 
-  cname_domain              = "d3eyi6749eogkv.cloudfront.net"
-  www_acme_challenge        = "10BxG5sYBrsXy9nTFn4U2dn90v0ic7yFGkf5egYYzvM"
-  api_acme_challenge        = "dTEB4iW45IMydD38YUCjjwtbaX1V-tXki-J1dZ4IIK4"
-  search_api_acme_challenge = "mn-kwBxpLeqkLBenVhQYZIoX02iIaMPaAiYw1ndiKy4"
-  assets_acme_challenge     = "nml3dVZaOkLIUql5v6rxPb-vHy2PoXbJ6oFGzMB8SrY"
+  cname_domain              = "d25mxit1hgdj3z.cloudfront.net"
+  www_acm_value             = "_d3502b7f8e8375277e10b2a7a5c5184f.tfmgdnztqk.acm-validations.aws."
+  www_acm_name              = "_d3fce2c248a4041784f06c22a0090865.assets."
+  api_acm_value             = "_bd3d82c6197b75e9ab21e7a60512f7ef.tfmgdnztqk.acm-validations.aws."
+  api_acm_name              = "_588eb18af3dc5d8581c483bd3df00607.api."
+  search_api_acm_value      = "_64f5fb82d733c1d2222e4aa64a03b037.tfmgdnztqk.acm-validations.aws."
+  search_api_acm_name       = "_652fee20b56f7182234ee35cf8cbbc3e.search-api."
+  assets_acm_value          = "_67847da8bf05e8175ebfdf514f34cd3f.tfmgdnztqk.acm-validations.aws."
+  assets_acm_name           = "_d3fce2c248a4041784f06c22a0090865.assets."
+  antivirus_api_acm_value   = "_304c9698a6caf6522fd7c0f8c1f3f206.tfmgdnztqk.acm-validations.aws."
+  antivirus_api_acm_name    = "_e9bbdc88aebdbb1753eb4c81fd7cf1b9.antivirus-api."
 }
+
 
 module "application_logs" {
   source = "../../modules/log-groups"

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -26,17 +26,17 @@ module "production_router" {
 
   log_retention_days = "3653"
 
-  cname_domain              = "d3pp9vxqezcjw2.cloudfront.net"
-  www_acm_value             = "_2533026340ed4b4a24b09340fedc85d5.jfrzftwwjs.acm-validations.aws."
-  www_acm_name              = "_f8537f5176fa0132541cc64978203785.www."
-  api_acm_value             = "_a716cce694fa6f137f0b635d2d99e640.jfrzftwwjs.acm-validations.aws."
-  api_acm_name              = "_cd4d4ebc88b211a33f49a7bfbec4153c.api."
-  search_api_acm_value      = "_43a6fa789628598d9d54032cf6b0275a.jfrzftwwjs.acm-validations.aws."
-  search_api_acm_name       = "_f6f4c3316e1f46a83a398775af242e71.search-api."
-  assets_acm_value          = "_1e1ff1759e34e6e56f7000e46eba51a2.jfrzftwwjs.acm-validations.aws."
-  assets_acm_name           = "_a504b430ba24d9f975df4d5677fa5683.assets."
-  antivirus_api_acm_value   = "_a2c38fdc747637add5b6ff0958fe5141.jfrzftwwjs.acm-validations.aws."
-  antivirus_api_acm_name    = "_c304f7f525b21772de85e239fc32df96.antivirus-api."
+  cname_domain            = "d3pp9vxqezcjw2.cloudfront.net"
+  www_acm_value           = "_2533026340ed4b4a24b09340fedc85d5.jfrzftwwjs.acm-validations.aws."
+  www_acm_name            = "_f8537f5176fa0132541cc64978203785.www."
+  api_acm_value           = "_a716cce694fa6f137f0b635d2d99e640.jfrzftwwjs.acm-validations.aws."
+  api_acm_name            = "_cd4d4ebc88b211a33f49a7bfbec4153c.api."
+  search_api_acm_value    = "_43a6fa789628598d9d54032cf6b0275a.jfrzftwwjs.acm-validations.aws."
+  search_api_acm_name     = "_f6f4c3316e1f46a83a398775af242e71.search-api."
+  assets_acm_value        = "_1e1ff1759e34e6e56f7000e46eba51a2.jfrzftwwjs.acm-validations.aws."
+  assets_acm_name         = "_a504b430ba24d9f975df4d5677fa5683.assets."
+  antivirus_api_acm_value = "_a2c38fdc747637add5b6ff0958fe5141.jfrzftwwjs.acm-validations.aws."
+  antivirus_api_acm_name  = "_c304f7f525b21772de85e239fc32df96.antivirus-api."
 }
 
 module "application_logs" {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -27,10 +27,16 @@ module "production_router" {
   log_retention_days = "3653"
 
   cname_domain              = "d3pp9vxqezcjw2.cloudfront.net"
-  www_acme_challenge        = "6R2Srug_clrhWCdEv-BXP9bbZY88cBSk_d5B9CFaiDM"
-  api_acme_challenge        = "eovwGgagiCUwdb-NlbZndlV6JIukpZtK2MJQcXtb5ec"
-  search_api_acme_challenge = "6BF1gcDwKfuLc_xCP1Se8PIjXjL8Ayk8QFgDxqsX8qw"
-  assets_acme_challenge     = "qFDTBZVXxuuaMqgm1c-D5wX4iRJogcnTEaJdhDSG-rw"
+  www_acm_value             = "_2533026340ed4b4a24b09340fedc85d5.jfrzftwwjs.acm-validations.aws."
+  www_acm_name              = "_f8537f5176fa0132541cc64978203785.www."
+  api_acm_value             = "_a716cce694fa6f137f0b635d2d99e640.jfrzftwwjs.acm-validations.aws."
+  api_acm_name              = "_cd4d4ebc88b211a33f49a7bfbec4153c.api."
+  search_api_acm_value      = "_43a6fa789628598d9d54032cf6b0275a.jfrzftwwjs.acm-validations.aws."
+  search_api_acm_name       = "_f6f4c3316e1f46a83a398775af242e71.search-api."
+  assets_acm_value          = "_1e1ff1759e34e6e56f7000e46eba51a2.jfrzftwwjs.acm-validations.aws."
+  assets_acm_name           = "_a504b430ba24d9f975df4d5677fa5683.assets."
+  antivirus_api_acm_value   = "_a2c38fdc747637add5b6ff0958fe5141.jfrzftwwjs.acm-validations.aws."
+  antivirus_api_acm_name    = "_c304f7f525b21772de85e239fc32df96.antivirus-api."
 }
 
 module "application_logs" {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -21,10 +21,16 @@ module "staging_router" {
   log_retention_days = "180"
 
   cname_domain              = "d316z22457q6mz.cloudfront.net"
-  www_acme_challenge        = "gAvnidL435OgRSEbsmaRao8t6h556S7pR579scyWidY"
-  api_acme_challenge        = "PnHbLO52oob6u-vDm1oLuO6eYA6jhZNSPZHRAwkPQSk"
-  search_api_acme_challenge = "CBejAeUi-c-88fyngXwAd9Q45ivBiPqbXm4wnD9-7nY"
-  assets_acme_challenge     = "qHoJDoj_Fckc061F_DZ7BhQRhMv4EV3BYZ9hKGoew84"
+  www_acm_value             = "_a4da5eba3aafdf9678deaa24a883eb7f.jfrzftwwjs.acm-validations.aws."
+  www_acm_name              = "_1d240148b08ff53cf23f086a0ede70d0.www."
+  api_acm_value             = "_da88346b4df90d2f48f5325214f4eefa.jfrzftwwjs.acm-validations.aws."
+  api_acm_name              = "_931290d183ce63092cf3a11a27c829d1.api."
+  search_api_acm_value      = "_ce105f953286c5abeb4119857ef8be0d.jfrzftwwjs.acm-validations.aws."
+  search_api_acm_name       = "_bcc5b347135144bac6efcc6b43fe5b4b.search-api."
+  assets_acm_value          = "_b610609289861ce0b0b91b86f87ecfcd.jfrzftwwjs.acm-validations.aws."
+  assets_acm_name           = "_d1566e76f4f310932de01dc91651f590.assets."
+  antivirus_api_acm_value   = "_b60218e4087dbd3ca9082994dfaa380a.jfrzftwwjs.acm-validations.aws."
+  antivirus_api_acm_name    = "_3a55f25136ea0e61591ff87ec05181a0.antivirus-api."
 }
 
 module "application_logs" {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -20,17 +20,17 @@ module "staging_router" {
 
   log_retention_days = "180"
 
-  cname_domain              = "d316z22457q6mz.cloudfront.net"
-  www_acm_value             = "_a4da5eba3aafdf9678deaa24a883eb7f.jfrzftwwjs.acm-validations.aws."
-  www_acm_name              = "_1d240148b08ff53cf23f086a0ede70d0.www."
-  api_acm_value             = "_da88346b4df90d2f48f5325214f4eefa.jfrzftwwjs.acm-validations.aws."
-  api_acm_name              = "_931290d183ce63092cf3a11a27c829d1.api."
-  search_api_acm_value      = "_ce105f953286c5abeb4119857ef8be0d.jfrzftwwjs.acm-validations.aws."
-  search_api_acm_name       = "_bcc5b347135144bac6efcc6b43fe5b4b.search-api."
-  assets_acm_value          = "_b610609289861ce0b0b91b86f87ecfcd.jfrzftwwjs.acm-validations.aws."
-  assets_acm_name           = "_d1566e76f4f310932de01dc91651f590.assets."
-  antivirus_api_acm_value   = "_b60218e4087dbd3ca9082994dfaa380a.jfrzftwwjs.acm-validations.aws."
-  antivirus_api_acm_name    = "_3a55f25136ea0e61591ff87ec05181a0.antivirus-api."
+  cname_domain            = "d316z22457q6mz.cloudfront.net"
+  www_acm_value           = "_a4da5eba3aafdf9678deaa24a883eb7f.jfrzftwwjs.acm-validations.aws."
+  www_acm_name            = "_1d240148b08ff53cf23f086a0ede70d0.www."
+  api_acm_value           = "_da88346b4df90d2f48f5325214f4eefa.jfrzftwwjs.acm-validations.aws."
+  api_acm_name            = "_931290d183ce63092cf3a11a27c829d1.api."
+  search_api_acm_value    = "_ce105f953286c5abeb4119857ef8be0d.jfrzftwwjs.acm-validations.aws."
+  search_api_acm_name     = "_bcc5b347135144bac6efcc6b43fe5b4b.search-api."
+  assets_acm_value        = "_b610609289861ce0b0b91b86f87ecfcd.jfrzftwwjs.acm-validations.aws."
+  assets_acm_name         = "_d1566e76f4f310932de01dc91651f590.assets."
+  antivirus_api_acm_value = "_b60218e4087dbd3ca9082994dfaa380a.jfrzftwwjs.acm-validations.aws."
+  antivirus_api_acm_name  = "_3a55f25136ea0e61591ff87ec05181a0.antivirus-api."
 }
 
 module "application_logs" {

--- a/terraform/modules/router/route53.tf
+++ b/terraform/modules/router/route53.tf
@@ -2,47 +2,58 @@ resource "aws_route53_zone" "root" {
   name = "${var.domain}"
 }
 
-resource "aws_route53_record" "www_acme_challenge" {
+resource "aws_route53_record" "www_acm_validation" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name    = "_acme-challenge.www.${var.domain}"
-  type    = "TXT"
-  ttl     = "120"
+  name    = "${var.www_acm_name}${var.domain}"
+  type    = "CNAME"
+  ttl     = "86400"
 
   records = [
-    "${var.www_acme_challenge}",
+    "${var.www_acm_value}",
   ]
 }
 
-resource "aws_route53_record" "api_acme_challenge" {
+resource "aws_route53_record" "api_acm_validation" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name    = "_acme-challenge.api.${var.domain}"
-  type    = "TXT"
-  ttl     = "120"
+  name    = "${var.api_acm_name}${var.domain}"
+  type    = "CNAME"
+  ttl     = "86400"
 
   records = [
-    "${var.api_acme_challenge}",
+    "${var.api_acm_value}",
   ]
 }
 
-resource "aws_route53_record" "search_api_acme_challenge" {
+resource "aws_route53_record" "search_api_acm_validation" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name    = "_acme-challenge.search-api.${var.domain}"
-  type    = "TXT"
-  ttl     = "120"
+  name    = "${var.search_api_acm_name}${var.domain}"
+  type    = "CNAME"
+  ttl     = "86400"
 
   records = [
-    "${var.search_api_acme_challenge}",
+    "${var.search_api_acm_value}",
   ]
 }
 
-resource "aws_route53_record" "assets_acme_challenge" {
+resource "aws_route53_record" "antivirus_api_acm_validation" {
   zone_id = "${aws_route53_zone.root.zone_id}"
-  name    = "_acme-challenge.assets.${var.domain}"
-  type    = "TXT"
-  ttl     = "120"
+  name    = "${var.antivirus_api_acm_name}${var.domain}"
+  type    = "CNAME"
+  ttl     = "86400"
 
   records = [
-    "${var.assets_acme_challenge}",
+    "${var.antivirus_api_acm_value}",
+  ]
+}
+
+resource "aws_route53_record" "assets_acm_validation" {
+  zone_id = "${aws_route53_zone.root.zone_id}"
+  name    = "${var.www_acm_name}${var.domain}"
+  type    = "CNAME"
+  ttl     = "86400"
+
+  records = [
+    "${var.assets_acm_value}",
   ]
 }
 

--- a/terraform/modules/router/variables.tf
+++ b/terraform/modules/router/variables.tf
@@ -5,8 +5,14 @@ variable "cname_domain" {
   default = ""
 }
 
-variable "www_acme_challenge" {}
-variable "api_acme_challenge" {}
-variable "search_api_acme_challenge" {}
-variable "assets_acme_challenge" {}
+variable "www_acm_value" {}
+variable "www_acm_name" {}
+variable "antivirus_api_acm_value" {}
+variable "antivirus_api_acm_name" {}
+variable "api_acm_value" {}
+variable "api_acm_name" {}
+variable "search_api_acm_value" {}
+variable "search_api_acm_name" {}
+variable "assets_acm_value" {}
+variable "assets_acm_name" {}
 variable "log_retention_days" {}


### PR DESCRIPTION
https://trello.com/c/40xHkNW8/1733-2-update-paas-cdn
This terraforms the validation changes from Let's Encrypt to ACM. The Preview and Staging environment changes have already been applied, once this is merged we will apply the production changes.

---------------

Here is the corresponding PaaS change request for reference: 
```
Create the following CNAME records to direct traffic from your domains to your CDN route

www.digitalmarketplace.service.gov.uk => d3pp9vxqezcjw2.cloudfront.net
api.digitalmarketplace.service.gov.uk =>
           d3pp9vxqezcjw2.cloudfront.net
search-api.digitalmarketplace.service.gov.uk => d3pp9vxqezcjw2.cloudfront.net
antivirus-api.digitalmarketplace.service.gov.uk => d3pp9vxqezcjw2.cloudfront.net
assets.digitalmarketplace.service.gov.uk =>
           d3pp9vxqezcjw2.cloudfront.net

To validate ownership of the domain, set the following DNS records



For domain www.digitalmarketplace.service.gov.uk, set DNS record
    Name:  _f8537f5176fa0132541cc64978203785.www.digitalmarketplace.service.gov.uk.
    Type:  CNAME
  
           Value: _2533026340ed4b4a24b09340fedc85d5.jfrzftwwjs.acm-validations.aws.
    TTL:   86400

Current validation status of www.digitalmarketplace.service.gov.uk: PENDING_VALIDATION




For domain assets.digitalmarketplace.service.gov.uk, set DNS record
    Name: 
           _a504b430ba24d9f975df4d5677fa5683.assets.digitalmarketplace.service.gov.uk.
    Type:  CNAME
    Value: _1e1ff1759e34e6e56f7000e46eba51a2.jfrzftwwjs.acm-validations.aws.
    TTL:   86400

Current validation status of assets.digitalmarketplace.service.gov.uk:
           PENDING_VALIDATION




For domain search-api.digitalmarketplace.service.gov.uk, set DNS record
    Name:  _f6f4c3316e1f46a83a398775af242e71.search-api.digitalmarketplace.service.gov.uk.
    Type:  CNAME
    Value:
           _43a6fa789628598d9d54032cf6b0275a.jfrzftwwjs.acm-validations.aws.
    TTL:   86400

Current validation status of search-api.digitalmarketplace.service.gov.uk: PENDING_VALIDATION




For domain antivirus-api.digitalmarketplace.service.gov.uk, set DNS record
    Name: 
           _c304f7f525b21772de85e239fc32df96.antivirus-api.digitalmarketplace.service.gov.uk.
    Type:  CNAME
    Value: _a2c38fdc747637add5b6ff0958fe5141.jfrzftwwjs.acm-validations.aws.
    TTL:   86400

Current validation status of
           antivirus-api.digitalmarketplace.service.gov.uk: PENDING_VALIDATION




For domain api.digitalmarketplace.service.gov.uk, set DNS record
    Name:  _cd4d4ebc88b211a33f49a7bfbec4153c.api.digitalmarketplace.service.gov.uk.
    Type:  CNAME
    Value:
           _a716cce694fa6f137f0b635d2d99e640.jfrzftwwjs.acm-validations.aws.
    TTL:   86400

Current validation status of api.digitalmarketplace.service.gov.uk: PENDING_VALIDATION



started:   2020-07-21T12:49:15Z
updated:   2020-07-21T12:56:38Z
```