### PR TITLE
Upgrade backup task for postgres 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	$(eval export S3_POST_URL_DATA=$(shell ${VIRTUALENV_ROOT}/bin/python ./scripts/generate-s3-post-url-data.py digitalmarketplace-database-backups ${DUMP_FILE_NAME}))
 
 	# Deploy the backup app
-	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup --no-route
+	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup:pg-12 --no-route
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"
 	cf restage db-backup
 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ deploy-db-backup-app: virtualenv ## Deploys the db backup app
 	$(eval export S3_POST_URL_DATA=$(shell ${VIRTUALENV_ROOT}/bin/python ./scripts/generate-s3-post-url-data.py digitalmarketplace-database-backups ${DUMP_FILE_NAME}))
 
 	# Deploy the backup app
-	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup:pg-12 --no-route
+	cf push db-backup -f <(make -s -C ${CURDIR} generate-manifest ARGS="-v DUMP_FILE_NAME -v S3_POST_URL_DATA") -o digitalmarketplace/db-backup --no-route
 	cf set-env db-backup PUBKEY "$$(cat ${DM_CREDENTIALS_REPO}/gpg/database-backups/public.key)"
 	cf restage db-backup
 

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ run-postgres-container: ## Runs a postgres container
 	docker stop ${POSTGRES_NAME} || true
 	docker rm -v ${POSTGRES_NAME} || true
 
-	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:10.13-alpine
+	docker run -d -p 63306:5432 -e POSTGRES_PASSWORD --name ${POSTGRES_NAME} postgres:12-alpine
 
 .PHONY: import-and-clean-db-dump
 import-and-clean-db-dump: virtualenv ## Connects to the postgres container, imports the latest dump and cleans it.

--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6.12-slim
 
 RUN mkdir /app
 

--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -4,7 +4,19 @@ RUN mkdir /app
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends gnupg2 jq wget vim curl postgresql-client
+    apt-get install -y --no-install-recommends gnupg2 jq wget vim curl 
+
+# Create the file repository configuration:
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+# Import the repository signing key:
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Update the package lists:
+RUN apt-get update
+
+# Install the version of PostgreSQL.
+RUN apt-get -y install postgresql-client-12
 
 COPY /create-db-dump.sh /app/create-db-dump.sh
 COPY /upload-dump-to-s3.py /app/upload-dump-to-s3.py

--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.12-slim
+FROM python:3.6.13-slim
 
 RUN mkdir /app
 


### PR DESCRIPTION
https://trello.com/c/mZ1ZDfS1/791-3-db-backup-app-is-running-end-of-life-os

Updates container and client to use postgres 12. Have tested successfully against preview: https://ci.marketplace.team/job/database-backup/1393/

## Notes
* `postgresql-client-12` is not available in the default package repository, therefore this adds the postgres repository as per the guidance in: https://www.postgresql.org/download/linux/ubuntu/
* This should not be merged until Postgres 12 has been rolled out to all environments 
* I will push the docker image once this PR is merged
