### PR TITLE
Add digitalmarketplace-developer-tools to CodeCommit backups

### DIFF
--- a/terraform/accounts/main/codecommit.tf
+++ b/terraform/accounts/main/codecommit.tf
@@ -94,6 +94,9 @@ variable "alphagov_git_repositories" {
     digitalmarketplace-govuk-frontend = {
       default_branch = "master"
     },
+    digitalmarketplace-developer-tools = {
+      default_branch = "main"
+    },
   }
 }
 


### PR DESCRIPTION
We recently created a new repo - [digitalmarketplace-developer-tools](https://github.com/alphagov/digitalmarketplace-developer-tools)
Add this repo to our CodeCommit backups so we have a copy in case something disastrous happens to Github.