### PR TITLE
Enable MFA delete protection on our S3 buckets

### DIFF
--- a/terraform/accounts/development/s3_buckets.tf
+++ b/terraform/accounts/development/s3_buckets.tf
@@ -71,6 +71,7 @@ resource "aws_s3_bucket" "dev_uploads_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   policy = data.aws_iam_policy_document.dev_uploads_s3_bucket_policy_document.json
@@ -157,6 +158,7 @@ resource "aws_s3_bucket" "cleaned_db_dumps_s3_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   policy = data.aws_iam_policy_document.cleaned_db_dumps_s3_bucket_policy_document.json

--- a/terraform/modules/cloudtrail/modules/cloudtrail-bucket/main.tf
+++ b/terraform/modules/cloudtrail/modules/cloudtrail-bucket/main.tf
@@ -75,6 +75,7 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   policy = data.aws_iam_policy_document.cloudtrail_bucket_policy.json

--- a/terraform/modules/jenkins/log_bucket/s3_bucket.tf
+++ b/terraform/modules/jenkins/log_bucket/s3_bucket.tf
@@ -8,6 +8,7 @@ resource "aws_s3_bucket" "jenkins_logs_bucket" {
 
   versioning {
     enabled = true
+    mfa_delete = true
   }
 
   # The id 156460612806 is the ELB account (eu-west-1)


### PR DESCRIPTION
We missed some buckets in #942, so add MFA delete protection to those as well.

I've run `make` plan on all environments and accounts (other than backups where MFA delete isn't enabled because it conflicts with our retention policy) and verified that there are no more changes where Terraform is trying to turn it back off.