### PR TITLE
install tfenv manually

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Terraform
+      - name: Install tfenv
         run: |
-          brew install tfenv
-          tfenv install
+          git clone https://github.com/tfutils/tfenv.git ~/.tfenv
+          echo "$HOME/.tfenv/bin" >> $GITHUB_PATH
+      
+      - name: Install Terraform
+        run: tfenv install
 
       - name: Setup Terraform cache
         uses: actions/cache@v2


### PR DESCRIPTION
`tfenv` has stopped installing via `brew` on Linux, seemingly due to an issue in the dependency chain breaking the build e.g. https://github.com/alphagov/digitalmarketplace-aws/runs/2325307890?check_suite_focus=true
```
Run brew install tfenv
==> Downloading https://linuxbrew.bintray.com/bottles/bzip2-1.0.8.x86_64_linux.bottle.1.tar.gz
curl: (22) The requested URL returned error: 403 Forbidden
Error: Failed to download resource "bzip2"
Download failed: https://linuxbrew.bintray.com/bottles/bzip2-1.0.8.x86_64_linux.bottle.1.tar.gz
Error: Process completed with exit code 1.
```
to work around this we can install tfenv manually, this is as per the manual steps https://github.com/tfutils/tfenv#manual adapted slightly to work with Github Actions.

(spotted whilst working on another story)