### PR TITLE
Scale staging back to its normal size

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -1,32 +1,10 @@
 ---
 domain: staging.marketplace.team
 maintenance_mode: live
-instances: 5
+instances: 2
 
 api:
   memory: 2GB
-  instances: 10
-
-user-frontend:
-  instances: 2
-
-admin-frontend:
-  instances: 2
-  memory: 1GB
-
-antivirus-api:
-  instances: 4
-
-buyer-frontend:
-  memory: 1G
-
-search-api:
-  memory: 1G
-
-supplier-frontend:
-  instances: 10
-  memory: 1GB
 
 router:
-  instances: 6
-  rate_limiting_enabled: disabled
+  rate_limiting_enabled: enabled

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -4,8 +4,8 @@ maintenance_mode: live
 instances: 5
 
 api:
-  memory: 4GB
-  instances: 20
+  memory: 2GB
+  instances: 10
 
 user-frontend:
   instances: 2
@@ -18,15 +18,14 @@ antivirus-api:
   instances: 4
 
 buyer-frontend:
-  instances: 10
   memory: 1G
 
 search-api:
   memory: 1G
 
 supplier-frontend:
-  instances: 40
-  memory: 4GB
+  instances: 10
+  memory: 1GB
 
 router:
   instances: 6

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -15,7 +15,7 @@ admin-frontend:
   memory: 1GB
 
 antivirus-api:
-  instances: 8
+  instances: 4
 
 buyer-frontend:
   instances: 10


### PR DESCRIPTION
Trello: https://trello.com/c/kGmsXWZ1/520-3-find-out-whether-dmp-can-cope-with-dos5-closing

We've now finished the load testing, so we can scale staging back in.

Reverts https://github.com/alphagov/digitalmarketplace-aws/pull/760 and https://github.com/alphagov/digitalmarketplace-aws/pull/758