### PR TITLE
Revert "re-enable redis env var on preview"

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -34,11 +34,6 @@ applications:
 
       DM_LOG_PATH: ''
 
-      {% if env|default([])|length > 0 %}
-        {% for k, v in env.items() %}
-      {{ k }}: {{ v }}
-        {% endfor %}
-      {% endif %}
       {% block env %}
       {% endblock %}
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -49,6 +49,3 @@ router:
 
 search-api:
   instances: 2
-
-env:
-  DM_USE_REDIS_SESSION_TYPE: "true"


### PR DESCRIPTION
Revert this so we don't continue blocking the pipeline.
Reverts alphagov/digitalmarketplace-aws#771