### PR TITLE
Upgrade log streaming Lambda runtime from Node 10 to Node 14

### DIFF
--- a/terraform/modules/log-streaming/lambda.tf
+++ b/terraform/modules/log-streaming/lambda.tf
@@ -69,7 +69,7 @@ resource "aws_lambda_function" "log_stream_lambda" {
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   role             = aws_iam_role.lambda.arn
   handler          = "main.handler"
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs14.x"
   memory_size      = 128
   timeout          = 10
 


### PR DESCRIPTION
Node 10 is EOL on April 30th 2021 and will no longer receive security updates. Upgrade the runtime to Node 14, the most recent LTS version which is supported until April 2023.

I have had a quick scan of [the changelogs](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md) from Node 10 to 14 and I don't believe we are using anything that's been deprecated. I'll deploy to preview first and check logs are still arriving in Logit to make sure it's all still fine before doing the other environments.

https://trello.com/c/sBqxdTZC/1734-upgrade-logstream-lambda-to-latest-active-lts