### PR TITLE
Remove Ares' AWS account

### DIFF
--- a/terraform/modules/iam-users/users/main.tf
+++ b/terraform/modules/iam-users/users/main.tf
@@ -1,8 +1,3 @@
-resource "aws_iam_user" "argyris_galamatis" {
-  name          = "argyrisgalamatis"
-  force_destroy = true
-}
-
 resource "aws_iam_user" "laurence_de_bruxelles" {
   name          = "laurencedebruxelles"
   force_destroy = true


### PR DESCRIPTION
He's no longer working at CDIO

Should be deployed along with https://github.com/alphagov/digitalmarketplace-credentials/pull/379
to avoid AWS complaining about members of groups who don't exist.

https://trello.com/c/lWn7rC35/2185-remove-ares-from-all-the-things-%F0%9F%91%8B