### PR TITLE
Enable MFA delete protection on our S3 buckets

### DIFF
--- a/terraform/environments/preview/s3_buckets.tf
+++ b/terraform/environments/preview/s3_buckets.tf
@@ -37,6 +37,7 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -126,6 +127,7 @@ resource "aws_s3_bucket" "agreements_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -220,6 +222,7 @@ resource "aws_s3_bucket" "reports_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -295,6 +298,7 @@ resource "aws_s3_bucket" "communications_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -386,6 +390,7 @@ resource "aws_s3_bucket" "documents_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -457,6 +462,7 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -529,6 +535,7 @@ resource "aws_s3_bucket" "submissions_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {

--- a/terraform/environments/preview/s3_replication_buckets.tf
+++ b/terraform/environments/preview/s3_replication_buckets.tf
@@ -39,6 +39,7 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -89,6 +90,7 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -139,6 +141,7 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -189,6 +192,7 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {

--- a/terraform/environments/production/s3_buckets.tf
+++ b/terraform/environments/production/s3_buckets.tf
@@ -37,6 +37,7 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -301,6 +302,7 @@ resource "aws_s3_bucket" "communications_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -465,6 +467,7 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -538,6 +541,7 @@ resource "aws_s3_bucket" "submissions_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {

--- a/terraform/environments/production/s3_replication_buckets.tf
+++ b/terraform/environments/production/s3_replication_buckets.tf
@@ -38,6 +38,7 @@ resource "aws_s3_bucket" "cross_region_documents_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -88,6 +89,7 @@ resource "aws_s3_bucket" "cross_region_agreements_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -138,6 +140,7 @@ resource "aws_s3_bucket" "cross_region_communications_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -188,6 +191,7 @@ resource "aws_s3_bucket" "cross_region_submissions_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {

--- a/terraform/environments/staging/s3_buckets.tf
+++ b/terraform/environments/staging/s3_buckets.tf
@@ -37,6 +37,7 @@ resource "aws_s3_bucket" "server_access_logs_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   server_side_encryption_configuration {
@@ -104,6 +105,7 @@ resource "aws_s3_bucket" "agreements_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -183,6 +185,7 @@ resource "aws_s3_bucket" "reports_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -254,6 +257,7 @@ resource "aws_s3_bucket" "communications_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -331,6 +335,7 @@ resource "aws_s3_bucket" "documents_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -389,6 +394,7 @@ resource "aws_s3_bucket" "g7-draft-documents_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {
@@ -458,6 +464,7 @@ resource "aws_s3_bucket" "submissions_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {

--- a/terraform/modules/s3-document-bucket/main.tf
+++ b/terraform/modules/s3-document-bucket/main.tf
@@ -67,6 +67,7 @@ resource "aws_s3_bucket" "document_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   logging {


### PR DESCRIPTION
This was identified in our recent ITHC and we've already updated all the buckets in the AWS console. Update Terraform to match what's deployed.

If you checkout this branch and run `make plan` for one of preview, staging or production the only changes you should now see are removing some Cloudwatch alarms (see #941) and maybe a DNS validation update.