### PR TITLE
Update postgresql in `make run-postgres-container` from 9.5 to 10.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ run-postgres-container: ## Runs a postgres container
 	docker stop ${POSTGRES_NAME} || true
 	docker rm -v ${POSTGRES_NAME} || true
 
-	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:9.5-alpine
+	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:10.13-alpine
 
 .PHONY: import-and-clean-db-dump
 import-and-clean-db-dump: virtualenv ## Connects to the postgres container, imports the latest dump and cleans it.

--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -1,15 +1,11 @@
-FROM python:3.6.1-slim
+FROM python:3.6-slim
 
 RUN mkdir /app
 
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' > /etc/apt/sources.list.d/pgdg.list && \
-    apt-get update && \
+RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends gnupg2 jq wget vim curl && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
-      apt-key add - && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends postgresql-client-9.5
+    apt-get install -y --no-install-recommends gnupg2 jq wget vim curl postgresql-client
+
 COPY /create-db-dump.sh /app/create-db-dump.sh
 COPY /upload-dump-to-s3.py /app/upload-dump-to-s3.py
 


### PR DESCRIPTION
We are now using PostgreSQL 10.13 in production, we should make sure our database backup pipeline uses the same or newer version.

I have verfied that the Docker images involved exist and can be built, once this PR is approved I will push `digitalmarketplace/db-backup` to Docker Hub.