### PR TITLE
remove redis env var

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -107,6 +107,3 @@ db-migration:
   memory: 128M
   services:
     - digitalmarketplace_api_db
-
-env:
-  DM_USE_REDIS_SESSION_TYPE: "true"


### PR DESCRIPTION
We can remove this as it is now enabled by default.