### PR TITLE
Pass list of draft services to supplier-frontend

### DIFF
--- a/paas/supplier-frontend.j2
+++ b/paas/supplier-frontend.j2
@@ -32,5 +32,6 @@
       DM_MAILCHIMP_OPEN_FRAMEWORK_NOTIFICATION_MAILING_LIST_ID: {{ supplier_frontend.mailchimp_open_framework_notification_mailing_list_id }}
       DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
 
+      DM_G12_RECOVERY_DRAFT_IDS: {{ g12_recovery_draft_ids|join(',') }}
       DM_G12_RECOVERY_SUPPLIER_IDS: {{ g12_recovery_supplier_ids|join(',') }}
 {% endblock %}


### PR DESCRIPTION
Trello: https://trello.com/c/13Ryt5o5/679-5-as-a-supplier-i-cannot-see-submit-any-draft-services-that-ccs-will-not-consider

We will be using this configuration to hide draft services not involved in the G12 recovery process.

Environment variables must be strings, so convert the list to a comma-separated string.

This relies on https://github.com/alphagov/digitalmarketplace-credentials/pull/366, which adds the necessary fields into the credentials.