### PR TITLE
Fix bug in paas-clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ cleanup-db-backup: ## Remove snapshot service and app
 
 .PHONY: paas-clean
 paas-clean: ## Cleans up all files created for the PaaS deployment
-	cf logout
+	-cf logout
 
 .PHONY: run-postgres-container
 run-postgres-container: ## Runs a postgres container


### PR DESCRIPTION
Allow the `cf logout` command to fail by using Make specific syntax[[1]]. If for some reason we aren't already logged in to PaaS, cf logout will complain that it can't log out. I think this caused some recent release failures.

https://ci.marketplace.team/job/release-app-paas/7084/console

[1]: https://www.gnu.org/software/make/manual/html_node/Errors.html#Errors