### PR TITLE
use curl to perform backup upload

### DIFF
--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -2,17 +2,17 @@ FROM python:3.6.1-slim
 
 RUN mkdir /app
 
-COPY /create-db-dump.sh /app/create-db-dump.sh
-COPY /upload-dump-to-s3.py /app/upload-dump-to-s3.py
-
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends gnupg2 jq wget vim && \
+    apt-get install -y --no-install-recommends gnupg2 jq wget vim curl && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
       apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends postgresql-client-9.5 && \
     pip install requests
+
+COPY /create-db-dump.sh /app/create-db-dump.sh
+COPY /upload-dump-to-s3.py /app/upload-dump-to-s3.py
 
 CMD ["tail", "-f", "/dev/null"]

--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -9,9 +9,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
       apt-key add - && \
     apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-9.5 && \
-    pip install requests
-
+    apt-get install -y --no-install-recommends postgresql-client-9.5
 COPY /create-db-dump.sh /app/create-db-dump.sh
 COPY /upload-dump-to-s3.py /app/upload-dump-to-s3.py
 

--- a/db-backup/upload-dump-to-s3.py
+++ b/db-backup/upload-dump-to-s3.py
@@ -21,7 +21,7 @@ def upload_dump_to_s3():
         response = subprocess.check_output(curl_args)
         print(response)
     except subprocess.CalledProcessError as e:
-        raise Exception(f"Upload failed with error: " + e.output)
+        raise Exception(f"Upload failed with error: {e.output}")
 
     print('Successfully uploaded {} to {}'.format(dump_file, url))
 

--- a/db-backup/upload-dump-to-s3.py
+++ b/db-backup/upload-dump-to-s3.py
@@ -1,32 +1,29 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import json
-import requests
-from requests.exceptions import HTTPError
+import subprocess
 
 
 def upload_dump_to_s3():
     s3_post_url_data = json.loads(os.environ['S3_POST_URL_DATA'])
     dump_file = "/app/{}".format(os.environ['DUMP_FILE_NAME'])
-
     url = s3_post_url_data['url']
     fields = s3_post_url_data['fields']
-    files = {"file": open(dump_file, 'rb')}
-
-    response = requests.post(url, data=fields, files=files)
-
+    curl_args = ['curl', '--fail']
+    for k, v in fields.items():
+        curl_args.append('-F')
+        curl_args.append(f"{k}={v}")
+    curl_args.append('-F')
+    curl_args.append(f"file=@{dump_file}")
+    curl_args.append(url)
     try:
-        response.raise_for_status()
-    except HTTPError as e:
-        print("Error uploading {} to {}: {}".format(dump_file, url, e.args[0]))
-        sys.exit(1)
-    except Exception as e:
-        print("Error uploading: {}".format(e))
-        sys.exit(2)
-    else:
-        print('Successfully uploaded {} to {}'.format(dump_file, url))
+        response = subprocess.check_output(curl_args)
+        print(response)
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Upload failed with error: " + e.output)
+
+    print('Successfully uploaded {} to {}'.format(dump_file, url))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
use `curl` to perform backup upload to workaround python error

https://trello.com/c/dG5psGPK/2070-production-database-backup-failing

# Notes

* This will need to be manually pushed to the Docker tag once merged, I have run it against a tag and you can see that output on Jenkins here: https://ci.marketplace.team/job/database-backup/
* I have made a separate card to address the issues around the other image dependencies being very out of date which is here https://trello.com/c/mZ1ZDfS1 this is a known issue as described in: https://alphagov.github.io/digitalmarketplace-manual/developing-the-digital-marketplace/docker-strategies.html#manually-managed