### PR TITLE
set redis service name on frontend apps

### DIFF
--- a/paas/admin-frontend.j2
+++ b/paas/admin-frontend.j2
@@ -27,4 +27,5 @@
 
       DM_CLARIFICATION_QUESTION_EMAIL: {{ supplier_frontend.clarification_question_email }}
       DM_FOLLOW_UP_EMAIL_TO: {{ supplier_frontend.follow_up_email_to }}
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 {% endblock %}

--- a/paas/brief-responses-frontend.j2
+++ b/paas/brief-responses-frontend.j2
@@ -9,6 +9,7 @@
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 
       SECRET_KEY: {{ shared_tokens.password_key }}
 

--- a/paas/briefs-frontend.j2
+++ b/paas/briefs-frontend.j2
@@ -8,6 +8,7 @@
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 

--- a/paas/buyer-frontend.j2
+++ b/paas/buyer-frontend.j2
@@ -9,8 +9,10 @@
 
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
 
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
       DM_SEARCH_API_AUTH_TOKEN: {{ search_api.auth_tokens[0] }}
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
+      
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 

--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -30,4 +30,5 @@
       DM_MAILCHIMP_USERNAME: {{ supplier_frontend.mailchimp_username }}
       DM_MAILCHIMP_API_KEY: {{ supplier_frontend.mailchimp_api_key }}
       DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID: {{ supplier_frontend.mailchimp_open_framework_notification_mailing_list_id }}
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 {% endblock %}

--- a/paas/user-frontend.j2
+++ b/paas/user-frontend.j2
@@ -8,6 +8,7 @@
       DM_DATA_API_URL: https://dm-api-{{ environment }}.cloudapps.digital
 
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
+      DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment

The code in https://github.com/alphagov/digitalmarketplace-utils/pull/584 expects this env var to be set, this is a prerequisite to enabling redis sessions on preview.