### PR TITLE
Revert "temporarily disable rate limiting"

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -7,7 +7,7 @@ api:
   memory: 2GB
 
 router:
-  rate_limiting_enabled: disabled
+  rate_limiting_enabled: enabled
 
 buyer-frontend:
   services:


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-aws#781
https://trello.com/c/2qF5k1Xx/570-1-run-performance-tests-against-staging-for-the-new-user-session-management-tbc
We can re-enable rate limiting now we've concluded performance tests. 