### PR TITLE
Revert "use restored DB"

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -5,10 +5,6 @@ instances: 2
 
 api:
   memory: 2GB
-  services:
-    - digitalmarketplace_api_db-restored-2
-    - digitalmarketplace_prometheus
-    - digitalmarketplace_splunk
 
 router:
   instances: 3


### PR DESCRIPTION
https://trello.com/c/c00Ix4wd/2230-p4-database-dump-failing-on-staging

Reverts alphagov/digitalmarketplace-aws#914

Revert to use renamed restored DB.