### PR TITLE
Add assets URL to buyer frontend

### DIFF
--- a/paas/buyer-frontend.j2
+++ b/paas/buyer-frontend.j2
@@ -12,7 +12,8 @@
       DM_REDIS_SERVICE_NAME: 'digitalmarketplace_redis'
       DM_SEARCH_API_AUTH_TOKEN: {{ search_api.auth_tokens[0] }}
       DM_SEARCH_API_URL: https://dm-search-api-{{ environment }}.cloudapps.digital
-      
+
+      DM_ASSETS_URL: https://assets.{{ domain }}
 
       PROXY_AUTH_CREDENTIALS: {{ proxy_auth_credentials }}
 


### PR DESCRIPTION
https://trello.com/c/5E22SHaQ/988-ccs-sourcing-admins-cant-view-suppliers-modern-slavery-statements

It's currently hard-coded (https://github.com/alphagov/digitalmarketplace-buyer-frontend/commit/1e5b9e7def105d4c055b25c72fa7e6fd2acd49e6), which we want to remove.