### PR TITLE
Point API to new restored database in Staging

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -5,6 +5,10 @@ instances: 2
 
 api:
   memory: 2GB
+  services:
+    - restore_db_14_08_2021
+    - digitalmarketplace_prometheus
+    - digitalmarketplace_splunk
 
 router:
   instances: 3


### PR DESCRIPTION
The last time staging was updated with clean live-like data, the job failed and left the database in an inconsistent state, so we had to do a restore (see https://alphagov.github.io/digitalmarketplace-manual/infrastructure/database-backups.html?highlight=database%20restore#restoring-from-a-backup)

Trello: https://trello.com/c/VmiVQKkA