### PR TITLE
Remove router prometheus metrics

### DIFF
--- a/vars/common.yml
+++ b/vars/common.yml
@@ -1,15 +1,12 @@
 ---
 router:
   routes:
-    - dm-router-{env}.cloudapps.digital
-    - dm-router-{env}.cloudapps.digital/_metrics
     - www.{env}.marketplace.team
     - api.{env}.marketplace.team
     - search-api.{env}.marketplace.team
     - antivirus-api.{env}.marketplace.team
     - assets.{env}.marketplace.team
   services:
-    - digitalmarketplace_prometheus 
     - digitalmarketplace_splunk
 
 api:
@@ -18,7 +15,7 @@ api:
     - dm-api-{env}.cloudapps.digital/_metrics
   services:
     - digitalmarketplace_api_db
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 search-api:
@@ -27,7 +24,7 @@ search-api:
     - dm-search-api-{env}.cloudapps.digital/_metrics
   services:
     - search_api_elasticsearch
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 antivirus-api:
@@ -36,7 +33,7 @@ antivirus-api:
     - dm-antivirus-api-{env}.cloudapps.digital
     - dm-antivirus-api-{env}.cloudapps.digital/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
 
 user-frontend:
@@ -44,7 +41,7 @@ user-frontend:
     - dm-{env}.cloudapps.digital/user
     - dm-{env}.cloudapps.digital/user/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -53,7 +50,7 @@ admin-frontend:
     - dm-{env}.cloudapps.digital/admin
     - dm-{env}.cloudapps.digital/admin/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -64,7 +61,7 @@ buyer-frontend:
     - dm-{env}.cloudapps.digital/_metrics
     - dm-{env}.cloudapps.digital/buyers/direct-award
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -74,7 +71,7 @@ supplier-frontend:
     - dm-{env}.cloudapps.digital/suppliers
     - dm-{env}.cloudapps.digital/suppliers/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -83,7 +80,7 @@ briefs-frontend:
     - dm-{env}.cloudapps.digital/buyers
     - dm-{env}.cloudapps.digital/buyers/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 
@@ -92,7 +89,7 @@ brief-responses-frontend:
     - dm-{env}.cloudapps.digital/suppliers/opportunities
     - dm-{env}.cloudapps.digital/suppliers/opportunities/_metrics
   services:
-    - digitalmarketplace_prometheus 
+    - digitalmarketplace_prometheus
     - digitalmarketplace_splunk
     - digitalmarketplace_redis
 

--- a/vars/ip_whitelist_routes.json
+++ b/vars/ip_whitelist_routes.json
@@ -1,6 +1,5 @@
 {
   "preview": {
-    "router": [{"hostname": "dm-router-preview", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-preview", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-preview", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-preview", "path": "/_metrics"}],
@@ -12,7 +11,6 @@
     "user-frontend": [{"hostname": "dm-preview", "path": "/user/_metrics"}]
   },
   "staging": {
-    "router": [{"hostname": "dm-router-staging", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-staging", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-staging", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-staging", "path": "/_metrics"}],
@@ -24,7 +22,6 @@
     "user-frontend": [{"hostname": "dm-staging", "path": "/user/_metrics"}]
   },
   "production": {
-    "router": [{"hostname": "dm-router-production", "path": "/_metrics"}],
     "api": [{"hostname": "dm-api-production", "path": "/_metrics"}],
     "search-api": [{"hostname": "dm-search-api-production", "path": "/_metrics"}],
     "antivirus-api": [{"hostname": "dm-antivirus-api-production", "path": "/_metrics"}],

--- a/vars/production.yml
+++ b/vars/production.yml
@@ -9,8 +9,6 @@ router:
   instances: 6
   rate_limiting_enabled: enabled
   routes:
-    - dm-router-{env}.cloudapps.digital
-    - dm-router-{env}.cloudapps.digital/_metrics
     - www.digitalmarketplace.service.gov.uk
     - api.digitalmarketplace.service.gov.uk
     - search-api.digitalmarketplace.service.gov.uk


### PR DESCRIPTION
This reverts commit 1f63c17bb66fbd75fefdb26a14f9a8db806f9158.

We have found that we don't use the metrics from nginx ever, and the metrics exporter often causes a lot of alarms because it doesn't start reliably.

@gidsg and I agreed that we should just remove the metrics.

Once this PR has been merged and the router has been redeployed on all stages we can merge alphagov/digitalmarketplace-router#98.