### PR TITLE
Change Jenkins disk space alarms to use Minimum

### DIFF
--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -27,9 +27,10 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
   period             = "300"
 
   // If totals 10gb or lower (in bytes)
-  statistic           = "Sum"
+  statistic           = "Minimum"
   comparison_operator = "LessThanOrEqualToThreshold"
   threshold           = "10000000000"
+  datapoints_to_alarm = 1
 
   // Email slack
   alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]
@@ -53,9 +54,10 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
   period             = "300"
 
   // If totals 1gb or lower (in bytes)
-  statistic           = "Sum"
+  statistic           = "Minimum"
   comparison_operator = "LessThanOrEqualToThreshold"
   threshold           = "1000000000"
+  datapoints_to_alarm = 1
 
   // Email slack
   alarm_actions = ["${module.alarm_email_sns.email_topic_arn}"]


### PR DESCRIPTION
This was changed in the AWS console by @bjgill as part of
https://trello.com/c/tlhoS1vi/2088-disk-space-alarms-for-jenkins-are-reporting-incorrect-values

Update the config in Terraform as well so we don't revert the changes when making future infrastructure changes. I added the `datapoints_to_alarm` variable because Terraform was complaining without it and we do want to alarm when we get 1 datapoint:

```
Error: aws_cloudwatch_metric_alarm.jenkins_data_volume_disk_space: expected datapoints_to_alarm to be at least (1), got 0
```