### PR TITLE
Drop support for python < v3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are a few independent tools we're using that are configured and run from t
 ## Setup
 
 ### Set up python dependencies
-Install dependencies with [venv](https://docs.python.org/3.6/library/venv.html)
+Install dependencies with [venv](https://docs.python.org/3.9/library/venv.html)
 and [pip](https://pip.pypa.io/en/latest/installing.html).
 
 ```


### PR DESCRIPTION
https://trello.com/c/XL6YJ30H/201-upgrade-everything-to-python-38-9

This is only a development requirement, but we still drop support for the older versions of Python.
This won't affect anything that uses AWS it will just mean that we can't guarantee that any future changes to the Python code will work with version of Python < 3.9