### PR TITLE
Use Docker credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ deploy-app: ## Deploys the app to PaaS
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${RELEASE_NAME},,$(error Must specify RELEASE_NAME))
 	$(if ${STAGE},,$(error Must specify STAGE))
+	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
+	$(if ${DOCKER_USERNAME},,$(error Must specify DOCKER_USERNAME))
 	cf push --no-start --no-route -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --docker-username ${DOCKER_USERNAME}
 
 	@echo "Waiting to ensure new app's assigned service credentials have taken effect..."

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ deploy-app: ## Deploys the app to PaaS
 	$(if ${APPLICATION_NAME},,$(error Must specify APPLICATION_NAME))
 	$(if ${RELEASE_NAME},,$(error Must specify RELEASE_NAME))
 	$(if ${STAGE},,$(error Must specify STAGE))
-	cf push --no-start --no-route -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME}
+	cf push --no-start --no-route -f <(make -s -C ${CURDIR} generate-manifest) -o digitalmarketplace/${APPLICATION_NAME}:${RELEASE_NAME} --docker-username ${DOCKER_USERNAME}
 
 	@echo "Waiting to ensure new app's assigned service credentials have taken effect..."
 	sleep 60


### PR DESCRIPTION
https://trello.com/c/TM0mwfiE/2014-add-dockerhub-credentials-to-paas-manifests

Note `CF_DOCKER_PASSWORD` should be automatically picked up and used as long as the env var is set. See https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html#private-repo