### PR TITLE
Scale up staging for load testing

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -4,8 +4,8 @@ maintenance_mode: live
 instances: 5
 
 api:
-  memory: 2GB
-  instances: 10
+  memory: 4GB
+  instances: 20
 
 user-frontend:
   instances: 2
@@ -18,14 +18,15 @@ antivirus-api:
   instances: 4
 
 buyer-frontend:
+  instances: 10
   memory: 1G
 
 search-api:
   memory: 1G
 
 supplier-frontend:
-  instances: 10
-  memory: 1GB
+  instances: 40
+  memory: 4GB
 
 router:
   instances: 6

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,10 +1,32 @@
 ---
 domain: staging.marketplace.team
 maintenance_mode: live
-instances: 2
+instances: 5
 
 api:
   memory: 2GB
+  instances: 10
+
+user-frontend:
+  instances: 2
+
+admin-frontend:
+  instances: 2
+  memory: 1GB
+
+antivirus-api:
+  instances: 4
+
+buyer-frontend:
+  memory: 1G
+
+search-api:
+  memory: 1G
+
+supplier-frontend:
+  instances: 10
+  memory: 1GB
 
 router:
-  rate_limiting_enabled: enabled
+  instances: 6
+  rate_limiting_enabled: disabled


### PR DESCRIPTION
Trello: https://trello.com/c/kGmsXWZ1/520-3-find-out-whether-dmp-can-cope-with-dos5-closing

We will shortly be running load testing on staging. The goal is to find out whether the DMp is likely to be able to handle a reasonable worst-case scenario for traffic during DOS 5 closing.

For this test to give us meaningful results, we need staging to match production as it will be on the day of DOS 5 closing. Thus, scale up staging. I've modelled the scale after that we used for DOS 5 opening and G12 closing.

Also disable rate-limiting, since we are running the load test from a single IP.