### PR TITLE
Revert "bump postgres container version"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ run-postgres-container: ## Runs a postgres container
 	docker stop ${POSTGRES_NAME} || true
 	docker rm -v ${POSTGRES_NAME} || true
 
-	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:12-alpine
+	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:10.13-alpine
 
 .PHONY: import-and-clean-db-dump
 import-and-clean-db-dump: virtualenv ## Connects to the postgres container, imports the latest dump and cleans it.


### PR DESCRIPTION
The upgrade to postgres 12 failed. So, until that's fixed, we're back on postgres 10.

Reverts alphagov/digitalmarketplace-aws#827