### PR TITLE
use python 3.9 in backup job dockerfile

### DIFF
--- a/db-backup/Dockerfile
+++ b/db-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.13-slim
+FROM python:3.9-slim
 
 RUN mkdir /app
 


### PR DESCRIPTION
https://trello.com/c/PqMIVIGW/33-upgrade-apps-to-python-36-39
Note I have tested this using a tag on Jenkins and Dockerhub 
https://ci.marketplace.team/job/database-backup/1522/
https://hub.docker.com/layers/digitalmarketplace/db-backup/db-backup-python-39/images/sha256-8483a4c2127a2205acb0993aa051d3a89054f4f06c2776ee69d389f05e731ddf?context=repo

## Deployment
As this is manually managed, once this is merged I will push it to the `latest` tag.
