### PR TITLE
Increase frequency of Jenkins disk space checks

### DIFF
--- a/terraform/accounts/main/alarms.tf
+++ b/terraform/accounts/main/alarms.tf
@@ -22,9 +22,9 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_data_volume_disk_space" {
     path = "/data"
   }
 
-  // For every 300 seconds
+  // For every minute
   evaluation_periods = "1"
-  period             = "300"
+  period             = "60"
 
   // If totals 10gb or lower (in bytes)
   statistic           = "Minimum"
@@ -49,9 +49,9 @@ resource "aws_cloudwatch_metric_alarm" "jenkins_main_volume_disk_space" {
     path = "/"
   }
 
-  // For every 300 seconds
+  // For every minute
   evaluation_periods = "1"
-  period             = "300"
+  period             = "60"
 
   // If totals 1gb or lower (in bytes)
   statistic           = "Minimum"


### PR DESCRIPTION
To every minute, rather than every 5 minutes.

We recently had an incident where Docker used up all the available disk space building multiple images concurrently, crashed and then deleted the temporary files that had caused the problem. This wasn't caught by the disk space alarm because it only checks every 5 minutes and the disk filled up much faster than that.

The AWS docs say that events from AWS services are at a 1 minute frequency by default[[1]], so the highest frequency we can set the alarm to is also 1 minute.

https://trello.com/c/LkA70qqT/812-1-investigate-why-we-didnt-get-a-jenkins-low-disk-space-alert

[1]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html