### PR TITLE
Change `digitalmarketplace-content-loader` default branch

### DIFF
--- a/terraform/accounts/main/codecommit.tf
+++ b/terraform/accounts/main/codecommit.tf
@@ -38,7 +38,7 @@ variable "alphagov_git_repositories" {
       default_branch = "main"
     },
     digitalmarketplace-content-loader = {
-      default_branch = "master"
+      default_branch = "main"
     },
     digitalmarketplace-credentials = {
       default_branch = "master"


### PR DESCRIPTION
to `main` as this is now what we're using. This will fix the failing code backup job.

https://trello.com/c/DrVWMkcZ/2169-rename-default-branches-on-our-repos-from-master-to-main.