### PR TITLE
remove old jenkins instance

### DIFF
--- a/terraform/accounts/main/jenkins.tf
+++ b/terraform/accounts/main/jenkins.tf
@@ -8,20 +8,6 @@ module "jenkins_elb_log_bucket" {
   name   = "jenkins-ci.marketplace.team-logs-bucket"
 }
 
-module "jenkins_2" {
-  source                            = "../../modules/jenkins/jenkins"
-  name                              = "jenkins2"
-  aws_account_and_jenkins_login_ips = var.aws_account_and_jenkins_login_ips
-  jenkins_public_key_name           = aws_key_pair.jenkins.key_name # Or ${var.ssh_key_name}
-  jenkins_instance_profile          = aws_iam_instance_profile.jenkins.name
-  jenkins_wildcard_elb_cert_arn     = aws_acm_certificate.jenkins_wildcard_elb_certificate.arn
-  ami_id                            = "ami-01e6a0b85de033c99"
-  instance_type                     = "t3.large"
-  dns_zone_id                       = aws_route53_zone.marketplace_team.zone_id
-  dns_name                          = "ci-old.marketplace.team"
-  log_bucket_name                   = module.jenkins_elb_log_bucket.bucket_id
-}
-
 module "jenkins_3" {
   source                            = "../../modules/jenkins/jenkins"
   name                              = "jenkins3"


### PR DESCRIPTION
https://trello.com/c/cacoWXHC/63-5-upgrade-the-version-of-python-on-jenkins-to-at-least-38

We have retired this in favour of jenkins3.