### PR TITLE
Fix CloudWatch log group ARN

### DIFF
--- a/terraform/modules/cloudtrail/modules/cloudtrail-cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-cloudtrail/main.tf
@@ -5,6 +5,6 @@ resource "aws_cloudtrail" "cloudtrail" {
   include_global_service_events = true
   is_multi_region_trail         = true
   enable_log_file_validation    = true
-  cloud_watch_logs_group_arn    = var.cloud_watch_logs_group_arn
+  cloud_watch_logs_group_arn    = "${var.cloud_watch_logs_group_arn}:*"
   cloud_watch_logs_role_arn     = var.cloud_watch_logs_role_arn
 }

--- a/terraform/modules/cloudtrail/modules/cloudtrail-cloudwatch/main.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-cloudwatch/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy" "cloud_watch_policy" {
         "logs:CreateLogStream"
       ],
       "Resource": [
-        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}"
+        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}:*"
       ]
     },
     {
@@ -46,7 +46,7 @@ resource "aws_iam_role_policy" "cloud_watch_policy" {
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}"
+        "${aws_cloudwatch_log_group.cloudtrail_log_group.arn}:*"
       ]
     }
   ]


### PR DESCRIPTION
In #874 we upgraded the Terraform AWS provider to 3.34.0. In the PR description, I noted that this upgrade made changes to the CloudWatch log group ARN, but that I didn't think it mattered.

It turns out this isn't true - AWS rejects the ARN without a trailing `:*` but this only raises an error when we try to apply the changes.

From the provider upgrade docs[[1]]:

> Previously, the resource returned the Amazon Resource Name (ARN) directly from the API, which included a :* suffix to denote all CloudWatch Log Streams under the CloudWatch Log Group. Most other AWS resources that return ARNs and many other AWS services do not use the :* suffix. The suffix is now automatically removed.

The docs recommend using string interpolation to add the trailing `:*` back in everywhere it was missing, so do that.

[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_cloudwatch_log_group