### PR TITLE
Enable default S3 encryption

### DIFF
--- a/terraform/accounts/backups/main.tf
+++ b/terraform/accounts/backups/main.tf
@@ -37,17 +37,17 @@ resource "aws_s3_bucket_policy" "backups_tfstate_bucket_policy" {
   bucket = "digitalmarketplace-terraform-state-backups"
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "BackupsTFStateOnlyEncryptedConnectionPolicy"
+    Id      = "BackupsTFStateOnlyEncryptedConnectionPolicy"
     Statement = [
       {
-        Effect: "Deny",
-        Principal: "*",
-        Action: "*",
-        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-backups/*",
-        Condition: {
-            Bool: {
-                "aws:SecureTransport": "false"
-            }
+        Effect : "Deny",
+        Principal : "*",
+        Action : "*",
+        Resource : "arn:aws:s3:::digitalmarketplace-terraform-state-backups/*",
+        Condition : {
+          Bool : {
+            "aws:SecureTransport" : "false"
+          }
         }
       }
     ]

--- a/terraform/accounts/backups/s3_buckets.tf
+++ b/terraform/accounts/backups/s3_buckets.tf
@@ -51,6 +51,13 @@ resource "aws_s3_bucket" "cross_region_database_backups_s3_bucket" {
 }
 POLICY
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "database_backups_s3_bucket" {
@@ -135,6 +142,14 @@ POLICY
 
       destination {
         bucket = aws_s3_bucket.cross_region_database_backups_s3_bucket.arn
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
       }
     }
   }

--- a/terraform/accounts/development/main.tf
+++ b/terraform/accounts/development/main.tf
@@ -21,17 +21,17 @@ resource "aws_s3_bucket_policy" "development_tfstate_bucket_policy" {
   bucket = "digitalmarketplace-terraform-state-development"
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "DevTFStateOnlyEncryptedConnectionPolicy"
+    Id      = "DevTFStateOnlyEncryptedConnectionPolicy"
     Statement = [
       {
-        Effect: "Deny",
-        Principal: "*",
-        Action: "*",
-        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-development/*",
-        Condition: {
-            Bool: {
-                "aws:SecureTransport": "false"
-            }
+        Effect : "Deny",
+        Principal : "*",
+        Action : "*",
+        Resource : "arn:aws:s3:::digitalmarketplace-terraform-state-development/*",
+        Condition : {
+          Bool : {
+            "aws:SecureTransport" : "false"
+          }
         }
       }
     ]

--- a/terraform/accounts/development/s3_buckets.tf
+++ b/terraform/accounts/development/s3_buckets.tf
@@ -74,6 +74,14 @@ resource "aws_s3_bucket" "dev_uploads_s3_bucket" {
   }
 
   policy = data.aws_iam_policy_document.dev_uploads_s3_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "cleaned_db_dumps_s3_bucket_policy_document" {
@@ -152,5 +160,13 @@ resource "aws_s3_bucket" "cleaned_db_dumps_s3_bucket" {
   }
 
   policy = data.aws_iam_policy_document.cleaned_db_dumps_s3_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 

--- a/terraform/accounts/main/main.tf
+++ b/terraform/accounts/main/main.tf
@@ -21,17 +21,17 @@ resource "aws_s3_bucket_policy" "main_tfstate_bucket_policy" {
   bucket = "digitalmarketplace-terraform-state-main"
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "MainTFStateOnlyEncryptedConnectionPolicy"
+    Id      = "MainTFStateOnlyEncryptedConnectionPolicy"
     Statement = [
       {
-        Effect: "Deny",
-        Principal: "*",
-        Action: "*",
-        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-main/*",
-        Condition: {
-            Bool: {
-                "aws:SecureTransport": "false"
-            }
+        Effect : "Deny",
+        Principal : "*",
+        Action : "*",
+        Resource : "arn:aws:s3:::digitalmarketplace-terraform-state-main/*",
+        Condition : {
+          Bool : {
+            "aws:SecureTransport" : "false"
+          }
         }
       }
     ]

--- a/terraform/accounts/production/main.tf
+++ b/terraform/accounts/production/main.tf
@@ -21,17 +21,17 @@ resource "aws_s3_bucket_policy" "production_tfstate_bucket_policy" {
   bucket = "digitalmarketplace-terraform-state-production"
   policy = jsonencode({
     Version = "2012-10-17"
-    Id = "ProdTFStateOnlyEncryptedConnectionPolicy"
+    Id      = "ProdTFStateOnlyEncryptedConnectionPolicy"
     Statement = [
       {
-        Effect: "Deny",
-        Principal: "*",
-        Action: "*",
-        Resource: "arn:aws:s3:::digitalmarketplace-terraform-state-production/*",
-        Condition: {
-            Bool: {
-                "aws:SecureTransport": "false"
-            }
+        Effect : "Deny",
+        Principal : "*",
+        Action : "*",
+        Resource : "arn:aws:s3:::digitalmarketplace-terraform-state-production/*",
+        Condition : {
+          Bool : {
+            "aws:SecureTransport" : "false"
+          }
         }
       }
     ]

--- a/terraform/environments/preview/s3_buckets.tf
+++ b/terraform/environments/preview/s3_buckets.tf
@@ -38,6 +38,14 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # TODO remove these hard-coded definitions in favour of using the terraform/modules/s3-document-bucket module after the
@@ -220,6 +228,14 @@ resource "aws_s3_bucket" "reports_bucket" {
   }
 
   policy = data.aws_iam_policy_document.reports_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Communications jenkins: read write listversions
@@ -298,6 +314,14 @@ resource "aws_s3_bucket" "communications_bucket" {
 
       destination {
         bucket = aws_s3_bucket.cross_region_communications_s3_bucket.arn
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
       }
     }
   }
@@ -439,6 +463,14 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
     target_bucket = aws_s3_bucket.server_access_logs_bucket.id
     target_prefix = "digitalmarketplace-g7-draft-documents-preview-preview/"
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Submissions - jenkins: listversions
@@ -519,5 +551,13 @@ resource "aws_s3_bucket" "submissions_bucket" {
   }
 
   policy = data.aws_iam_policy_document.submissions_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 

--- a/terraform/environments/preview/s3_replication_buckets.tf
+++ b/terraform/environments/preview/s3_replication_buckets.tf
@@ -40,6 +40,14 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "cross_region_agreements_s3_bucket_policy_document" {
@@ -81,6 +89,14 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 
@@ -124,6 +140,14 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "cross_region_submissions_s3_bucket_policy_document" {
@@ -165,6 +189,14 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/terraform/environments/production/s3_buckets.tf
+++ b/terraform/environments/production/s3_buckets.tf
@@ -38,6 +38,14 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # TODO remove these hard-coded definitions in favour of using the terraform/modules/s3-document-bucket module after the
@@ -145,6 +153,14 @@ resource "aws_s3_bucket" "agreements_bucket" {
       }
     }
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Reports - devs: read write list jenkins: read write list
@@ -218,6 +234,14 @@ resource "aws_s3_bucket" "reports_bucket" {
   }
 
   policy = data.aws_iam_policy_document.reports_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Communications jenkins: read write listversions
@@ -296,6 +320,14 @@ resource "aws_s3_bucket" "communications_bucket" {
 
       destination {
         bucket = aws_s3_bucket.cross_region_communications_s3_bucket.arn
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
       }
     }
   }
@@ -383,6 +415,14 @@ resource "aws_s3_bucket" "documents_bucket" {
       }
     }
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # G7-draft-documents
@@ -430,6 +470,14 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
   logging {
     target_bucket = aws_s3_bucket.server_access_logs_bucket.id
     target_prefix = "digitalmarketplace-g7-draft-documents-production-production/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 
@@ -509,6 +557,14 @@ resource "aws_s3_bucket" "submissions_bucket" {
 
       destination {
         bucket = aws_s3_bucket.cross_region_submissions_s3_bucket.arn
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
       }
     }
   }

--- a/terraform/environments/production/s3_replication_buckets.tf
+++ b/terraform/environments/production/s3_replication_buckets.tf
@@ -39,6 +39,14 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "cross_region_agreements_s3_bucket_policy_document" {
@@ -80,6 +88,14 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 
@@ -123,6 +139,14 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "cross_region_submissions_s3_bucket_policy_document" {
@@ -164,6 +188,14 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
 
   versioning {
     enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 

--- a/terraform/environments/staging/s3_buckets.tf
+++ b/terraform/environments/staging/s3_buckets.tf
@@ -38,6 +38,14 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
   versioning {
     enabled = true
   }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # TODO remove these hard-coded definitions in favour of using the terraform/modules/s3-document-bucket module after the
@@ -104,6 +112,14 @@ resource "aws_s3_bucket" "agreements_bucket" {
   }
 
   policy = data.aws_iam_policy_document.agreements_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Reports - jenkins: read write list
@@ -175,6 +191,14 @@ resource "aws_s3_bucket" "reports_bucket" {
   }
 
   policy = data.aws_iam_policy_document.reports_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Communications - jenkins: listversions
@@ -238,6 +262,14 @@ resource "aws_s3_bucket" "communications_bucket" {
   }
 
   policy = data.aws_iam_policy_document.communications_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # Documents - jenkins: read write list listversions
@@ -307,6 +339,14 @@ resource "aws_s3_bucket" "documents_bucket" {
   }
 
   policy = data.aws_iam_policy_document.documents_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 
 # G7-draft-documents
@@ -354,6 +394,14 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
   logging {
     target_bucket = aws_s3_bucket.server_access_logs_bucket.id
     target_prefix = "digitalmarketplace-g7-draft-documents-staging-staging/"
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
   }
 }
 
@@ -418,5 +466,13 @@ resource "aws_s3_bucket" "submissions_bucket" {
   }
 
   policy = data.aws_iam_policy_document.submissions_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 

--- a/terraform/modules/cloudtrail/modules/cloudtrail-bucket/main.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-bucket/main.tf
@@ -78,4 +78,12 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   }
 
   policy = data.aws_iam_policy_document.cloudtrail_bucket_policy.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }

--- a/terraform/modules/jenkins/log_bucket/s3_bucket.tf
+++ b/terraform/modules/jenkins/log_bucket/s3_bucket.tf
@@ -48,5 +48,12 @@ resource "aws_s3_bucket" "jenkins_logs_bucket" {
 }
 POLICY
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 

--- a/terraform/modules/s3-document-bucket/main.tf
+++ b/terraform/modules/s3-document-bucket/main.tf
@@ -75,5 +75,13 @@ resource "aws_s3_bucket" "document_bucket" {
   }
 
   policy = data.aws_iam_policy_document.document_bucket_policy_document.json
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }
 


### PR DESCRIPTION
https://trello.com/c/HCf26VVT/922-3-645-bucket-without-default-encryption-enabled

Enable default encryption for all our S3 buckets. This was prompted by the recent IT health check. Security benefits likely to be minimal, but it's free and easy to enable, so why not.

We've tested that this shouldn't cause problems already - see 029e9ac. This commit adds the necessary config to all other buckets in all environments/accounts/etc.

Also terraformat picked up some unrelated formatting-only changes.