### PR TITLE
Revert "enable redis env var on preview only"

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -34,11 +34,6 @@ applications:
 
       DM_LOG_PATH: ''
 
-      {% if env|default([])|length > 0 %}
-        {% for k, v in env.items() %}
-      {{ k }}: {{ v }}
-        {% endfor %}
-      {% endif %}
       {% block env %}
       {% endblock %}
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -49,6 +49,3 @@ router:
 
 search-api:
   instances: 2
-
-env:
-  DM_USE_REDIS_SESSION_TYPE: "true"


### PR DESCRIPTION
Revert whilst investigating why this broke deployment.

Reverts alphagov/digitalmarketplace-aws#769