### PR TITLE
Pass list of suppliers to apps

### DIFF
--- a/paas/api.j2
+++ b/paas/api.j2
@@ -10,4 +10,6 @@
 
       DM_SEARCH_API_AUTH_TOKEN: {{ search_api.auth_tokens[0] }}
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
+
+      DM_G12_RECOVERY_SUPPLIER_IDS: {{ g12_recovery_supplier_ids|join(',') }}
 {% endblock %}

--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -31,4 +31,6 @@
       DM_MAILCHIMP_API_KEY: {{ supplier_frontend.mailchimp_api_key }}
       DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID: {{ supplier_frontend.mailchimp_open_framework_notification_mailing_list_id }}
       DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
+
+      DM_G12_RECOVERY_SUPPLIER_IDS: {{ g12_recovery_supplier_ids|join(',') }}
 {% endblock %}


### PR DESCRIPTION
Trello: https://trello.com/c/KikQx3R2/

We will be using this configuration to show the G12 recovery process only to the suppliers involved.

Environment variables must be strings, so convert the list to a comma-separated string.

This relies on https://github.com/alphagov/digitalmarketplace-credentials/pull/359, which adds the necessary fields into the credentials.