### PR TITLE
Fix bug in deploy-app recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ deploy-app: ## Deploys the app to PaaS
 	@echo "Waiting for previous app version to process existing requests..."
 	sleep 60
 
-	cf stop ${APPLICATION_NAME}
-	cf delete -f ${APPLICATION_NAME}
+	-cf stop ${APPLICATION_NAME}
+	-cf delete -f ${APPLICATION_NAME}
 	cf rename ${APPLICATION_NAME}-release ${APPLICATION_NAME}
 
 .PHONY: deploy-db-migration


### PR DESCRIPTION
https://trello.com/c/Kop14JBa/1425-spike-our-zero-downtime-deploy-script-can-fail-in-a-way-that-requires-manual-recovery

Allow the commands to delete the previous app in the deploy-app recipe to fail [[1]]. If for some reason the existing app has the wrong name or isn't present, we still want the deployed app to be renamed to have the right name.

[1]: https://www.gnu.org/software/make/manual/html_node/Errors.html#Errors