### PR TITLE
Remove 'louiseryan' AWS user

### DIFF
--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -3,11 +3,6 @@ resource "aws_iam_user" "argyris_galamatis" {
   force_destroy = true
 }
 
-resource "aws_iam_user" "louise_ryan" {
-  name          = "louiseryan"
-  force_destroy = true
-}
-
 resource "aws_iam_user" "laurence_de_bruxelles" {
   name          = "laurencedebruxelles"
   force_destroy = true


### PR DESCRIPTION
Louise stayed with GDS and so is no longer our Lead TA. We've already removed them from the groups allowing access to anything in https://github.com/alphagov/digitalmarketplace-credentials/pull/369 so it's safe to also remove the AWS account.

https://trello.com/c/i0mmpFna/885-1-address-ithc-issue-649-credentials-unused-for-90-days-or-greater-are-not-disabled