### PR TITLE
Only allow encrypted connections to Terraform state buckets

### DIFF
--- a/terraform/accounts/backups/main.tf
+++ b/terraform/accounts/backups/main.tf
@@ -33,3 +33,23 @@ terraform {
   }
 }
 
+resource "aws_s3_bucket_policy" "backups_tfstate_bucket_policy" {
+  bucket = "digitalmarketplace-terraform-state-backups"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "BackupsTFStateOnlyEncryptedConnectionPolicy"
+    Statement = [
+      {
+        Effect: "Deny",
+        Principal: "*",
+        Action: "*",
+        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-backups/*",
+        Condition: {
+            Bool: {
+                "aws:SecureTransport": "false"
+            }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -17,6 +17,27 @@ terraform {
   }
 }
 
+resource "aws_s3_bucket_policy" "development_tfstate_bucket_policy" {
+  bucket = "digitalmarketplace-terraform-state-development"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "DevTFStateOnlyEncryptedConnectionPolicy"
+    Statement = [
+      {
+        Effect: "Deny",
+        Principal: "*",
+        Action: "*",
+        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-development/*",
+        Condition: {
+            Bool: {
+                "aws:SecureTransport": "false"
+            }
+        }
+      }
+    ]
+  })
+}
+
 module "iam_common" {
   source                            = "../../modules/iam-common"
   aws_account_and_jenkins_login_ips = var.aws_account_and_jenkins_login_ips

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -17,6 +17,27 @@ terraform {
   }
 }
 
+resource "aws_s3_bucket_policy" "main_tfstate_bucket_policy" {
+  bucket = "digitalmarketplace-terraform-state-main"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "MainTFStateOnlyEncryptedConnectionPolicy"
+    Statement = [
+      {
+        Effect: "Deny",
+        Principal: "*",
+        Action: "*",
+        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-main/*",
+        Condition: {
+            Bool: {
+                "aws:SecureTransport": "false"
+            }
+        }
+      }
+    ]
+  })
+}
+
 module "iam_common" {
   source                            = "../../modules/iam-common"
   aws_account_and_jenkins_login_ips = var.aws_account_and_jenkins_login_ips

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -17,6 +17,27 @@ terraform {
   }
 }
 
+resource "aws_s3_bucket_policy" "production_tfstate_bucket_policy" {
+  bucket = "digitalmarketplace-terraform-state-production"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id = "ProdTFStateOnlyEncryptedConnectionPolicy"
+    Statement = [
+      {
+        Effect: "Deny",
+        Principal: "*",
+        Action: "*",
+        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-production/*",
+        Condition: {
+            Bool: {
+                "aws:SecureTransport": "false"
+            }
+        }
+      }
+    ]
+  })
+}
+
 module "iam_common" {
   source                            = "../../modules/iam-common"
   aws_account_and_jenkins_login_ips = var.aws_account_and_jenkins_login_ips


### PR DESCRIPTION
Define access policies for our Terraform state buckets that only permit encrypted connections. This addresses a medium-risk vulnerability from our recent ITHC.

These are the Terraform state buckets and therefore they cannot be created through Terraform or easily managed through a module. This is why the policies are defined in-line after the Terraform backend configuration in each AWS account.

https://trello.com/c/KeWS6zRV/925-644-bucket-allowing-clear-text-http-communication