### PR TITLE
bind apps to redis on preview

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,9 +4,44 @@ maintenance_mode: live
 
 api:
   memory: 2GB
-
+  
 buyer-frontend:
   instances: 2
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+
+admin-frontend:
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+
+brief-responses-frontend:
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+
+briefs-frontend:
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+
+supplier-frontend:
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+    
+user-frontend:
+  services:
+    - digitalmarketplace_prometheus 
+    - digitalmarketplace_splunk
+    - digitalmarketplace_redis
+
 
 router:
   instances: 2


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment

Bind frontend apps to redis instance for testing on preview only 
(note the other services need to be specified so they are not overwritten)﻿
