### PR TITLE
Add another router app to Staging and Preview

### DIFF
--- a/vars/preview.yml
+++ b/vars/preview.yml
@@ -4,12 +4,12 @@ maintenance_mode: live
 
 api:
   memory: 2GB
-  
+
 buyer-frontend:
   instances: 2
 
 router:
-  instances: 2
+  instances: 3
   rate_limiting_enabled: enabled
 
 search-api:

--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -7,4 +7,5 @@ api:
   memory: 2GB
 
 router:
+  instances: 3
   rate_limiting_enabled: enabled


### PR DESCRIPTION
Trello: https://trello.com/c/wW4w1XQZ

We need to decrease the production rate limit to cope with an over-eager scraper. See https://github.com/alphagov/digitalmarketplace-router/pull/109

Unfortunately, this lower rate limit is just too low for Preview and Staging. They typically see peaks of ~8 requests/s from our tests. The rate limit change reduces their rate limits from 10 requests/s to 6 requests/s.

So increase the number of router instances to 3. This should increase the rate limit for those environments to 9 requests/s, which should be sufficient for our tests.

This is intended to be a temporary stop-gap whilst we work out a better long-term approach to coping with the scraper's traffic.