### PR TITLE
Revert "Disconnect AV from the docs bucket in preview"

### DIFF
--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -79,6 +79,7 @@ module "antivirus-sns" {
   bucket_arns = [
     "${aws_s3_bucket.agreements_bucket.arn}",
     "${aws_s3_bucket.communications_bucket.arn}",
+    "${aws_s3_bucket.documents_bucket.arn}",
     "${aws_s3_bucket.submissions_bucket.arn}",
   ]
 }


### PR DESCRIPTION
The purpose of the disconnection was to allow us to publish the framework in preview without overloading the AV. However, it turns out that this is blocked because preview doesn't have all the submission documents that production does. This causes the publish script to fail.

Copying the documents from production to preview is hard (94GB). So instead of publishing the framework in preview, we're just going to do it in production instead. The database sync will then propagate the publishing to preview. Thus, we no longer need to run the script, so can re-enable AV.

Reverts alphagov/digitalmarketplace-aws#732