### PR TITLE
Remove ITHC IAM user and Jenkins instance

### DIFF
--- a/terraform/accounts/main/jenkins.tf
+++ b/terraform/accounts/main/jenkins.tf
@@ -22,20 +22,6 @@ module "jenkins_2" {
   log_bucket_name                   = "${module.jenkins_elb_log_bucket.bucket_id}"
 }
 
-module "jenkins_3" {
-  source                            = "../../modules/jenkins/jenkins"
-  name                              = "jenkins2"
-  aws_account_and_jenkins_login_ips = "${var.aws_account_and_jenkins_login_ips}"
-  jenkins_public_key_name           = "${aws_key_pair.jenkins.key_name}"
-  jenkins_instance_profile          = "${aws_iam_instance_profile.jenkins.name}"
-  jenkins_wildcard_elb_cert_arn     = "${aws_acm_certificate.jenkins_wildcard_elb_certificate.arn}"
-  ami_id                            = "ami-01e6a0b85de033c99"
-  instance_type                     = "t3.large"
-  dns_zone_id                       = "${aws_route53_zone.marketplace_team.zone_id}"
-  dns_name                          = "ci2.marketplace.team"
-  log_bucket_name                   = "${module.jenkins_elb_log_bucket.bucket_id}"
-}
-
 module "jenkins_snapshots" {
   source = "../../modules/jenkins/snapshots"
 }

--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -43,7 +43,3 @@ resource "aws_iam_user" "alex_smith" {
   force_destroy = true
 }
 
-resource "aws_iam_user" "fidus_infotech" {
-  name          = "fidus_infotech"
-  force_destroy = true
-}


### PR DESCRIPTION
https://trello.com/c/xtHL9yV1/603-1-clean-up-after-pentesting

The ITHC company has finished their work so we can remove their IAM account and the Jenkins instance we stood up for them to test against.

The `SecurityAudit` group and roles are still in place for next year - I will find somewhere suitable to document these to save us time in the future.