### PR TITLE
Upgrade Terraform AWS provider to v3.34.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ terraformatest:
 
 .PHONY: test-terraform
 test-terraform:
+	$(eval export AWS_DEFAULT_REGION=eu-west-2)
 	./scripts/validate-terraform.sh
 
 .PHONY: test-flake8

--- a/terraform/accounts/backups/main.tf
+++ b/terraform/accounts/backups/main.tf
@@ -1,8 +1,4 @@
 provider "aws" {
-  region = "eu-west-1"
-}
-
-provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
@@ -23,6 +19,13 @@ module "cyber_security_audit_role" {
 }
 
 terraform {
+    required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-backups"
     key     = "accounts/backups/terraform.tfstate"

--- a/terraform/accounts/backups/s3_buckets.tf
+++ b/terraform/accounts/backups/s3_buckets.tf
@@ -2,7 +2,6 @@ resource "aws_s3_bucket" "cross_region_database_backups_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-database-backups"
   acl      = "private"
-  region   = "eu-west-2"
 
   versioning {
     enabled = true

--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -1,12 +1,15 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
 resource "aws_iam_account_alias" "alias" {
   account_alias = "digitalmarketplace-development"
 }
 
 terraform {
+    required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-development"
     key     = "accounts/development/terraform.tfstate"

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -1,12 +1,15 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
-resource "aws_iam_account_alias" "alias" {
+  resource "aws_iam_account_alias" "alias" {
   account_alias = "digitalmarketplace"
 }
 
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-main"
     key     = "accounts/main/terraform.tfstate"

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -1,12 +1,15 @@
-provider "aws" {
-  region = "eu-west-1"
-}
-
 resource "aws_iam_account_alias" "alias" {
   account_alias = "digitalmarketplace-production"
 }
 
 terraform {
+    required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-production"
     key     = "accounts/production/terraform.tfstate"

--- a/terraform/environments/preview/main.tf
+++ b/terraform/environments/preview/main.tf
@@ -1,14 +1,16 @@
 provider "aws" {
-  region  = "eu-west-1"
-  version = "2.70"
-}
-
-provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
 
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-development"
     key     = "environments/preview/terraform.tfstate"

--- a/terraform/environments/preview/s3_replication_buckets.tf
+++ b/terraform/environments/preview/s3_replication_buckets.tf
@@ -35,7 +35,6 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-documents-preview-preview"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_documents_s3_bucket_policy_document.json
 
   versioning {
@@ -78,7 +77,6 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-agreements-preview-preview"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_agreements_s3_bucket_policy_document.json
 
   versioning {
@@ -121,7 +119,6 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-communications-preview-preview"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_communications_s3_bucket_policy_document.json
 
   versioning {
@@ -164,7 +161,6 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-submissions-preview-preview"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_submissions_s3_bucket_policy_document.json
 
   versioning {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -1,14 +1,16 @@
 provider "aws" {
-  region  = "eu-west-1"
-  version = "2.70"
-}
-
-provider "aws" {
   alias  = "london"
   region = "eu-west-2"
 }
 
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-production"
     key     = "environments/production/terraform.tfstate"

--- a/terraform/environments/production/s3_replication_buckets.tf
+++ b/terraform/environments/production/s3_replication_buckets.tf
@@ -34,7 +34,6 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-documents-production"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_documents_s3_bucket_policy_document.json
 
   versioning {
@@ -77,7 +76,6 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-agreements-production"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_agreements_s3_bucket_policy_document.json
 
   versioning {
@@ -120,7 +118,6 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-communications-production"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_communications_s3_bucket_policy_document.json
 
   versioning {
@@ -163,7 +160,6 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
   provider = aws.london
   bucket   = "digitalmarketplace-cross-region-submissions-production"
   acl      = "private"
-  region   = "eu-west-2"
   policy   = data.aws_iam_policy_document.cross_region_submissions_s3_bucket_policy_document.json
 
   versioning {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,9 +1,11 @@
-provider "aws" {
-  region  = "eu-west-1"
-  version = "2.70"
-}
-
 terraform {
+    required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.34.0"
+      region  = "eu-west-1"
+    }
+  }
   backend "s3" {
     bucket  = "digitalmarketplace-terraform-state-production"
     key     = "environments/staging/terraform.tfstate"

--- a/terraform/modules/antivirus-sns/main.tf
+++ b/terraform/modules/antivirus-sns/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_sns_topic" "s3_file_upload_notification" {

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 module "cloudtrail-bucket" {

--- a/terraform/modules/iam-common/main.tf
+++ b/terraform/modules/iam-common/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 data "aws_caller_identity" "current" {

--- a/terraform/modules/jenkins/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/jenkins/ec2.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_instance" "jenkins" {

--- a/terraform/modules/jenkins/log_bucket/s3_bucket.tf
+++ b/terraform/modules/jenkins/log_bucket/s3_bucket.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_s3_bucket" "jenkins_logs_bucket" {

--- a/terraform/modules/jenkins/snapshots/snapshots.tf
+++ b/terraform/modules/jenkins/snapshots/snapshots.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 data "aws_iam_policy_document" "snapshot_jenkins_data_role" {

--- a/terraform/modules/log-groups/main.tf
+++ b/terraform/modules/log-groups/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_cloudwatch_log_group" "application_logs" {

--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 provider "archive" {

--- a/terraform/modules/logging/log-metric-filters/main.tf
+++ b/terraform/modules/logging/log-metric-filters/main.tf
@@ -2,7 +2,6 @@
 
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_cloudwatch_log_metric_filter" "request_time_bucket_0" {

--- a/terraform/modules/paas/iam.tf
+++ b/terraform/modules/paas/iam.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_iam_user" "paas_app" {

--- a/terraform/modules/router/route53.tf
+++ b/terraform/modules/router/route53.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_route53_zone" "root" {

--- a/terraform/modules/sops-credentials/main.tf
+++ b/terraform/modules/sops-credentials/main.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 provider "aws" {

--- a/terraform/modules/switch-roles/developers.tf
+++ b/terraform/modules/switch-roles/developers.tf
@@ -1,6 +1,5 @@
 provider "aws" {
   region  = "eu-west-1"
-  version = "~> 2.70"
 }
 
 resource "aws_iam_policy" "developer" {


### PR DESCRIPTION
Apologies in advance, this is a sizeable PR but it's not easy to split up.

In order to use the Node 14 Lambda runtime instead of Node 10 for our log streaming Lambda[[1]], we also need to upgrade the AWS provider.

Some of our modules had provider versions defined and some didn't, so I've taken the opportunity to clean things up and only define provider versions in the places we can run Terraform from - `main.tf` in each account and environment folder. The modules will get the correct version of the provider passed down to them when they're loaded.

We are on Terraform v.0.12, but plan to upgrade to 0.13 and 0.14 soon. Use the new `required_providers` syntax for the version definitions so this change is compatible with both Terraform v0.12 and v0.13[[2]].

Also set a `AWS_DEFAULT_REGION` environment variable for validation to work around a limitation in `terraform validate` in 0.12[[3]]

Applying these changes will recreate the Jenkins DNS records and change the ARN for our Cloud Watch group from `"arn:aws:logs:eu-west-1:398263320410:log-group:digitalmarketplace-main-account-cloudtrail-cloudtrail-log-group:*"` to `"arn:aws:logs:eu-west-1:398263320410:log-group:digitalmarketplace-main-account-cloudtrail-cloudtrail-log-group"` (removing `:*` from the end). ARNs are generated by AWS so this appears to be a change coming from updating the provider version. It's also updated in all the places that use this ARN (eg. the access policies), and I don't think dropping the `:*` changes the meaning of anything we do with this ARN. Therefore, I don't expect it to cause any problems. I'll apply changes to the development account and preview environment first and check Cloud Watch is still working to make sure though.

https://trello.com/c/sBqxdTZC/1734-upgrade-logstream-lambda-to-latest-active-lts

[1]: https://github.com/alphagov/digitalmarketplace-aws/blob/master/terraform/modules/log-streaming/lambda.tf#L73
[2]: https://www.terraform.io/docs/language/providers/requirements.html#v0-12-compatible-provider-requirements
[3]: https://github.com/hashicorp/terraform/issues/21408