### PR TITLE
Revert "increase supplier frontend instances and memory"

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -16,8 +16,8 @@ router:
     - assets.digitalmarketplace.service.gov.uk
 
 api:
-  memory: 4GB
-  instances: 20
+  memory: 2GB
+  instances: 10
 
 user-frontend:
   instances: 2
@@ -38,5 +38,5 @@ search-api:
   memory: 1G
 
 supplier-frontend:
-  instances: 20
-  memory: 4GB
+  instances: 10
+  memory: 1GB


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-aws#704

scaling back down after anticipated increase in traffic.