### PR TITLE
Document need to update production rate limit

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -4,6 +4,8 @@ maintenance_mode: live
 instances: 5
 
 router:
+  # If you change the number of router instances, update the per-instance rate limit to keep the overall rate limit the
+  # same. See digitalmarketplace-router/templates/nginx.conf.j2#L53
   instances: 6
   rate_limiting_enabled: enabled
   routes:


### PR DESCRIPTION
Trello: https://trello.com/c/guiQfAf8/1456-our-request-rate-limit-varies-depending-on-the-number-of-router-apps-deployed

nginx does rate limiting on a per-instance basis. So if you increase the number of instances, you need to decrease the rte limit so that the overall rate limit stays the same. Add a comment reminding people to do this.

The same thing could also apply for other environments, but we only really care about production.