### PR TITLE
Update CodeCommit repository default branches

### DIFF
--- a/terraform/accounts/main/codecommit.tf
+++ b/terraform/accounts/main/codecommit.tf
@@ -1,45 +1,107 @@
 variable "alphagov_git_repositories" {
-  type = list(string)
+  type = map(object({
+    default_branch = string
+  }))
 
-  default = [
-    "digitalmarketplace-api",
-    "digitalmarketplace-search-api",
-    "digitalmarketplace-admin-frontend",
-    "digitalmarketplace-agreements",
-    "digitalmarketplace-antivirus-api",
-    "digitalmarketplace-apiclient",
-    "digitalmarketplace-aws",
-    "digitalmarketplace-bad-words",
-    "digitalmarketplace-brief-responses-frontend",
-    "digitalmarketplace-briefs-frontend",
-    "digitalmarketplace-buyer-frontend",
-    "digitalmarketplace-content-loader",
-    "digitalmarketplace-credentials",
-    "digitalmarketplace-docker-base",
-    "digitalmarketplace-frameworks",
-    "digitalmarketplace-frontend-toolkit",
-    "digitalmarketplace-functional-tests",
-    "digitalmarketplace-jenkins",
-    "digitalmarketplace-maintenance",
-    "digitalmarketplace-manual",
-    "digitalmarketplace-performance-testing",
-    "digitalmarketplace-router",
-    "digitalmarketplace-runner",
-    "digitalmarketplace-scripts",
-    "digitalmarketplace-supplier-frontend",
-    "digitalmarketplace-test-utils",
-    "digitalmarketplace-user-frontend",
-    "digitalmarketplace-utils",
-    "digitalmarketplace-visual-regression",
-    "digitalmarketplace-govuk-frontend",
-  ]
+  default = {
+    digitalmarketplace-api = {
+      default_branch = "master"
+    },
+    digitalmarketplace-search-api = {
+      default_branch = "master"
+    },
+    digitalmarketplace-admin-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-agreements = {
+      default_branch = "master"
+    },
+    digitalmarketplace-antivirus-api = {
+      default_branch = "master"
+    },
+    digitalmarketplace-apiclient = {
+      default_branch = "master"
+    },
+    digitalmarketplace-aws = {
+      default_branch = "master"
+    },
+    digitalmarketplace-bad-words = {
+      default_branch = "master"
+    },
+    digitalmarketplace-brief-responses-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-briefs-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-buyer-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-content-loader = {
+      default_branch = "master"
+    },
+    digitalmarketplace-credentials = {
+      default_branch = "master"
+    },
+    digitalmarketplace-docker-base = {
+      default_branch = "master"
+    },
+    digitalmarketplace-frameworks = {
+      default_branch = "main"
+    },
+    digitalmarketplace-frontend-toolkit = {
+      default_branch = "master"
+    },
+    digitalmarketplace-functional-tests = {
+      default_branch = "master"
+    },
+    digitalmarketplace-jenkins = {
+      default_branch = "main"
+    },
+    digitalmarketplace-maintenance = {
+      default_branch = "master"
+    },
+    digitalmarketplace-manual = {
+      default_branch = "master"
+    },
+    digitalmarketplace-performance-testing = {
+      default_branch = "master"
+    },
+    digitalmarketplace-router = {
+      default_branch = "master"
+    },
+    digitalmarketplace-runner = {
+      default_branch = "main"
+    },
+    digitalmarketplace-scripts = {
+      default_branch = "master"
+    },
+    digitalmarketplace-supplier-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-test-utils = {
+      default_branch = "main"
+    },
+    digitalmarketplace-user-frontend = {
+      default_branch = "master"
+    },
+    digitalmarketplace-utils = {
+      default_branch = "master"
+    },
+    digitalmarketplace-visual-regression = {
+      default_branch = "master"
+    },
+    digitalmarketplace-govuk-frontend = {
+      default_branch = "master"
+    },
+  }
 }
 
 resource "aws_codecommit_repository" "codecommit_backup_repos" {
-  count = length(var.alphagov_git_repositories)
+  for_each = var.alphagov_git_repositories
 
-  repository_name = var.alphagov_git_repositories[count.index]
-  description     = "Backup CodeCommit repo for github.com/alphagov/${var.alphagov_git_repositories[count.index]}"
-  default_branch  = "master"
+  repository_name = each.key
+  description     = "Backup CodeCommit repo for github.com/alphagov/${each.key}"
+  default_branch  = each.value["default_branch"]
 }
 


### PR DESCRIPTION
We've started to change our default git branches from `master` to `main`. Update our Terraform configuration to be able to handle different default branch names, and update the branch names for the repos we've already changed.

Also switch to the new (in 0.12.6) `for_each` Terraform operator which makes things a bit easier.

Applying these changes will destroy and re-create all of our CodeCommit resources because they're currently saved in the Terraform state by list index, and this PR changes each repo to a map key. I have checked the Jenkins job which does the backup and I don't think this will cause problems, but I'll run the job after applying to make sure.

I'll also add an item to the 'Tasks per-repo' check list on the attached Trello card to remind us to also update this file with the new default branch name.

https://trello.com/c/DrVWMkcZ/2169-rename-default-branches-on-our-repos-from-master-to-main