### PR TITLE
Revert "temporarily remove vars"

### DIFF
--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -10,6 +10,9 @@
       DM_MANDRILL_API_KEY: {{ shared_tokens.mandrill_key }}
       DM_NOTIFY_API_KEY: {{ notify_api_key }}
 
+      DM_DNB_API_USERNAME: {{ supplier_frontend.dnb_api_username }}
+      DM_DNB_API_PASSWORD: {{ supplier_frontend.dnb_api_password }}
+
       SECRET_KEY: {{ shared_tokens.password_key }}
       SHARED_EMAIL_KEY: {{ shared_tokens.shared_email_key }}
 


### PR DESCRIPTION
https://trello.com/c/NcLdEdYq/2082-incident-db-api-contract-has-expired
we can revert this now credentials are working again.
Reverts alphagov/digitalmarketplace-aws#767