### PR TITLE
Add terraform testing to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Ubuntu packages
-        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev terraform=$(cat terraform/.terraform-version)
+        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -30,6 +30,17 @@ jobs:
       - name: Run Python tests
         run: make test
 
+  terraform_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Terraform
+        run: |
+          brew install tfenv
+          tfenv install
+
       - name: Validate terraform
         run: |
           make terraformatest
+          make test-terraform

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,12 @@ jobs:
           brew install tfenv
           tfenv install
 
+      - name: Setup Terraform cache
+        uses: actions/cache@v2
+        with:
+          path: "**/.terraform"
+          key: terraform-${{ runner.os }}-${{ hashFiles('**/.terraform-version') }}
+
       - name: Validate terraform
         run: |
           make terraformatest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Ubuntu packages
-        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev
+        run: sudo apt-get install libxml2-dev libxslt1-dev python-dev terraform=$(cat terraform/.terraform-version)
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -27,5 +27,9 @@ jobs:
       - name: Install dependencies
         run: make requirements-dev
 
-      - name: Run tests
+      - name: Run Python tests
         run: make test
+
+      - name: Validate terraform
+        run: |
+          make terraformatest

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: test-flake8 test-unit
 
 .PHONY: terraformat
 terraformat:
-	terraform fmt -list=true -diff=true -write=true terraform
+	terraform fmt -list=true -diff=true -write=true -recursive terraform
 
 .PHONY: terraformatest
 terraformatest:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ terraformat:
 terraformatest:
 	./scripts/check-terraform-formatting.sh
 
+.PHONY: test-terraform
+test-terraform:
+	./scripts/validate-terraform.sh
+
 .PHONY: test-flake8
 test-flake8: virtualenv
 	${VIRTUALENV_ROOT}/bin/flake8 .

--- a/scripts/check-terraform-formatting.sh
+++ b/scripts/check-terraform-formatting.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-LINT_OUTPUT=$(terraform fmt -write=false -list=true -diff=true terraform)
+LINT_OUTPUT=$(terraform fmt -write=false -list=true -diff=true -recursive terraform)
 if [ ! -z "${LINT_OUTPUT}" ]; then
   echo "${LINT_OUTPUT}"
-  echo "Terraform formatting check has FAILED. Fix formatting issues with \`terraform fmt -write=true -list=true -diff=true terraform\` from the root of the repository."
+  echo "Terraform formatting check has FAILED. Fix formatting issues with \`terraform fmt -write=true -list=true -diff=true -recursive terraform\` from the root of the repository."
   exit 1
 fi
 

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eou pipefail
+
+function validate() {
+  validate_path=$1
+
+  echo $validate_path
+  cd $validate_path
+
+  if [ ! -e .terraform ]
+  then
+    terraform init -backend=false
+  fi
+
+  terraform validate
+  cd - > /dev/null
+}
+
+for account in terraform/accounts/*
+do
+  validate $account
+done
+
+for environment in terraform/environments/*
+do
+  validate $environment
+done

--- a/scripts/validate-terraform.sh
+++ b/scripts/validate-terraform.sh
@@ -7,8 +7,9 @@ function validate() {
   echo $validate_path
   cd $validate_path
 
-  if [ ! -e .terraform ]
+  if [ ! -e .terraform/terraform.tfstate ]
   then
+    # Has never been initialised with AWS access, so we can safely (re-)initialise without AWS access.
     terraform init -backend=false
   fi
 

--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
 
   // Email slack
   alarm_actions = [module.alarm_email_sns.email_topic_arn]
-  ok_actions = [module.alarm_recovery_email_sns.email_topic_arn]
+  ok_actions    = [module.alarm_recovery_email_sns.email_topic_arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
@@ -61,6 +61,6 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
 
   // Email slack
   alarm_actions = [module.alarm_email_sns.email_topic_arn]
-  ok_actions = [module.alarm_recovery_email_sns.email_topic_arn]
+  ok_actions    = [module.alarm_recovery_email_sns.email_topic_arn]
 }
 

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "eu-west-1"
+  region = "eu-west-1"
 }
 
 resource "aws_iam_account_alias" "alias" {

--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -88,6 +88,6 @@ resource "aws_cloudwatch_metric_alarm" "log_stream_lambda_error_alarm" {
 
   // Email slack
   alarm_actions = [module.alarm_email_sns.email_topic_arn]
-  ok_actions = [module.alarm_recovery_email_sns.email_topic_arn]
+  ok_actions    = [module.alarm_recovery_email_sns.email_topic_arn]
 }
 


### PR DESCRIPTION
Inspired by [a recent PR](https://github.com/alphagov/digitalmarketplace-aws/pull/750), where we wasted a lot of time on manual testing.

Add a script that we run in CI. This will check that our terraform code is syntactically correct, internally consistent, and properly formatted. It does not try to access external state, so is safe to run in CI.

Needs Terraform 0.12, so this PR depends on https://github.com/alphagov/digitalmarketplace-aws/pull/750