### PR TITLE
Remove alarms that require no action

### DIFF
--- a/terraform/environments/preview/alarms.tf
+++ b/terraform/environments/preview/alarms.tf
@@ -46,14 +46,6 @@ module "router_500_alarm" {
   alarm_recovery_email_topic_arn = module.alarm_recovery_email_sns.email_topic_arn
 }
 
-module "router_429_alarm" {
-  source                         = "../../modules/logging/alarms/status-code"
-  environment                    = "preview"
-  status_code                    = "429"
-  alarm_email_topic_arn          = module.alarm_email_sns.email_topic_arn
-  alarm_recovery_email_topic_arn = module.alarm_recovery_email_sns.email_topic_arn
-}
-
 module "dropped_av_sns_alarm" {
   source                         = "../../modules/logging/alarms/dropped-av-sns"
   environment                    = "preview"

--- a/terraform/environments/production/alarms.tf
+++ b/terraform/environments/production/alarms.tf
@@ -46,14 +46,6 @@ module "router_500_alarm" {
   alarm_recovery_email_topic_arn = module.alarm_recovery_email_sns.email_topic_arn
 }
 
-module "router_429_alarm" {
-  source                         = "../../modules/logging/alarms/status-code"
-  environment                    = "production"
-  status_code                    = "429"
-  alarm_email_topic_arn          = module.alarm_email_sns.email_topic_arn
-  alarm_recovery_email_topic_arn = module.alarm_recovery_email_sns.email_topic_arn
-}
-
 module "reset_email_bad_role_alarm" {
   source                         = "../../modules/logging/alarms/reset-email-bad-role"
   environment                    = "production"

--- a/terraform/modules/logging/alarms/slow-requests/alarms.tf
+++ b/terraform/modules/logging/alarms/slow-requests/alarms.tf
@@ -1,28 +1,3 @@
-resource "aws_cloudwatch_metric_alarm" "slow_requests_5_10_alarm" {
-  alarm_name        = "${var.environment}-${var.app_name}-slow-requests-5-10s"
-  alarm_description = "Alerts on 5 or more requests between 5-10 seconds in the last minute"
-
-  // Metric
-  namespace   = "DM-RequestTimeBuckets"
-  metric_name = "${var.environment}-router-request-times-8"
-
-  // For every 5 minutes
-  evaluation_periods = "1"
-  period             = "300"
-
-  // If totals 5 or higher
-  statistic           = "Sum"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = "5"
-
-  // If there is no data then do not alarm
-  treat_missing_data = "notBreaching"
-
-  // Email slack
-  alarm_actions = [var.alarm_email_topic_arn]
-  ok_actions    = [var.alarm_recovery_email_topic_arn]
-}
-
 resource "aws_cloudwatch_metric_alarm" "slow_requests_gt_10_alarm" {
   alarm_name        = "${var.environment}-router-slow-requests-gt10s"
   alarm_description = "Alerts on 5 or more requests over 10 seconds in the last minute"


### PR DESCRIPTION
We have a scraper which is triggering these alarms with 100's of requests every hour. We don't need to do anything when they're triggered so they're causing us unnecessary alarm fatigue and could result in us missing real problems. 

Increasing the trigger thresholds to over what the scraper causes will effectively cause the alarms to never trigger, which won't be any more use than simply deleting them. 

https://trello.com/c/sZqatZVp/4-2-reduce-alerts-that-require-no-action