### PR TITLE
Revert "Point API to new restored database in Staging"

### DIFF
--- a/vars/staging.yml
+++ b/vars/staging.yml
@@ -5,10 +5,6 @@ instances: 2
 
 api:
   memory: 2GB
-  services:
-    - restore_db_14_08_2021
-    - digitalmarketplace_prometheus
-    - digitalmarketplace_splunk
 
 router:
   instances: 3


### PR DESCRIPTION
Renaming new service to digitalmarketplace_api_db (see https://alphagov.github.io/digitalmarketplace-manual/infrastructure/database-backups.html?highlight=database%20restore#restoring-from-a-backup)

This reverts commit 9d0c3512