### PR TITLE
Scale up production for DOS5 closing

### DIFF
--- a/vars/production.yml
+++ b/vars/production.yml
@@ -16,25 +16,27 @@ router:
     - assets.digitalmarketplace.service.gov.uk
 
 api:
-  memory: 2GB
-  instances: 10
+  memory: 4GB
+  instances: 20
 
 user-frontend:
-  instances: 2
+  instances: 4
 
 admin-frontend:
   instances: 2
   memory: 1GB
 
 antivirus-api:
-  instances: 4
+  instances: 8
+  memory: 4GB
 
 buyer-frontend:
+  instances: 10
   memory: 1G
 
 search-api:
   memory: 1G
 
 supplier-frontend:
-  instances: 10
-  memory: 1GB
+  instances: 40
+  memory: 4GB


### PR DESCRIPTION
DOS5 closes for applications at 1pm GMT November 17th. Scale the production environment up so we can handle the expected additional traffic. Decisions explained in the relevant [DRD](https://docs.google.com/document/d/18aKH60ojA0IVWjtAiLmxNRxcTeGnwWCofOAVn21Q0mM/) (GDS only)

https://trello.com/c/H2BFCt6l/535-05-scale-platform-manually-for-dos5