### PR TITLE
Disconnect AV from the docs bucket in preview

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -79,7 +79,6 @@ module "antivirus-sns" {
   bucket_arns = [
     "${aws_s3_bucket.agreements_bucket.arn}",
     "${aws_s3_bucket.communications_bucket.arn}",
-    "${aws_s3_bucket.documents_bucket.arn}",
     "${aws_s3_bucket.submissions_bucket.arn}",
   ]
 }


### PR DESCRIPTION
This is needed before setting G-Cloud-12 as live in preview for testing.

Following the procedure in https://alphagov.github.io/digitalmarketplace-manual/content-and-frameworks/framework-lifecycle-for-developers.html#g-cloud