### PR TITLE
Double antivirus-api instances for load tests

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -15,7 +15,7 @@ admin-frontend:
   memory: 1GB
 
 antivirus-api:
-  instances: 4
+  instances: 8
 
 buyer-frontend:
   instances: 10


### PR DESCRIPTION
Trello: https://trello.com/c/kGmsXWZ1/520-3-find-out-whether-dmp-can-cope-with-dos5-closing

The load test we ran today was broadly successful. We found though that antivirus-api seemed to be struggling a bit. This isn't actually a problem - the overnight job will pick up anything that it missed during the day.

Double the number of instances ahead of our test tomorrow to see if that helps things.

Will be reverted tomorrow after the load testing is complete.