### PR TITLE
Set up Ubuntu 20 LTS instance

### DIFF
--- a/terraform/accounts/main/jenkins.tf
+++ b/terraform/accounts/main/jenkins.tf
@@ -22,6 +22,20 @@ module "jenkins_2" {
   log_bucket_name                   = module.jenkins_elb_log_bucket.bucket_id
 }
 
+module "jenkins_3" {
+  source                            = "../../modules/jenkins/jenkins"
+  name                              = "jenkins3"
+  aws_account_and_jenkins_login_ips = var.aws_account_and_jenkins_login_ips
+  jenkins_public_key_name           = aws_key_pair.jenkins.key_name # Or ${var.ssh_key_name}
+  jenkins_instance_profile          = aws_iam_instance_profile.jenkins.name
+  jenkins_wildcard_elb_cert_arn     = aws_acm_certificate.jenkins_wildcard_elb_certificate.arn
+  ami_id                            = "ami-03caf24deed650e2c"
+  instance_type                     = "t3.large"
+  dns_zone_id                       = aws_route53_zone.marketplace_team.zone_id
+  dns_name                          = "ci-test.marketplace.team"
+  log_bucket_name                   = module.jenkins_elb_log_bucket.bucket_id
+}
+
 module "jenkins_snapshots" {
   source = "../../modules/jenkins/snapshots"
 }

--- a/terraform/modules/jenkins/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/jenkins/ec2.tf
@@ -13,6 +13,9 @@ resource "aws_instance" "jenkins" {
   tags = {
     Name = var.name
   }
+  root_block_device {
+    volume_size = "32"
+  }
 }
 
 resource "aws_eip" "jenkins" {


### PR DESCRIPTION
https://trello.com/c/cacoWXHC/63-5-upgrade-the-version-of-python-on-jenkins-to-at-least-38

This sets up a new Jenkins instance which is running Ubuntu 20 LTS which includes Python 3.8 in the package manager.

