### PR TITLE
enable redis env var on preview only

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -34,6 +34,11 @@ applications:
 
       DM_LOG_PATH: ''
 
+      {% if env|default([])|length > 0 %}
+        {% for k, v in env.items() %}
+      {{ k }}: {{ v }}
+        {% endfor %}
+      {% endif %}
       {% block env %}
       {% endblock %}
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -49,3 +49,6 @@ router:
 
 search-api:
   instances: 2
+
+env:
+  DM_USE_REDIS_SESSION_TYPE: true

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -51,4 +51,4 @@ search-api:
   instances: 2
 
 env:
-  DM_USE_REDIS_SESSION_TYPE: true
+  DM_USE_REDIS_SESSION_TYPE: "true"


### PR DESCRIPTION
https://trello.com/c/0XO8CHaP/381-05-stand-up-the-paas-infrastructure-for-the-preview-environment

We want to test redis initially on preview only. This is behind an env var. To set this on preview only this also introduces some logic to allow per-environment additions to the env block of the manifest.

I have tested this using `make generate-manifest`