### PR TITLE
re-enable redis env var on preview

### DIFF
--- a/paas/_base.j2
+++ b/paas/_base.j2
@@ -34,6 +34,11 @@ applications:
 
       DM_LOG_PATH: ''
 
+      {% if env|default([])|length > 0 %}
+        {% for k, v in env.items() %}
+      {{ k }}: {{ v }}
+        {% endfor %}
+      {% endif %}
       {% block env %}
       {% endblock %}
 

--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -49,3 +49,6 @@ router:
 
 search-api:
   instances: 2
+
+env:
+  DM_USE_REDIS_SESSION_TYPE: "true"


### PR DESCRIPTION
https://trello.com/c/yS6OcI31/382-2-run-the-new-user-session-management-on-the-preview-environment-temporarily-for-testing
Reverts alphagov/digitalmarketplace-aws#772
Enable this again following the changes in https://github.com/alphagov/digitalmarketplace-utils/pull/586
3rd time lucky? 🤞 